### PR TITLE
Prefetch facets when using "with_facet_values"

### DIFF
--- a/cegs_portal/search/models/reg_effects.py
+++ b/cegs_portal/search/models/reg_effects.py
@@ -18,7 +18,7 @@ class EffectObservationDirectionType(Enum):
 
 class RegulatoryEffectObservationSet(models.QuerySet):
     def with_facet_values(self):
-        return self.prefetch_related("facet_values")
+        return self.prefetch_related("facet_values", "facet_values__facet")
 
 
 class RegulatoryEffectObservation(Accessioned, Searchable, Faceted):


### PR DESCRIPTION
We need to know the facets to get the "Direction" facet_value for REOs. And any time we use "with_facet_values" we wan't to know the Direction.

This saves us an n+1 query for facets.