### PR TITLE
Update dnafeature/reo access controls on background thread

### DIFF
--- a/cegs_portal/search/models/__init__.py
+++ b/cegs_portal/search/models/__init__.py
@@ -1,3 +1,4 @@
+from . import signals
 from .accession import Accessioned, AccessionIdLog, AccessionIds
 from .dna_feature import DNAFeature, DNAFeatureType
 from .experiment import Biosample, CellLine, Experiment, ExperimentDataFile, TissueType

--- a/cegs_portal/search/models/signals.py
+++ b/cegs_portal/search/models/signals.py
@@ -1,0 +1,33 @@
+from django.db import connection
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from cegs_portal.search.models.experiment import Experiment
+from cegs_portal.tasks.decorators import as_task
+from cegs_portal.tasks.models import ThreadTask
+from cegs_portal.utils.decorators import skip_in_testing
+
+
+@receiver(post_save, sender=Experiment)
+@skip_in_testing
+@as_task(pass_id=True)
+def set_access_controls(task_id, sender, instance, created, raw, using, update_fields, **kwargs):
+    if created:
+        ThreadTask.set_description(task_id, "Experiment created")
+        return
+
+    ThreadTask.set_description(task_id, f"Modify access controls of {instance.accession_id}")
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """UPDATE search_dnafeature
+               SET public = %s, archived = %s
+               WHERE experiment_accession_id = %s""",
+            [instance.public, instance.archived, instance.accession_id],
+        )
+        cursor.execute(
+            """UPDATE search_regulatoryeffectobservation
+               SET public = %s, archived = %s
+               WHERE experiment_accession_id = %s""",
+            [instance.public, instance.archived, instance.accession_id],
+        )

--- a/cegs_portal/tasks/conftest.py
+++ b/cegs_portal/tasks/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from cegs_portal.tasks.models import ThreadTask
+
+
+@pytest.fixture(scope="function", autouse=True)
+def execute_before_any_test(db):
+    ThreadTask.objects.all().delete()

--- a/cegs_portal/tasks/tests/test_tasks.py
+++ b/cegs_portal/tasks/tests/test_tasks.py
@@ -8,7 +8,6 @@ from cegs_portal.tasks.models import ThreadTask
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.django_db(transaction=True)
 def test_create_task():
     @as_task(pass_id=False)
     def test_func():
@@ -27,7 +26,6 @@ def test_create_task():
     assert all_tasks.first().failed_exception is None
 
 
-@pytest.mark.django_db(transaction=True)
 def test_create_task_description():
     @as_task(description="Test Description")
     def test_func():
@@ -45,7 +43,6 @@ def test_create_task_description():
     assert not all_tasks.first().failed
 
 
-@pytest.mark.django_db(transaction=True)
 def test_create_task_pass_id_description():
     @as_task(pass_id=True, description="Test Description")
     def test_func(task_id):
@@ -65,7 +62,6 @@ def test_create_task_pass_id_description():
     assert first_task.failed_exception == f"Failed Task {first_task.id}"
 
 
-@pytest.mark.django_db(transaction=True)
 def test_task_exception():
     @as_task(pass_id=False)
     def test_func():

--- a/cegs_portal/utils/decorators.py
+++ b/cegs_portal/utils/decorators.py
@@ -1,0 +1,12 @@
+from functools import wraps
+
+from django.conf import settings
+
+
+def skip_in_testing(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        if not settings.TESTING:
+            return f(*args, **kwargs)
+
+    return wrapper

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -274,3 +274,4 @@ FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+TESTING = False

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -39,3 +39,4 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+TESTING = True


### PR DESCRIPTION
Updating the access controls for a set of dnafeatures/reos when an experiment is set private or archived can take a few moments. To avoid locking the whole server up the work should be done in the background.

There's some code in here for testing -- we don't want the new signal handler going off during tests, so I added a way to disable it.