### PR TITLE
Adds pagination info to experiment list JSON

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -50,10 +50,8 @@ def paged_experiments() -> Pageable[Experiment]:
     e6 = ExperimentFactory(other_files=(other_file(), other_file()), biosamples=(BiosampleFactory(),))
     e6.data_files.set(((data_file(e6),)))
     experiments = sorted([e1, e2, e3, e4, e5, e6], key=lambda x: x.accession_id)
-    return MockPaginator(
-        experiments,
-        3,
-    )
+    pages = MockPaginator(experiments, 3)
+    return pages.page(1)
 
 
 def data_file(experiment=None) -> ExperimentDataFile:

--- a/cegs_portal/search/json_templates/v1/experiment.py
+++ b/cegs_portal/search/json_templates/v1/experiment.py
@@ -5,17 +5,21 @@ from cegs_portal.utils.pagination_types import Pageable
 
 
 def experiments(experiments_obj: Pageable[Experiment], options: Optional[dict[str, Any]] = None):
-    results = [
-        {
-            "accession_id": e.accession_id,
-            "name": e.name,
-            "description": e.description,
-            "biosamples": [biosample(b) for b in e.biosamples.all()],
-        }
-        for e in experiments_obj.object_list
-    ]
-
-    return results
+    return {
+        "object_list": [
+            {
+                "accession_id": e.accession_id,
+                "name": e.name,
+                "description": e.description,
+                "biosamples": [biosample(b) for b in e.biosamples.all()],
+            }
+            for e in experiments_obj.object_list
+        ],
+        "page": experiments_obj.number,
+        "has_next_page": experiments_obj.has_next(),
+        "has_prev_page": experiments_obj.has_previous(),
+        "num_pages": experiments_obj.paginator.num_pages,
+    }
 
 
 def experiment(experiment_obj: Experiment, options: Optional[dict[str, Any]] = None):

--- a/cegs_portal/search/json_templates/v1/tests/test_experiment.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_experiment.py
@@ -13,25 +13,21 @@ pytestmark = pytest.mark.django_db
 
 
 def test_experiments_json(paged_experiments: Pageable[Experiment]):
-    for experiment in paged_experiments.object_list:
-        experi_cell_lines: list[str] = []
-        experi_tissue_types: list[str] = []
-        for bios in experiment.biosamples.all():
-            experi_cell_lines.append(bios.cell_line_name)
-            experi_tissue_types.append(bios.cell_line.tissue_type_name)
-
-        setattr(experiment, "cell_lines", experi_cell_lines)
-        setattr(experiment, "tissue_types", experi_tissue_types)
-
-    result = [
-        {
-            "accession_id": e.accession_id,
-            "name": e.name,
-            "description": e.description,
-            "biosamples": [b_json(b) for b in e.biosamples.all()],
-        }
-        for e in paged_experiments.object_list
-    ]
+    result = {
+        "object_list": [
+            {
+                "accession_id": e.accession_id,
+                "name": e.name,
+                "description": e.description,
+                "biosamples": [b_json(b) for b in e.biosamples.all()],
+            }
+            for e in paged_experiments.object_list
+        ],
+        "page": paged_experiments.number,
+        "has_next_page": paged_experiments.has_next(),
+        "has_prev_page": paged_experiments.has_previous(),
+        "num_pages": paged_experiments.paginator.num_pages,
+    }
 
     assert exps_json(paged_experiments) == result
 


### PR DESCRIPTION
The experiment list is always paginated, so the JSON needs to include that information so clients know how to get all the experiments.