### PR TITLE
Add searching by accession id, ensembl id, and gene name

### DIFF
--- a/cegs_portal/search/models/utils.py
+++ b/cegs_portal/search/models/utils.py
@@ -5,9 +5,9 @@ from psycopg2.extras import NumericRange
 
 
 class QueryToken(Enum):
-    LOCATION = auto()
     ENSEMBL_ID = auto()
     ACCESSION_ID = auto()
+    GENE_NAME = auto()
 
     def associate(self, value: str) -> tuple["QueryToken", str]:
         return (self, value)
@@ -23,6 +23,9 @@ class ChromosomeLocation:
 
     def __str__(self) -> str:
         return f"{self.chromo}: {self.range.lower}-{self.range.upper}"
+
+    def __eq__(self, other) -> bool:
+        return self.chromo == other.chromo and self.range == other.range
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/cegs_portal/search/templates/search/v1/partials/_paged_nav.html
+++ b/cegs_portal/search/templates/search/v1/partials/_paged_nav.html
@@ -1,12 +1,16 @@
 {% if data|length > 0 %}
 <div id="{{ container_id }}" class="my-4">
     <div class="text-xl font-bold">{{ name }}</div>
+    {% if data.paginator %}
     {% include table with features=data.object_list %}
+    {% else %}
+    {% include table with features=data %}
+    {% endif %}
 </div>
 {% else %}
 <div id="{{ container_id }}">{{ no_data }}</div>
 {% endif %}
