### PR TITLE
Redirect search of a single feature id to the feature page

### DIFF
--- a/cegs_portal/search/models/__init__.py
+++ b/cegs_portal/search/models/__init__.py
@@ -10,5 +10,5 @@ from .reg_effects import (
     RegulatoryEffectObservation,
     RegulatoryEffectObservationSet,
 )
-from .utils import AccessionId, AccessionType, ChromosomeLocation, QueryToken
+from .utils import AccessionId, AccessionType, ChromosomeLocation, IdType
 from .variants import Subject, Variant, VCFEntry, VCFFile

--- a/cegs_portal/search/models/utils.py
+++ b/cegs_portal/search/models/utils.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum, StrEnum
 from typing import Optional
 
 from psycopg2.extras import NumericRange
@@ -83,12 +83,12 @@ class AccessionId:
         )
 
 
-class QueryToken(Enum):
-    ENSEMBL_ID = auto()
-    ACCESSION_ID = auto()
-    GENE_NAME = auto()
+class IdType(StrEnum):
+    ENSEMBL = "ensembl"
+    ACCESSION = "accession"
+    GENE_NAME = "name"
 
-    def associate(self, value: str) -> tuple["QueryToken", str]:
+    def associate(self, value: str) -> tuple["IdType", str]:
         return (self, value)
 
 

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -4,16 +4,9 @@ from typing import Any, Optional, cast
 from django.db.models import Q, QuerySet
 from psycopg2.extras import NumericRange
 
-from cegs_portal.search.models import DNAFeature, DNAFeatureType, QueryToken
+from cegs_portal.search.models import DNAFeature, DNAFeatureType, IdType
 from cegs_portal.search.view_models.errors import ObjectNotFoundError, ViewModelError
 from cegs_portal.utils.http_exceptions import Http500
-
-
-# TODO: create StrEnum class so e.g., `"ensemble" == IdType.ENSEMBL` works as expected
-class IdType(Enum):
-    ENSEMBL = "ensembl"
-    NAME = "name"
-    ACCESSION = "accession"
 
 
 class LocSearchType(Enum):
@@ -108,7 +101,7 @@ class DNAFeatureSearch:
     @classmethod
     def ids_search(
         cls,
-        ids: list[tuple[QueryToken, str]],
+        ids: list[tuple[IdType, str]],
         assembly: Optional[str],
         feature_properties: list[str],
     ) -> QuerySet[DNAFeature]:
@@ -122,11 +115,11 @@ class DNAFeatureSearch:
         ensembl_ids = []
         gene_names = []
         for id_type, feature_id in ids:
-            if id_type == QueryToken.ACCESSION_ID:
+            if id_type == IdType.ACCESSION:
                 accession_ids.append(feature_id)
-            elif id_type == QueryToken.ENSEMBL_ID:
+            elif id_type == IdType.ENSEMBL:
                 ensembl_ids.append(feature_id)
-            elif id_type == QueryToken.GENE_NAME:
+            elif id_type == IdType.GENE_NAME:
                 gene_names.append(feature_id)
             else:
                 raise Http500(f"Invalid Query Token: ({id_type}, {feature_id})")

--- a/cegs_portal/search/view_models/v1/search.py
+++ b/cegs_portal/search/view_models/v1/search.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 from cegs_portal.search.models import ChromosomeLocation, Facet
-from cegs_portal.search.models.utils import QueryToken
+from cegs_portal.search.models.utils import IdType
 from cegs_portal.search.view_models.v1 import DNAFeatureSearch, LocSearchType
 
 
 class Search:
     @classmethod
-    def dnafeature_id_search(cls, ids: list[tuple[QueryToken, str]], assembly: Optional[str]):
+    def dnafeature_ids_search(cls, ids: list[tuple[IdType, str]], assembly: Optional[str]):
         return DNAFeatureSearch.ids_search(
             ids,
             assembly,
@@ -15,7 +15,7 @@ class Search:
         )
 
     @classmethod
