### PR TITLE
Show RegEffectObservation sources in REO page

### DIFF
--- a/cegs_portal/search/templates/search/v1/reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/reg_effect.html
@@ -25,8 +25,8 @@
 
     {% if regulatory_effect.sources.all|length > 0 %}
     <div>
-        <div class="text-xl font-bold">Source DHSs</div>
-        {% include "search/v1/partials/_features.html" with regions=regulatory_effect.sources.all %}
+        <div class="text-xl font-bold">Source Features</div>
+        {% include "search/v1/partials/_features.html" with features=regulatory_effect.sources.all %}
     </div>
     {% endif %}
     {% endspaceless %}


### PR DESCRIPTION
Fixes a that passed in the sources to the partial as the wrong variable name Also changes the header; not all sources are DHSs (some are cCREs)

Fixes https://github.com/ReddyLab/cegs-portal/issues/10