### PR TITLE
Open new search window when clicking on a zoomed-in bucket

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
+++ b/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
@@ -192,32 +192,40 @@ export class GenomeRenderer {
     }
 
     _zoomOutButton(svg, chromIndex, scales, xInset) {
-        const buttonVMargin = 10;
-        const buttonHeight = this.chromDimensions.chromSpacing * scales.scaleY - buttonVMargin * 2;
-        const buttonTop =
+        const fontSize = 140;
+        const strokeSize = 3;
+        const fillColor = "#9D9D9D";
+        const cornerRadius = 2;
+        const vMargin = 10;
+        const text = "Zoom Out";
+        const textVAdjustment = 7;
+        const textHAnchor = "middle";
+        const textVAnchor = "central";
+        const height = this.chromDimensions.chromSpacing * scales.scaleY - vMargin * 2;
+        const width = 25 * scales.scaleX;
+        const top =
             this.renderContext.yInset +
             (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * chromIndex * scales.scaleY -
-            (buttonHeight + buttonVMargin);
-        const buttonWidth = 25 * scales.scaleX;
+            (height + vMargin);
 
         let buttonGroup = svg.append("g");
         let button = buttonGroup.append("rect");
         button
-            .attr("width", buttonWidth)
-            .attr("x", xInset + (this.renderContext.viewWidth - buttonWidth) / 2)
-            .attr("y", buttonTop)
-            .attr("height", buttonHeight)
-            .attr("stroke", 1)
-            .attr("fill", "#9D9D9D")
-            .attr("rx", 3 * scales.scale);
+            .attr("width", width)
+            .attr("x", xInset + (this.renderContext.viewWidth - width) / 2)
+            .attr("y", top)
+            .attr("height", height)
+            .attr("stroke-width", strokeSize)
+            .attr("fill", fillColor)
+            .attr("rx", cornerRadius * scales.scale);
         let buttonText = buttonGroup.append("text");
         buttonText
             .attr("x", xInset + this.renderContext.viewWidth / 2)
-            .attr("y", buttonTop + buttonHeight / 2 - 7)
-            .attr("font-size", 140)
-            .attr("text-anchor", "middle")
-            .attr("dominant-baseline", "central")
-            .text("Zoom Out");
+            .attr("y", top + height / 2 - textVAdjustment)
+            .attr("font-size", fontSize)
+            .attr("text-anchor", textHAnchor)
+            .attr("dominant-baseline", textVAnchor)
+            .text(text);
     }
 
     render(

--- a/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
+++ b/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
@@ -46,11 +46,10 @@ export class Tooltip {
         this.node.removeAttribute("display");
         this.node.setAttribute(
             "transform",
-            `translate(${this.renderContext.xInset + this.renderContext.toPx(d.start) * scaleX}, ${
-                this.renderContext.yInset +
-                chomIdx *
-                    (this.renderContext.chromDimensions.chromHeight + this.renderContext.chromDimensions.chromSpacing) *
-                    scaleY
+            `translate(${this.renderContext.xInset + this.renderContext.toPx(d.start) * scaleX}, ${this.renderContext.yInset +
+            chomIdx *
+            (this.renderContext.chromDimensions.chromHeight + this.renderContext.chromDimensions.chromSpacing) *
+            scaleY
             }) scale(2)`
         );
         this._count.textContent = `Ct: ${d.count}`;
@@ -194,7 +193,7 @@ export class GenomeRenderer {
         const bucketHeight = 44 * scaleY;
         const sourceCountRange = sourceCountInterval[1] - sourceCountInterval[0];
         const targetCountRange = targetCountInterval[1] - targetCountInterval[0];
-        const scales = {scale, scaleX, scaleY};
+        const scales = { scale, scaleX, scaleY };
 
         const svg = d3
             .create("svg")
@@ -237,7 +236,7 @@ export class GenomeRenderer {
                     this.renderContext.yInset +
                     (this.chromDimensions.chromHeight / 2 +
                         (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * i) *
-                        scaleY
+                    scaleY
             )
             .attr("font-size", Math.max(Math.ceil(14 * (scaleY * 0.3)), 32))
             .text((chromo) => chromo.chrom);
@@ -284,7 +283,7 @@ export class GenomeRenderer {
                 .attr(
                     "y",
                     this.renderContext.yInset +
-                        (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * i * scaleY
+                    (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * i * scaleY
                 )
                 .attr("width", bucketWidth)
                 .attr("height", bucketHeight);
@@ -322,7 +321,7 @@ export class GenomeRenderer {
                 .attr(
                     "y",
                     this.renderContext.yInset +
-                        (54 + (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * i) * scaleY
+                    (54 + (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * i) * scaleY
                 )
                 .attr("width", bucketWidth)
                 .attr("height", bucketHeight);
@@ -381,7 +380,7 @@ export class GenomeRenderer {
                     mouseLeave();
                 })
                 .on("click", (event, rect) => {
-                    this.onBucketClick(i, rect.start, this);
+                    this.onBucketClick(i, chromName, rect.start, rect.end, this);
                 });
 
             targetRects

--- a/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
+++ b/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
@@ -87,6 +87,7 @@ export class GenomeRenderer {
         this.renderContext = new VizRenderContext(this.chromDimensions, genome);
         this.tooltip = new Tooltip(this.renderContext);
         this.onBucketClick = null;
+        this.onBackgroundClick = null;
     }
 
     _chromosomeOutline(scales, d, i) {
@@ -380,8 +381,10 @@ export class GenomeRenderer {
                     mouseLeave();
                 })
                 .on("click", (event, rect) => {
+                    event.stopImmediatePropagation();
                     this.onBucketClick(i, chromName, rect.start, rect.end, this);
                 });
+
 
             targetRects
                 .on("mouseenter", (event, rect) => {
@@ -423,12 +426,15 @@ export class GenomeRenderer {
                     mouseLeave();
                 })
                 .on("click", (event, rect) => {
-                    this.onBucketClick(i, rect.start, this);
+                    event.stopImmediatePropagation();
+                    this.onBucketClick(i, chromName, rect.start, rect.end, this);
                 });
         }
 
         svg.append(() => this.tooltip.node);
-
+        svg.on("click", (event, rect) => {
+            this.onBackgroundClick(rect, this);
+        });
         return svg.node();
     }
 }

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -209,11 +209,12 @@
             const scaleY = state.g(STATE_SCALE_Y);
             const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
             let currentLevel = state.g(STATE_ALL_FILTERED);
+            let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
             let countIntervals = state.g(STATE_COUNT_FILTER_INTERVALS);
             let sourceCountInterval = countIntervals.source;
             let targetCountInterval = countIntervals.target;
 
-            rc(g("chrom-data"), genomeRenderer.render(currentLevel, sourceCountInterval, targetCountInterval, viewBox, scale, scaleX, scaleY, highlightRegions));
+            rc(g("chrom-data"), genomeRenderer.render(currentLevel, focusIndex, sourceCountInterval, targetCountInterval, viewBox, scale, scaleX, scaleY, highlightRegions));
             rc(g("chrom-data-legend"), Legend(d3.scaleSequential(sourceCountInterval, sourceColors), {
                 title: "Source Count"
             }));

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -120,11 +120,13 @@
         import { mergeCoverageData, mergeFacets } from "{% static 'search/js/exp_viz/mergeDataStructures.js' %}";
 
         let genome;
+        let genomeName;
         let coverageData;
         let facets;
         try {
             let manifest = await getJson("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/coverage_manifest.json");
-            genome = await getJson(`{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/${manifest.genome}`);
+            genome = await getJson(`{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/${manifest.genome.file}`);
+            genomeName = manifest.genome.name
             coverageData = manifest.chromosomes;
             facets = manifest.facets;
         } catch (error) {
@@ -173,11 +175,12 @@
             [STATE_SELECTED_EXPERIMENTS]: ["{{ experiment.accession_id }}"]
         });
 
-        genomeRenderer.onBucketClick = (i, start, renderer) => {
+        genomeRenderer.onBucketClick = (i, chromName, start, end, renderer) => {
             let zoomed = state.g(STATE_ZOOMED);
             if(zoomed) {
                 state.u(STATE_VIEWBOX, [0, 0, renderer.renderContext.viewWidth, renderer.renderContext.viewHeight]);
                 state.u(STATE_ZOOM_CHROMO_INDEX, undefined);
+                window.open(`/search/results/?query=chr${chromName}:${start}-${end}+${genomeName}`, "_blank");
             } else {
                 state.u(STATE_VIEWBOX, [
                     renderer.renderContext.xInset + renderer.renderContext.toPx(start) * 30 - renderer.renderContext.viewHeight / 6,

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -178,8 +178,6 @@
         genomeRenderer.onBucketClick = (i, chromName, start, end, renderer) => {
             let zoomed = state.g(STATE_ZOOMED);
             if(zoomed) {
-                state.u(STATE_VIEWBOX, [0, 0, renderer.renderContext.viewWidth, renderer.renderContext.viewHeight]);
-                state.u(STATE_ZOOM_CHROMO_INDEX, undefined);
                 window.open(`/search/results/?query=chr${chromName}:${start}-${end}+${genomeName}`, "_blank");
             } else {
                 state.u(STATE_VIEWBOX, [
@@ -189,9 +187,18 @@
                     renderer.renderContext.viewHeight
                 ]);
                 state.u(STATE_ZOOM_CHROMO_INDEX, i);
+                state.u(STATE_ZOOMED, !zoomed);
             }
-            state.u(STATE_ZOOMED, !zoomed);
+
         }
+
+        genomeRenderer.onBackgroundClick = (rect, renderer) => {
+        let zoomed = state.g(STATE_ZOOMED);
+            if(zoomed) {
+                state.u(STATE_VIEWBOX, [0, 0, renderer.renderContext.viewWidth, renderer.renderContext.viewHeight]);
+                state.u(STATE_ZOOM_CHROMO_INDEX, undefined);
+                state.u(STATE_ZOOMED, !zoomed);
+            }}
 
         rc(g("chrom-data-header"), t("Experiment Coverage"));
 


### PR DESCRIPTION
Opens a new window/tab to a search of the location of a zoomed-in bucket when it's clicked on. Also adds a different method of zooming out (clicking anywhere in the SVG area _except_ a bucket), in case the user doesn't want to open a search window.