### PR TITLE
Adds task endpoint for viewing tasks

### DIFF
--- a/cegs_portal/tasks/conftest.py
+++ b/cegs_portal/tasks/conftest.py
@@ -1,8 +1,24 @@
 import pytest
 
+from cegs_portal.tasks.factories import ThreadTaskFactory
 from cegs_portal.tasks.models import ThreadTask
 
 
 @pytest.fixture(scope="function", autouse=True)
 def execute_before_any_test(db):
     ThreadTask.objects.all().delete()
+
+
+@pytest.fixture
+def unfinished_thread_task() -> ThreadTask:
+    return ThreadTaskFactory(ended_at=None, is_done=False)
+
+
+@pytest.fixture
+def finished_thread_task() -> ThreadTask:
+    return ThreadTaskFactory()
+
+
+@pytest.fixture
+def failed_thread_task() -> ThreadTask:
+    return ThreadTaskFactory(failed=True, failed_exception="task failed")

--- a/cegs_portal/tasks/factories.py
+++ b/cegs_portal/tasks/factories.py
@@ -1,0 +1,18 @@
+from datetime import datetime, timedelta, timezone
+
+from factory import Faker
+from factory.django import DjangoModelFactory
+
+from cegs_portal.tasks.models import ThreadTask
+
+
+class ThreadTaskFactory(DjangoModelFactory):
+    class Meta:
+        model = ThreadTask
+
+    description = Faker("text", max_nb_chars=140)
+    started_at = datetime.now(timezone.utc)
+    ended_at = datetime.now(timezone.utc) + timedelta(seconds=20)
+    is_done = True
+    failed = False
+    failed_exception = None

--- a/cegs_portal/tasks/json_templates/v1/__init__.py
+++ b/cegs_portal/tasks/json_templates/v1/__init__.py
@@ -1,0 +1,1 @@
+from .task import task

--- a/cegs_portal/tasks/json_templates/v1/task.py
+++ b/cegs_portal/tasks/json_templates/v1/task.py
@@ -1,0 +1,12 @@
+from cegs_portal.tasks.models import ThreadTask
+
+
+def task(task_obj: ThreadTask, options):
+    return {
+        "description": task_obj.description,
+        "started_at": task_obj.started_at,
+        "ended_at": task_obj.ended_at,
+        "is_done": task_obj.is_done,
+        "failed": task_obj.failed,
+        "failed_exception": task_obj.failed_exception,
+    }

--- a/cegs_portal/tasks/json_templates/v1/tests/test_task.py
+++ b/cegs_portal/tasks/json_templates/v1/tests/test_task.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cegs_portal.tasks.json_templates.v1.task import task
+from cegs_portal.tasks.models import ThreadTask
+
+pytestmark = pytest.mark.django_db
+
+
+def check_thread_task_object(task, task_dict):
+    assert task_dict["description"] == task.description
+    assert task_dict["started_at"] == task.started_at
+    assert task_dict["ended_at"] == task.ended_at
+    assert task_dict["is_done"] == task.is_done
+    assert task_dict["failed"] == task.failed
+    assert task_dict["failed_exception"] == task.failed_exception
+
+
+def test_unfinished_thread_task(unfinished_thread_task: ThreadTask):
+    check_thread_task_object(unfinished_thread_task, task(unfinished_thread_task, {}))
+
+
+def test_finished_thread_task(finished_thread_task: ThreadTask):
+    check_thread_task_object(finished_thread_task, task(finished_thread_task, {}))
+
+
+def test_failed_thread_task(failed_thread_task: ThreadTask):
+    check_thread_task_object(failed_thread_task, task(failed_thread_task, {}))

--- a/cegs_portal/tasks/templates/tasks/v1/task_status.html
+++ b/cegs_portal/tasks/templates/tasks/v1/task_status.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load static i18n %}
+
+{% block title %}Task {{ task.id }}{% endblock %}
+{% block content %}
+    <div class="text-2xl font-bold">Task {{ task.id }}</div>
+    <div>
+        <div><span class="font-bold">Description:</span> <span class="">{{ task.description }}</span></div>
+        <div><span class="font-bold">Started At:</span> <span class="">{{ task.started_at }}</span></div>
+        <div><span class="font-bold">Ended At:</span> <span class="">{{ task.ended_at }}</span></div>
+        <div><span class="font-bold">Completed:</span> <span class="">{{ task.is_done }}</span></div>
+        <div><span class="font-bold">Failed:</span> <span class="">{{ task.failed }}</span></div>
+        <div><span class="font-bold">Failure Reason:</span> <span class="">{{ task.failed_exception }}</span></div>
+    </div>
+{% endblock %}

