### PR TITLE
Check facet boxes in and search using search query facets

### DIFF
--- a/cegs_portal/search/templates/search/v1/partials/_features.html
+++ b/cegs_portal/search/templates/search/v1/partials/_features.html
@@ -1,13 +1,14 @@
     <div>
         <table class="data-table">
-            <tr><th>ID</th><th>Type</th><th>Name</th><th>Location</th><th>Strand</th><th>Reference Genome</th></tr>
+            <tr><th>ID</th><th>Feature Type</th><th>Cell Line</th><th>Location</th><th>Strand</th><th>Closest Gene</th><th>Reference Genome</th></tr>
             {% for feature in features %}
                 <tr class="{% cycle 'bg-blue-100' 'bg-blue-50' %}">
                     <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}">{{ feature.accession_id }}</a></td>
-                    <td>{{ feature.feature_subtype }}</td>
-                    <td>{{ feature.name }}</td>
+                    <td>{{ feature.get_feature_type_display }}</td>
+                    <td>{{ feature.cell_line }}</td>
                     <td><span>{{ feature.chrom_name }}</span>: <span>{{ feature.location.lower }}-{{ feature.location.upper|add:"-1" }}</span></td>
                     <td>{{ feature.strand }}</td>
+                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}">{{ feature.closest_gene_name }} ({{ feature.closest_gene_ensembl_id }})</a>{% else %}N/A{% endif %}</td>
                     <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
                 </tr>
             {% endfor %}

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -33,7 +33,7 @@ svg > g > text {
                         <div class="flex flex-row flex-wrap gap-1">
                             {% for value in facet.values.all %}
                             <div>
-                                <input type="checkbox" id="{{ value.id }}" name="{{ facet.name }}"></input>
+                                <input type="checkbox" id="{{ value.id }}" name="{{ facet.name }}"{% if value.id in facets_query %} checked="" {% endif %}></input>
                                 <label for="{{ value.id }}">{{ value.value }}</label>
                             </div>
                             {% endfor %}
@@ -117,14 +117,19 @@ svg > g > text {
 
         const facetCheckboxes = document.querySelectorAll("[name=facetfield] input[type=checkbox]");
 
-        facetCheckboxes.forEach(checkbox => {
-            checkbox.addEventListener("change", _ => {
-                let checkedFacets = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
+        const updateFacetState = function() {
+            let checkedFacets = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
                                      .filter(i => i.checked) // Use Array.filter to remove unchecked checkboxes.
                                      .map(i => i.id)
                 state.updateSharedState(STATE_FACETS, checkedFacets);
+        }
+        facetCheckboxes.forEach(checkbox => {
+            checkbox.addEventListener("change", _ => {
+                updateFacetState();
             });
         });
+
+        updateFacetState();
 
         // Update the chromosome location at the top of the page
         state.addCallback(STATE_LOCATION, (state, key) => {
@@ -132,7 +137,7 @@ svg > g > text {
 
             rc(g("loc-header"), t(`chr${location.chr}: ${location.start}-${location.end}`));
 
-            __genDataPages(location.chr, location.start, location.end, 1)();
+            __genDataPages(location.chr, location.start, location.end, 1,  state[STATE_FACETS])();
         });
 
         state.addCallback(STATE_FACETS, _.throttle(

--- a/cegs_portal/search/views/v1/search.py
+++ b/cegs_portal/search/views/v1/search.py
@@ -39,6 +39,7 @@ class SearchView(TemplateJsonView):
             raise Http400(e)
 
         search_results["query"] = options["search_query"]
+        search_results["facets_query"] = options["facets"]
 
         if search_results["search_type"] == "LOCATION":
             feature_paginator = Paginator(search_results["features"], 20)


### PR DESCRIPTION
Previously, a search URL like http://127.0.0.1:8000/search/results/?query=chr1:157909847-157959940%20hg19&facet=11 ignored the selected facet in the query.

The changes mean that a user can go to a search URL with a facet and get the expected results.

Additionally, the result table has been updated to be in line with the feature table output in tables.js This will avoid visual "popping" as one table gets replaced with another.

Fixes #15 