### PR TITLE
Fix pagination when no assembly specified

### DIFF
--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -110,7 +110,7 @@ svg > g > text {
         let featureURL = function(chromosome, start, end, facets=[]) {
             let enabledFacets = facets.map(id => `facet=${id}`)
                                   .join('&');
-            return `/search/featureloc/${chromosome}/${start}/${end}?assembly={{ assembly }}&search_type=overlap&paginate=true&accept=application/json${enabledFacets !== '' ? '&' + enabledFacets : ''}`;
+            return `/search/featureloc/${chromosome}/${start}/${end}?{% if assembly %}assembly={{ assembly }}{% endif %}&search_type=overlap&paginate=true&accept=application/json${enabledFacets !== '' ? '&' + enabledFacets : ''}`;
         }
 
         {% include "search/v1/partials/_paged_nav_js.html" with data=features no_data="No DNA Features Found" container_id="dnafeature" prefix="feature" page_query="page" url_function="_ => featureURL(chromo, start, end, facets)" %}


### PR DESCRIPTION
The pagination URL assumed an assembly had been specified. When it hadn't "None" was passed as the assembly, which broke queries.

Fixes #13 