--- a/cegs_portal/tasks/tests/test_tasks.py
+++ b/cegs_portal/tasks/tests/test_tasks.py
@@ -94,12 +94,27 @@ def check_thread_task_response(task, task_json):
     assert task_json["failed_exception"] == task.failed_exception
 
 
-def test_unfinished_thread_task_html(client: Client, unfinished_thread_task: ThreadTask):
+def test_non_logged_in_task_json(client: Client):
+    response = client.get("/tasks/task/1?accept=application/json")
+    assert response.status_code == 302
+
+
+def test_unfinished_thread_task_html(client: Client, unfinished_thread_task: ThreadTask, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get(f"/tasks/task/{unfinished_thread_task.id}")
     assert response.status_code == 200
 
 
-def test_unfinished_thread_task_json(client: Client, unfinished_thread_task: ThreadTask):
+def test_unfinished_thread_task_json(client: Client, unfinished_thread_task: ThreadTask, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get(f"/tasks/task/{unfinished_thread_task.id}?accept=application/json")
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -107,12 +122,22 @@ def test_unfinished_thread_task_json(client: Client, unfinished_thread_task: Thr
     check_thread_task_response(unfinished_thread_task, json_content)
 
 
-def test_finished_thread_task_html(client: Client, finished_thread_task: ThreadTask):
+def test_finished_thread_task_html(client: Client, finished_thread_task: ThreadTask, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get(f"/tasks/task/{finished_thread_task.id}")
     assert response.status_code == 200
 
 
-def test_finished_thread_task_json(client: Client, finished_thread_task: ThreadTask):
+def test_finished_thread_task_json(client: Client, finished_thread_task: ThreadTask, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get(f"/tasks/task/{finished_thread_task.id}?accept=application/json")
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -120,12 +145,22 @@ def test_finished_thread_task_json(client: Client, finished_thread_task: ThreadT
     check_thread_task_response(finished_thread_task, json_content)
 
 
-def test_failed_thread_task_html(client: Client, failed_thread_task: ThreadTask):
+def test_failed_thread_task_html(client: Client, failed_thread_task: ThreadTask, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get(f"/tasks/task/{failed_thread_task.id}")
     assert response.status_code == 200
 
 
-def test_failed_thread_task_json(client: Client, failed_thread_task: ThreadTask):
+def test_failed_thread_task_json(client: Client, failed_thread_task: ThreadTask, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get(f"/tasks/task/{failed_thread_task.id}?accept=application/json")
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -133,11 +168,21 @@ def test_failed_thread_task_json(client: Client, failed_thread_task: ThreadTask)
     check_thread_task_response(failed_thread_task, json_content)
 
 
-def test_non_existent_thread_task_html(client: Client):
+def test_non_existent_thread_task_html(client: Client, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get("/tasks/task/1")
     assert response.status_code == 404
 
 
-def test_non_existent_thread_task_json(client: Client):
+def test_non_existent_thread_task_json(client: Client, django_user_model):
+    username = "user1"
+    password = "bar"
+    user = django_user_model.objects.create_user(username=username, password=password)
+    user.save()
+    client.login(username=username, password=password)
     response = client.get("/tasks/task/1?accept=application/json")
     assert response.status_code == 404

--- a/cegs_portal/tasks/tests/test_tasks.py
+++ b/cegs_portal/tasks/tests/test_tasks.py
@@ -1,8 +1,12 @@
+import json
 from time import sleep
 
 import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+from django.test import Client
 
 from cegs_portal.tasks.decorators import as_task
+from cegs_portal.tasks.models import ThreadTask
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -78,3 +82,62 @@ def test_task_exception():
     assert task is not None
     assert task.failed
     assert task.failed_exception == "test exception"
+
+
+def check_thread_task_response(task, task_json):
+    encoder = DjangoJSONEncoder()
+    assert task_json["description"] == task.description
+    assert task_json["started_at"] == encoder.default(task.started_at)
+    assert task_json["ended_at"] == (None if task.ended_at is None else encoder.default(task.ended_at))
+    assert task_json["is_done"] == task.is_done
+    assert task_json["failed"] == task.failed
+    assert task_json["failed_exception"] == task.failed_exception
+
+
+def test_unfinished_thread_task_html(client: Client, unfinished_thread_task: ThreadTask):
+    response = client.get(f"/tasks/task/{unfinished_thread_task.id}")
+    assert response.status_code == 200
+
+
+def test_unfinished_thread_task_json(client: Client, unfinished_thread_task: ThreadTask):
+    response = client.get(f"/tasks/task/{unfinished_thread_task.id}?accept=application/json")
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    check_thread_task_response(unfinished_thread_task, json_content)
+
+
+def test_finished_thread_task_html(client: Client, finished_thread_task: ThreadTask):
+    response = client.get(f"/tasks/task/{finished_thread_task.id}")
+    assert response.status_code == 200
+
+
+def test_finished_thread_task_json(client: Client, finished_thread_task: ThreadTask):
+    response = client.get(f"/tasks/task/{finished_thread_task.id}?accept=application/json")
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    check_thread_task_response(finished_thread_task, json_content)
+
+
+def test_failed_thread_task_html(client: Client, failed_thread_task: ThreadTask):
+    response = client.get(f"/tasks/task/{failed_thread_task.id}")
+    assert response.status_code == 200
+
+
+def test_failed_thread_task_json(client: Client, failed_thread_task: ThreadTask):
+    response = client.get(f"/tasks/task/{failed_thread_task.id}?accept=application/json")
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    check_thread_task_response(failed_thread_task, json_content)
+
+
+def test_non_existent_thread_task_html(client: Client):
+    response = client.get("/tasks/task/1")
+    assert response.status_code == 404
+
+
+def test_non_existent_thread_task_json(client: Client):
+    response = client.get("/tasks/task/1?accept=application/json")
+    assert response.status_code == 404

--- a/cegs_portal/tasks/urls.py
+++ b/cegs_portal/tasks/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from cegs_portal.tasks.views import TaskStatusView
+
+app_name = "tasks"
+urlpatterns = [
+    path("task/<int:task_id>", view=TaskStatusView.as_view(), name="status"),
+]

--- a/cegs_portal/tasks/view_models.py
+++ b/cegs_portal/tasks/view_models.py
@@ -1,0 +1,7 @@
+from cegs_portal.tasks.models import ThreadTask
+
+
+class ThreadTaskSearch:
+    @classmethod
+    def id_search(cls, task_id):
+        return ThreadTask.objects.get(id=task_id)

--- a/cegs_portal/tasks/views.py
+++ b/cegs_portal/tasks/views.py
@@ -1,1 +1,23 @@
-# Create your views here.
+import logging
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
+
+from cegs_portal.search.views.custom_views import TemplateJsonView
+from cegs_portal.tasks.json_templates.v1 import task
+from cegs_portal.tasks.view_models import ThreadTaskSearch
+
+logger = logging.getLogger("django.request")
+
+
+class TaskStatusView(LoginRequiredMixin, TemplateJsonView):
+    json_renderer = task
+    template = "tasks/v1/task_status.html"
+    template_data_name = "task"
+
+    def get_data(self, _options, task_id):
+        try:
+            return ThreadTaskSearch.id_search(task_id)
+        except ObjectDoesNotExist as e:
+            raise Http404(str(e))

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,6 +22,7 @@ urlpatterns: list[Union[URLPattern, URLResolver]] = (
             path("users/", include("cegs_portal.users.urls", namespace="users")),
             path("accounts/", include("allauth.urls")),
             path("search/", include("cegs_portal.search.urls")),
+            path("tasks/", include("cegs_portal.tasks.urls")),
             path("upload/", include("cegs_portal.uploads.urls")),
             path("", include("django_prometheus.urls")),
         ],


### PR DESCRIPTION
This endpoint will be part of the response of other endpoints that create long-running/asynchronous tasks, like the upcoming experiment data request endpoint.

I don't think that tasks being available to any logged in user is a security issue, so that's the level of security were offering around this endpoint.