### PR TITLE
Fixes a couple of issue with the JS on the featureloc page

### DIFF
--- a/cegs_portal/search/templates/search/v1/dna_features.html
+++ b/cegs_portal/search/templates/search/v1/dna_features.html
@@ -30,7 +30,7 @@
 
         const STATE_LOCATION = "location";
         let state = new State({
-            STATE_LOCATION: {
+            [STATE_LOCATION]: {
                 chr: "{{ loc.chr }}",
                 start: {{ loc.start }},
                 end: {{ loc.end }}
@@ -51,7 +51,7 @@
         let initialLocation = state.getSharedState(STATE_LOCATION);
 
         let featureURL = function(chromosome, start, end) {
-            return `/search/featureloc/chr${chromosome}/${start}/${end}?search_type=overlap&accept=application/json`;
+            return `/search/featureloc/${chromosome}/${start}/${end}?search_type=overlap&accept=application/json`;
         };
 
         {% include "search/v1/partials/_paged_nav_js.html" with data=features no_data="No DNA Feature Found" container_id="dnafeature" prefix="feature" page_query="page" url_function="_ => featureURL(chromo, start, end)" %}


### PR DESCRIPTION
* adds superfluous "chr" to a fetch url, resulting in a chromosome fetch of "chrchr1/xxxxxx/yyyyy", which doesn't exist of course
* wraps STATE_LOCATION in [], indicating that the key should be the value of STATE_LOCATION, not the string STATE_LOCATION.