-{% if data|length > 0 %}
+{% if data.paginator and data|length > 0 %}
 <div id="{{ prefix }}_pagination" class="pagination">
     <span class="step-links">
         {% if data.has_previous %}

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -239,7 +239,7 @@ svg > g > text {
             plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips' ],
             useHash   : true,
             hideEmptyTracks: false,
-            sharedStateCallbacks: [_ul{% switch "effect_plot" %}, applyPlot{% endswitch %}],
+            sharedStateCallbacks: [{% if search_type == "LOCATION" %}_ul{% endif %}{% switch "effect_plot" %}{% if search_type == "LOCATION" %}, {% endif %}applyPlot{% endswitch %}],
             width: 1200,
             tracks: [
                 Genoverse.Track.Scaleline.extend({ strand: false }),

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -51,10 +51,21 @@ svg > g > text {
                     <input type="submit" value="Search Again" class="search-button self-end">
                 </form>
             </div>
-            {% if loc_search.location %}
-            <div id="loc-header" class="text-2xl font-bold my-4">{{ loc_search.location.chromo }}: {{ loc_search.location.range.lower }}-{{ loc_search.location.range.upper }}</div>
+            {% if "IGNORE_LOC" in warnings %}
+            <div class="text-red-700">The location in the query has been ignored.</div>
+            <div class="text-red-700">Queries can include either gene IDs/names or locations. If a query contains both, the first type encountered is used and the other type is ignored.</div>
             {% endif %}
-            {% if loc_search.location and loc_search.assembly %}
+            {% if "TOO_MANY_LOCS" in warnings %}
+            <div class="text-red-700">The query contains more than one location; only the first location is used.</div>
+            {% endif %}
+            {% if "IGNORE_TERMS" in warnings %}
+            <div class="text-red-700">Gene IDs or names in the query were ignored</div>
+            <div class="text-red-700">Queries can include either gene IDs/names or locations. If a query contains both, the first type encountered is used and the other type is ignored.</div>
+            {% endif %}
+            {% if location %}
+            <div id="loc-header" class="text-2xl font-bold my-4">{{ location.chromo }}: {{ location.range.lower }}-{{ location.range.upper }}</div>
+            {% endif %}
+            {% if location and assembly %}
             <div class="p-2" id="genoverse"></div>
             {% endif %}
             {% switch "effect_plot" %}
@@ -81,9 +92,9 @@ svg > g > text {
         const STATE_DHS_EFFECT = "dhs-effect-data"
         let state = new State({
             [STATE_LOCATION]: {
-                chr: "{{ loc_search.location.chromo }}",
-                start: {{ loc_search.location.range.lower }},
-                end: {{ loc_search.location.range.upper }}
+                chr: "{{ location.chromo }}",
+                start: {{ location.range.lower }},
+                end: {{ location.range.upper }}
             },
             [STATE_FACETS]: [],
             [STATE_DHS_EFFECT]: null
@@ -99,7 +110,7 @@ svg > g > text {
         let featureURL = function(chromosome, start, end, facets=[]) {
             let enabledFacets = facets.map(id => `facet=${id}`)
                                   .join('&');
-            return `/search/featureloc/${chromosome}/${start}/${end}?assembly={{ loc_search.assembly }}&search_type=overlap&paginate=true&accept=application/json${enabledFacets !== '' ? '&' + enabledFacets : ''}`;
+            return `/search/featureloc/${chromosome}/${start}/${end}?assembly={{ assembly }}&search_type=overlap&paginate=true&accept=application/json${enabledFacets !== '' ? '&' + enabledFacets : ''}`;
         }
 
         {% include "search/v1/partials/_paged_nav_js.html" with data=features no_data="No DNA Features Found" container_id="dnafeature" prefix="feature" page_query="page" url_function="_ => featureURL(chromo, start, end, facets)" %}
@@ -214,17 +225,17 @@ svg > g > text {
         }
         {% endswitch %}
 
-        {% if loc_search.location and loc_search.assembly %}
+        {% if location and assembly %}
         // Show the browser
         let browser = new CEGSGenoverse({
             container : '#genoverse', // Where to inject Genoverse (css/jQuery selector/DOM element)
             // If no genome supplied, it must have at least chromosomeSize, e.g.:
             // chromosomeSize : 249250621, // chromosome 1, human
-            genome    : '{{ loc_search.assembly }}', // see js/genomes/
-            assembly  : '{{ loc_search.assembly }}',
-            chr       : "{{ loc_search.location.chromo }}".replace("chr", ""),
-            start     : {{ loc_search.location.range.lower }},
-            end       : {{ loc_search.location.range.upper }},
+            genome    : '{{ assembly }}', // see js/genomes/
+            assembly  : '{{ assembly }}',
+            chr       : "{{ location.chromo }}".replace("chr", ""),
+            start     : {{ location.range.lower }},
+            end       : {{ location.range.upper }},
             plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips' ],
             useHash   : true,
             hideEmptyTracks: false,

--- a/cegs_portal/search/view_models/v1/tests/test_search.py
+++ b/cegs_portal/search/view_models/v1/tests/test_search.py
@@ -2,92 +2,118 @@ import pytest
 
 from cegs_portal.search.models import ChromosomeLocation
 from cegs_portal.search.models.utils import QueryToken
-from cegs_portal.search.view_models.v1.search import parse_query
+from cegs_portal.search.view_models.v1.search import (
+    ParseWarning,
+    SearchType,
+    parse_query,
+)
 
 
 @pytest.mark.parametrize(
     "query, result",
     [
-        ("", ([], None, None)),
-        ("hg38", ([], None, "GRCh38")),
-        ("hg19", ([], None, "GRCh37")),
-        ("chr1:1-100", ([], ChromosomeLocation("chr1", "1", "100"), None)),
-        ("chr1:1-100 chr2: 2-200", ([], ChromosomeLocation("chr2", "2", "200"), None)),
-        ("   chr1:1-100    chr2: 2-200   ", ([], ChromosomeLocation("chr2", "2", "200"), None)),
-        ("   hg38   ", ([], None, "GRCh38")),
-        ("   hg19 hg38   ", ([], None, "GRCh38")),
-        ("DCPGENE00000000", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, None)),
-        ("DCPGENE00000000 hg19", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
-        ("hg19 DCPGENE00000000", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
-        ("   hg19    DCPGENE00000000    ", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
-        ("   hg19    DCPGENE00000000    ", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
+        ("", (None, [], None, None, set())),
+        ("hg38", (None, [], None, "GRCh38", set())),
+        ("hg19", (None, [], None, "GRCh37", set())),
+        ("chr1:1-100", (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), None, set())),
+        (
+            "chr1:1-100 chr2: 2-200",
+            (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), None, {ParseWarning.TOO_MANY_LOCS}),
+        ),
+        (
+            "   chr1:1-100    chr2: 2-200   ",
+            (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), None, {ParseWarning.TOO_MANY_LOCS}),
+        ),
+        ("   hg38   ", (None, [], None, "GRCh38", set())),
+        ("   hg19 hg38   ", (None, [], None, "GRCh38", set())),
+        ("DCPGENE00000000", (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, None, set())),
+        (
+            "DCPGENE00000000 hg19",
+            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+        ),
+        (
+            "hg19 DCPGENE00000000",
+            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+        ),
+        (
+            "   hg19    DCPGENE00000000    ",
+            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+        ),
+        (
+            "   hg19    DCPGENE00000000    ",
+            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+        ),
         (
             "hg19 DCPGENE00000000 DCPGENE00000001",
             (
+                SearchType.ID,
                 [
                     QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
                     QueryToken.ACCESSION_ID.associate("DCPGENE00000001"),
                 ],
                 None,
                 "GRCh37",
+                set(),
             ),
         ),
         (
-            "hg19 DCPGENE00000000 ENSG00000001",
+            "hg19, DCPGENE00000000, ENSG00000001",
             (
+                SearchType.ID,
                 [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
                 None,
                 "GRCh37",
+                set(),
             ),
         ),
         (
-            "DCPGENE00000000 hg19 ENSG00000001",
+            "DCPGENE00000000,hg19,ENSG00000001",
             (
+                SearchType.ID,
                 [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
                 None,
                 "GRCh37",
+                set(),
             ),
         ),
         (
             "hg19 chr1:1-100 DCPGENE00000000 ENSG00000001",
             (
-                [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
+                SearchType.LOCATION,
+                [],
                 ChromosomeLocation("chr1", "1", "100"),
                 "GRCh37",
+                {ParseWarning.IGNORE_TERMS},
             ),
         ),
         (
             " hg19 ENSG00000001   chr1:1-100 DCPGENE00000000 ",
             (
+                SearchType.ID,
                 [QueryToken.ENSEMBL_ID.associate("ENSG00000001"), QueryToken.ACCESSION_ID.associate("DCPGENE00000000")],
-                ChromosomeLocation("chr1", "1", "100"),
+                None,
                 "GRCh37",
+                {ParseWarning.IGNORE_LOC},
             ),
         ),
         (
             "hg19 chr1:1-100 BRCA2 DCPGENE00000000 ENSG00000001 CBX2",
             (
-                [
-                    QueryToken.GENE_NAME.associate("BRCA2"),
-                    QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
-                    QueryToken.ENSEMBL_ID.associate("ENSG00000001"),
-                    QueryToken.GENE_NAME.associate("CBX2"),
-                ],
+                SearchType.LOCATION,
+                [],
                 ChromosomeLocation("chr1", "1", "100"),
                 "GRCh37",
+                {ParseWarning.IGNORE_TERMS},
             ),
         ),
         (
             "hg19 chr1:1-100 BRCA2 DCPGENE00000000 ENSG00000001 chr2:2-200 CBX2",
             (
-                [
-                    QueryToken.GENE_NAME.associate("BRCA2"),
-                    QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
-                    QueryToken.ENSEMBL_ID.associate("ENSG00000001"),
-                    QueryToken.GENE_NAME.associate("CBX2"),
-                ],
-                ChromosomeLocation("chr2", "2", "200"),
+                SearchType.LOCATION,
+                [],
+                ChromosomeLocation("chr1", "1", "100"),
                 "GRCh37",
+                {ParseWarning.TOO_MANY_LOCS, ParseWarning.IGNORE_TERMS},
             ),
         ),
     ],

--- a/cegs_portal/search/view_models/v1/tests/test_search.py
+++ b/cegs_portal/search/view_models/v1/tests/test_search.py
@@ -1,0 +1,96 @@
+import pytest
+
+from cegs_portal.search.models import ChromosomeLocation
+from cegs_portal.search.models.utils import QueryToken
+from cegs_portal.search.view_models.v1.search import parse_query
+
+
+@pytest.mark.parametrize(
+    "query, result",
+    [
+        ("", ([], None, None)),
+        ("hg38", ([], None, "GRCh38")),
+        ("hg19", ([], None, "GRCh37")),
+        ("chr1:1-100", ([], ChromosomeLocation("chr1", "1", "100"), None)),
+        ("chr1:1-100 chr2: 2-200", ([], ChromosomeLocation("chr2", "2", "200"), None)),
+        ("   chr1:1-100    chr2: 2-200   ", ([], ChromosomeLocation("chr2", "2", "200"), None)),
+        ("   hg38   ", ([], None, "GRCh38")),
+        ("   hg19 hg38   ", ([], None, "GRCh38")),
+        ("DCPGENE00000000", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, None)),
+        ("DCPGENE00000000 hg19", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
+        ("hg19 DCPGENE00000000", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
+        ("   hg19    DCPGENE00000000    ", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
+        ("   hg19    DCPGENE00000000    ", ([QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37")),
+        (
+            "hg19 DCPGENE00000000 DCPGENE00000001",
+            (
+                [
+                    QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
+                    QueryToken.ACCESSION_ID.associate("DCPGENE00000001"),
+                ],
+                None,
+                "GRCh37",
+            ),
+        ),
+        (
+            "hg19 DCPGENE00000000 ENSG00000001",
+            (
+                [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
+                None,
+                "GRCh37",
+            ),
+        ),
+        (
+            "DCPGENE00000000 hg19 ENSG00000001",
+            (
+                [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
+                None,
+                "GRCh37",
+            ),
+        ),
+        (
+            "hg19 chr1:1-100 DCPGENE00000000 ENSG00000001",
+            (
+                [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
+                ChromosomeLocation("chr1", "1", "100"),
+                "GRCh37",
+            ),
+        ),
+        (
+            " hg19 ENSG00000001   chr1:1-100 DCPGENE00000000 ",
+            (
+                [QueryToken.ENSEMBL_ID.associate("ENSG00000001"), QueryToken.ACCESSION_ID.associate("DCPGENE00000000")],
+                ChromosomeLocation("chr1", "1", "100"),
+                "GRCh37",
+            ),
+        ),
+        (
+            "hg19 chr1:1-100 BRCA2 DCPGENE00000000 ENSG00000001 CBX2",
+            (
+                [
+                    QueryToken.GENE_NAME.associate("BRCA2"),
+                    QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
+                    QueryToken.ENSEMBL_ID.associate("ENSG00000001"),
+                    QueryToken.GENE_NAME.associate("CBX2"),
+                ],
+                ChromosomeLocation("chr1", "1", "100"),
+                "GRCh37",
+            ),
+        ),
+        (
+            "hg19 chr1:1-100 BRCA2 DCPGENE00000000 ENSG00000001 chr2:2-200 CBX2",
+            (
+                [
+                    QueryToken.GENE_NAME.associate("BRCA2"),
+                    QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
+                    QueryToken.ENSEMBL_ID.associate("ENSG00000001"),
+                    QueryToken.GENE_NAME.associate("CBX2"),
+                ],
+                ChromosomeLocation("chr2", "2", "200"),
+                "GRCh37",
+            ),
+        ),
+    ],
+)
+def test_parse_query(query, result):
+    assert parse_query(query) == result

--- a/cegs_portal/search/views/v1/search.py
+++ b/cegs_portal/search/views/v1/search.py
@@ -40,9 +40,8 @@ class SearchView(TemplateJsonView):
 
         search_results["query"] = options["search_query"]
 
-        if search_results["features"] is not None:
+        if search_results["search_type"] == "LOCATION":
             feature_paginator = Paginator(search_results["features"], 20)
             search_results["features"] = feature_paginator.get_page(options["feature_page"])
-        else:
-            search_results["features"] = []
+
         return search_results

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -852,6 +852,11 @@ input[type="submit"], input[type="button"], button {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity));
+}
+
 .filter {
   -webkit-filter: var(--tw-filter);
           filter: var(--tw-filter);

--- a/cegs_portal/utils/http_exceptions.py
+++ b/cegs_portal/utils/http_exceptions.py
@@ -1,6 +1,6 @@
 class Http500(Exception):
-    pass
+    """Internal Server Error"""
 
 
 class Http400(Exception):
-    pass
+    """Bad Request"""


### PR DESCRIPTION
Changes the query parsing algorithm some so that it "eats" its way through
the search string. This allows us to match genes last. There isn't
a good way to actually match gene names, so POSSIBLE_GENE_NAME_RE
is just a heuristic. Basically, if nothing else matches it might be
a gene name.

I don't think a location and a gene name (for isntance) makes sense
as a search term, so the parser will only return parse information
for one of those, based on what is first in the search query.

HOWEVER, it will also return some warning information so the user
can be told what part of their query was ignored.

Also ignored: multiple locations

Creates a new ids_search method on the DNAFeatureSearch view model.
This new method takes a list of IDs and returns the DNAFeatures with
those IDs.

This new search method is hooked into the search result html. There
are informative warnings if search result terms are ignored.

I think its unlikely that result pagination will be helpful for searches by
ID. Additionally, I expect that changing the results based on what the genome browser
is doing will be actively annoying. Therefore, these are turned off for ID-based searches.