-    def dnafeature_id_search_public(cls, ids: list[tuple[QueryToken, str]], assembly: Optional[str]):
+    def dnafeature_ids_search_public(cls, ids: list[tuple[IdType, str]], assembly: Optional[str]):
         return DNAFeatureSearch.ids_search_public(
             ids,
             assembly,
@@ -23,8 +23,8 @@ class Search:
         )
 
     @classmethod
-    def dnafeature_id_search_with_private(
-        cls, ids: list[tuple[QueryToken, str]], assembly: Optional[str], private_experiments: list[str]
+    def dnafeature_ids_search_with_private(
+        cls, ids: list[tuple[IdType, str]], assembly: Optional[str], private_experiments: list[str]
     ):
         return DNAFeatureSearch.ids_search_with_private(
             ids,

--- a/cegs_portal/search/views/custom_views.py
+++ b/cegs_portal/search/views/custom_views.py
@@ -14,7 +14,8 @@ from django.views.generic import View
 
 from cegs_portal.search.views.renderers import json
 from cegs_portal.search.views.view_utils import JSON_MIME
-from cegs_portal.utils.http_exceptions import Http400, Http500
+from cegs_portal.utils.http_exceptions import Http303, Http400, Http500
+from cegs_portal.utils.http_responses import HttpResponseSeeOtherRedirect
 
 logger = logging.getLogger("django.request")
 
@@ -85,6 +86,8 @@ class TemplateJsonView(View):
         try:
             assert data_handler is not None
             response = handler(request, options, data_handler(options, *args, **kwargs), *args, **kwargs)
+        except Http303 as redirect:
+            response = HttpResponseSeeOtherRedirect(redirect_to=redirect.location)
         except Http400 as err:
             response = self.http_bad_request(request, err)
         except Http404 as err:

--- a/cegs_portal/search/views/v1/dna_features.py
+++ b/cegs_portal/search/views/v1/dna_features.py
@@ -43,6 +43,8 @@ class DNAFeatureId(ExperimentAccessMixin, TemplateJsonView):
         GET queries used:
             accept
                 * application/json
+            assembly
+                * Should match a genome assembly that exists in the DB
             property (multiple)
                 * "regeffects" - preload associated reg effects
             id_type
@@ -52,6 +54,7 @@ class DNAFeatureId(ExperimentAccessMixin, TemplateJsonView):
             feature_id
         """
         options = super().request_options(request)
+        options["assembly"] = request.GET.get("assembly", None)
         options["feature_properties"] = request.GET.getlist("property", [])
         return options
 
@@ -76,7 +79,9 @@ class DNAFeatureId(ExperimentAccessMixin, TemplateJsonView):
         )
 
     def get_data(self, options, id_type, feature_id):
-        return DNAFeatureSearch.id_search(id_type, feature_id, feature_properties=options["feature_properties"])
+        return DNAFeatureSearch.id_search(
+            id_type, feature_id, assembly=options["assembly"], feature_properties=options["feature_properties"]
+        )
 
 
 class DNAFeatureLoc(TemplateJsonView):

--- a/cegs_portal/search/views/v1/search.py
+++ b/cegs_portal/search/views/v1/search.py
@@ -12,7 +12,7 @@ from cegs_portal.search.json_templates.v1.search_results import (
 )
 from cegs_portal.search.models import ChromosomeLocation, Facet
 from cegs_portal.search.models.dna_feature import DNAFeature
-from cegs_portal.search.models.utils import QueryToken
+from cegs_portal.search.models.utils import IdType
 from cegs_portal.search.view_models.v1 import Search
 from cegs_portal.search.views.custom_views import TemplateJsonView
 from cegs_portal.utils.http_exceptions import Http400
@@ -51,9 +51,9 @@ SearchResult = TypedDict(
 def parse_query(
     query: str,
 ) -> tuple[
-    Optional[SearchType], list[tuple[QueryToken, str]], Optional[ChromosomeLocation], Optional[str], set[ParseWarning]
+    Optional[SearchType], list[tuple[IdType, str]], Optional[ChromosomeLocation], Optional[str], set[ParseWarning]
 ]:
-    terms: list[tuple[QueryToken, str]] = []
+    terms: list[tuple[IdType, str]] = []
     location: Optional[ChromosomeLocation] = None
     assembly: Optional[str] = None
     warnings: set[ParseWarning] = set()
@@ -82,7 +82,7 @@ def parse_query(
             if search_type == SearchType.LOCATION:
                 warnings.add(ParseWarning.IGNORE_TERMS)
             else:
-                terms.append(QueryToken.ENSEMBL_ID.associate(match.group(1)))
+                terms.append(IdType.ENSEMBL.associate(match.group(1)))
                 search_type = SearchType.ID
 
             query = query[match.end() :]
@@ -92,7 +92,7 @@ def parse_query(
             if search_type == SearchType.LOCATION:
                 warnings.add(ParseWarning.IGNORE_TERMS)
             else:
-                terms.append(QueryToken.ACCESSION_ID.associate(match.group(1)))
+                terms.append(IdType.ACCESSION.associate(match.group(1)))
                 search_type = SearchType.ID
 
             query = query[match.end() :]
@@ -114,7 +114,7 @@ def parse_query(
             if search_type == SearchType.LOCATION:
                 warnings.add(ParseWarning.IGNORE_TERMS)
             else:
-                terms.append(QueryToken.GENE_NAME.associate(match.group(1)))
+                terms.append(IdType.GENE_NAME.associate(match.group(1)))
                 search_type = SearchType.ID
 
             query = query[match.end() :]

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -240,8 +240,28 @@ def test_experiment_feature_loc_with_authenticated_authorized_group_client(
     assert len(json_content["features"]) == 2
 
 
-def test_experiment_feature_accession_json(client: Client, search_feature: DNAFeature):
+def test_experiment_feature_accession_redirect(client: Client, search_feature: DNAFeature):
     response = client.get(f"/search/results/?query={search_feature.accession_id}&accept=application/json")  # noqa: E501
+
+    assert response.status_code == 303
+
+
+def test_experiment_feature_ensembl_redirect(client: Client, search_feature: DNAFeature):
+    response = client.get(f"/search/results/?query={search_feature.ensembl_id}&accept=application/json")  # noqa: E501
+
+    assert response.status_code == 303
+
+
+def test_experiment_feature_name_redirect(client: Client, search_feature: DNAFeature):
+    response = client.get(f"/search/results/?query={search_feature.name}&accept=application/json")  # noqa: E501
+
+    assert response.status_code == 303
+
+
+def test_experiment_feature_accession_json(client: Client, search_feature: DNAFeature, private_feature: DNAFeature):
+    response = client.get(
+        f"/search/results/?query={search_feature.accession_id}+{private_feature.accession_id}&accept=application/json"
+    )  # noqa: E501
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -258,30 +278,36 @@ def test_experiment_feature_accession_json(client: Client, search_feature: DNAFe
     assert len(json_content["features"]) == 1
 
 
-def test_experiment_feature_accession_with_anonymous_client(client: Client, private_feature: DNAFeature):
-    response = client.get(f"/search/results/?query={private_feature.accession_id}&accept=application/json")
+def test_experiment_feature_accession_with_anonymous_client(
+    client: Client, search_feature: DNAFeature, private_feature: DNAFeature
+):
+    response = client.get(
+        f"/search/results/?query={private_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_experiment_feature_accession_with_authenticated_client(
-    client: Client, private_feature: DNAFeature, django_user_model
+    client: Client, search_feature: DNAFeature, private_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
     django_user_model.objects.create_user(username=username, password=password)
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={private_feature.accession_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={private_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_experiment_feature_accession_with_authenticated_authorized_client(
-    client: Client, private_feature: DNAFeature, django_user_model
+    client: Client, search_feature: DNAFeature, private_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
@@ -289,15 +315,21 @@ def test_experiment_feature_accession_with_authenticated_authorized_client(
     user.experiments = [private_feature.experiment_accession_id]
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={private_feature.accession_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={private_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 1
+    assert len(json_content["features"]) == 2
 
 
 def test_experiment_feature_accession_with_authenticated_authorized_group_client(
-    client: Client, private_feature: DNAFeature, group_extension: GroupExtension, django_user_model
+    client: Client,
+    search_feature: DNAFeature,
+    private_feature: DNAFeature,
+    group_extension: GroupExtension,
+    django_user_model,
 ):
     username = "user1"
     password = "bar"
@@ -310,37 +342,45 @@ def test_experiment_feature_accession_with_authenticated_authorized_group_client
     user.groups.add(group_extension.group)
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={private_feature.accession_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={private_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
+    assert response.status_code == 200
+
+    json_content = json.loads(response.content)
+    assert len(json_content["features"]) == 2
+
+
+def test_archived_experiment_feature_accession_with_anonymous_client(
+    client: Client, archived_feature: DNAFeature, search_feature: DNAFeature
+):
+    response = client.get(
+        f"/search/results/?query={archived_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
     assert len(json_content["features"]) == 1
 
 
-def test_archived_experiment_feature_accession_with_anonymous_client(client: Client, archived_feature: DNAFeature):
-    response = client.get(f"/search/results/?query={archived_feature.accession_id}&accept=application/json")
-    assert response.status_code == 200
-
-    json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
-
-
 def test_archived_experiment_feature_accession_with_authenticated_client(
-    client: Client, archived_feature: DNAFeature, django_user_model
+    client: Client, archived_feature: DNAFeature, search_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
     django_user_model.objects.create_user(username=username, password=password)
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={archived_feature.accession_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={archived_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_archived_experiment_feature_accession_with_authenticated_authorized_client(
-    client: Client, archived_feature: DNAFeature, django_user_model
+    client: Client, archived_feature: DNAFeature, search_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
@@ -348,15 +388,21 @@ def test_archived_experiment_feature_accession_with_authenticated_authorized_cli
     user.experiments = [archived_feature.experiment_accession_id]
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={archived_feature.accession_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={archived_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_archived_experiment_feature_accession_with_authenticated_authorized_group_client(
-    client: Client, archived_feature: DNAFeature, group_extension: GroupExtension, django_user_model
+    client: Client,
+    archived_feature: DNAFeature,
+    search_feature: DNAFeature,
+    group_extension: GroupExtension,
+    django_user_model,
 ):
     username = "user1"
     password = "bar"
@@ -369,15 +415,19 @@ def test_archived_experiment_feature_accession_with_authenticated_authorized_gro
     user.groups.add(group_extension.group)
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={archived_feature.accession_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={archived_feature.accession_id}+{search_feature.accession_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
-def test_experiment_feature_ensembl_json(client: Client, feature: DNAFeature):
-    response = client.get(f"/search/results/?query={feature.ensembl_id}&accept=application/json")  # noqa: E501
+def test_experiment_feature_ensembl_json(client: Client, feature: DNAFeature, private_feature: DNAFeature):
+    response = client.get(
+        f"/search/results/?query={feature.ensembl_id}+{private_feature.ensembl_id}&accept=application/json"
+    )  # noqa: E501
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -394,30 +444,36 @@ def test_experiment_feature_ensembl_json(client: Client, feature: DNAFeature):
     assert len(json_content["features"]) == 1
 
 
-def test_experiment_feature_ensembl_with_anonymous_client(client: Client, private_feature: DNAFeature):
-    response = client.get(f"/search/results/?query={private_feature.ensembl_id}&accept=application/json")
+def test_experiment_feature_ensembl_with_anonymous_client(
+    client: Client, search_feature: DNAFeature, private_feature: DNAFeature
+):
+    response = client.get(
+        f"/search/results/?query={search_feature.ensembl_id}+{private_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_experiment_feature_ensembl_with_authenticated_client(
-    client: Client, private_feature: DNAFeature, django_user_model
+    client: Client, search_feature: DNAFeature, private_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
     django_user_model.objects.create_user(username=username, password=password)
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={private_feature.ensembl_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={search_feature.ensembl_id}+{private_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_experiment_feature_ensembl_with_authenticated_authorized_client(
-    client: Client, private_feature: DNAFeature, django_user_model
+    client: Client, search_feature: DNAFeature, private_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
@@ -425,15 +481,21 @@ def test_experiment_feature_ensembl_with_authenticated_authorized_client(
     user.experiments = [private_feature.experiment_accession_id]
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={private_feature.ensembl_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={search_feature.ensembl_id}+{private_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 1
+    assert len(json_content["features"]) == 2
 
 
 def test_experiment_feature_ensembl_with_authenticated_authorized_group_client(
-    client: Client, private_feature: DNAFeature, group_extension: GroupExtension, django_user_model
+    client: Client,
+    search_feature: DNAFeature,
+    private_feature: DNAFeature,
+    group_extension: GroupExtension,
+    django_user_model,
 ):
     username = "user1"
     password = "bar"
@@ -446,37 +508,45 @@ def test_experiment_feature_ensembl_with_authenticated_authorized_group_client(
     user.groups.add(group_extension.group)
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={private_feature.ensembl_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={search_feature.ensembl_id}+{private_feature.ensembl_id}&accept=application/json"
+    )
+    assert response.status_code == 200
+
+    json_content = json.loads(response.content)
+    assert len(json_content["features"]) == 2
+
+
+def test_archived_experiment_feature_ensembl_with_anonymous_client(
+    client: Client, archived_feature: DNAFeature, search_feature: DNAFeature
+):
+    response = client.get(
+        f"/search/results/?query={archived_feature.ensembl_id}+{search_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
     assert len(json_content["features"]) == 1
 
 
-def test_archived_experiment_feature_ensembl_with_anonymous_client(client: Client, archived_feature: DNAFeature):
-    response = client.get(f"/search/results/?query={archived_feature.ensembl_id}&accept=application/json")
-    assert response.status_code == 200
-
-    json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
-
-
 def test_archived_experiment_feature_ensembl_with_authenticated_client(
-    client: Client, archived_feature: DNAFeature, django_user_model
+    client: Client, archived_feature: DNAFeature, search_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
     django_user_model.objects.create_user(username=username, password=password)
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={archived_feature.ensembl_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={archived_feature.ensembl_id}+{search_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_archived_experiment_feature_ensembl_with_authenticated_authorized_client(
-    client: Client, archived_feature: DNAFeature, django_user_model
+    client: Client, archived_feature: DNAFeature, search_feature: DNAFeature, django_user_model
 ):
     username = "user1"
     password = "bar"
@@ -484,15 +554,21 @@ def test_archived_experiment_feature_ensembl_with_authenticated_authorized_clien
     user.experiments = [archived_feature.experiment_accession_id]
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={archived_feature.ensembl_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={archived_feature.ensembl_id}+{search_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_archived_experiment_feature_ensembl_with_authenticated_authorized_group_client(
-    client: Client, archived_feature: DNAFeature, group_extension: GroupExtension, django_user_model
+    client: Client,
+    archived_feature: DNAFeature,
+    search_feature: DNAFeature,
+    group_extension: GroupExtension,
+    django_user_model,
 ):
     username = "user1"
     password = "bar"
@@ -505,11 +581,13 @@ def test_archived_experiment_feature_ensembl_with_authenticated_authorized_group
     user.groups.add(group_extension.group)
     user.save()
     client.login(username=username, password=password)
-    response = client.get(f"/search/results/?query={archived_feature.ensembl_id}&accept=application/json")
+    response = client.get(
+        f"/search/results/?query={archived_feature.ensembl_id}+{search_feature.ensembl_id}&accept=application/json"
+    )
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
-    assert len(json_content["features"]) == 0
+    assert len(json_content["features"]) == 1
 
 
 def test_experiment_html(client: Client):

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -5,7 +5,7 @@ import pytest
 from django.test import Client
 
 from cegs_portal.search.models import ChromosomeLocation, DNAFeature
-from cegs_portal.search.models.utils import QueryToken
+from cegs_portal.search.models.utils import IdType
 from cegs_portal.search.views.v1.search import ParseWarning, SearchType, parse_query
 from cegs_portal.users.models import GroupExtension
 
@@ -27,30 +27,30 @@ from cegs_portal.users.models import GroupExtension
         ),
         ("   hg38   ", (None, [], None, "GRCh38", set())),
         ("   hg19 hg38   ", (None, [], None, "GRCh38", set())),
-        ("DCPGENE00000000", (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, None, set())),
+        ("DCPGENE00000000", (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, None, set())),
         (
             "DCPGENE00000000 hg19",
-            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+            (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, "GRCh37", set()),
         ),
         (
             "hg19 DCPGENE00000000",
-            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+            (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, "GRCh37", set()),
         ),
         (
             "   hg19    DCPGENE00000000    ",
-            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+            (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, "GRCh37", set()),
         ),
         (
             "   hg19    DCPGENE00000000    ",
-            (SearchType.ID, [QueryToken.ACCESSION_ID.associate("DCPGENE00000000")], None, "GRCh37", set()),
+            (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, "GRCh37", set()),
         ),
         (
             "hg19 DCPGENE00000000 DCPGENE00000001",
             (
                 SearchType.ID,
                 [
-                    QueryToken.ACCESSION_ID.associate("DCPGENE00000000"),
-                    QueryToken.ACCESSION_ID.associate("DCPGENE00000001"),
+                    IdType.ACCESSION.associate("DCPGENE00000000"),
+                    IdType.ACCESSION.associate("DCPGENE00000001"),
                 ],
                 None,
                 "GRCh37",
@@ -61,7 +61,7 @@ from cegs_portal.users.models import GroupExtension
             "hg19, DCPGENE00000000, ENSG00000001",
             (
                 SearchType.ID,
-                [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
+                [IdType.ACCESSION.associate("DCPGENE00000000"), IdType.ENSEMBL.associate("ENSG00000001")],
                 None,
                 "GRCh37",
                 set(),
@@ -71,7 +71,7 @@ from cegs_portal.users.models import GroupExtension
             "DCPGENE00000000,hg19,ENSG00000001",
             (
                 SearchType.ID,
-                [QueryToken.ACCESSION_ID.associate("DCPGENE00000000"), QueryToken.ENSEMBL_ID.associate("ENSG00000001")],
+                [IdType.ACCESSION.associate("DCPGENE00000000"), IdType.ENSEMBL.associate("ENSG00000001")],
                 None,
                 "GRCh37",
                 set(),
@@ -91,7 +91,7 @@ from cegs_portal.users.models import GroupExtension
             " hg19 ENSG00000001   chr1:1-100 DCPGENE00000000 ",
             (
                 SearchType.ID,
-                [QueryToken.ENSEMBL_ID.associate("ENSG00000001"), QueryToken.ACCESSION_ID.associate("DCPGENE00000000")],
+                [IdType.ENSEMBL.associate("ENSG00000001"), IdType.ACCESSION.associate("DCPGENE00000000")],
                 None,
                 "GRCh37",
                 {ParseWarning.IGNORE_LOC},

--- a/cegs_portal/utils/http_exceptions.py
+++ b/cegs_portal/utils/http_exceptions.py
@@ -1,6 +1,12 @@
-class Http500(Exception):
-    """Internal Server Error"""
+class Http303(Exception):
+    def __init__(self, message: str, location) -> None:
+        super().__init__(message)
+        self.location = location
 
 
 class Http400(Exception):
     """Bad Request"""
+
+
+class Http500(Exception):
+    """Internal Server Error"""

--- a/cegs_portal/utils/http_responses.py
+++ b/cegs_portal/utils/http_responses.py
@@ -1,0 +1,5 @@
+from django.http.response import HttpResponseRedirectBase
+
+
+class HttpResponseSeeOtherRedirect(HttpResponseRedirectBase):
+    status_code = 303


### PR DESCRIPTION
If a user does a search on a single DNA Feature, it makes sense to jump straight to that feature, rather than show an intermediate search interface. 

This is done via a redirect (HTTP status 303).

Because users can add an assembly/ref genome to the search query I added the same ability to a dnafeature id search.

QueryToken and IdType were combined because they contain the same information and need to stay in sync, so they may as well be the same Enum.

Three new tests were added to check that redirects work. Updated the old tests to search for two features so that the redirects aren't triggered.