### PR TITLE
Feature effect auth

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -229,6 +229,27 @@ def source_reg_effects():
 
 
 @pytest.fixture
+def hidden_source_reg_effects():
+    source = DNAFeatureFactory(parent=None)
+
+    reo1 = RegEffectFactory(
+        sources=(source,),
+        public=False,
+    )
+    reo2 = RegEffectFactory(
+        sources=(source,),
+        archived=True,
+    )
+    reo3 = RegEffectFactory(
+        sources=(source,),
+    )
+    return {
+        "source": source,
+        "effects": [reo1, reo2, reo3],
+    }
+
+
+@pytest.fixture
 def target_reg_effects():
     target = DNAFeatureFactory(parent=None)
 
@@ -237,6 +258,27 @@ def target_reg_effects():
     )
     reo2 = RegEffectFactory(
         targets=(target,),
+    )
+    reo3 = RegEffectFactory(
+        targets=(target,),
+    )
+    return {
+        "target": target,
+        "effects": [reo1, reo2, reo3],
+    }
+
+
+@pytest.fixture
+def hidden_target_reg_effects():
+    target = DNAFeatureFactory(parent=None)
+
+    reo1 = RegEffectFactory(
+        targets=(target,),
+        public=False,
+    )
+    reo2 = RegEffectFactory(
+        targets=(target,),
+        archived=True,
     )
     reo3 = RegEffectFactory(
         targets=(target,),

--- a/cegs_portal/search/view_models/v1/reg_effects.py
+++ b/cegs_portal/search/view_models/v1/reg_effects.py
@@ -74,6 +74,16 @@ class RegEffectSearch:
         return reg_effects
 
     @classmethod
+    def source_search_public(cls, *args, **kwargs):
+        return cls.source_search(*args, *kwargs).filter(public=True, archived=False)
+
+    @classmethod
+    def source_search_with_private(cls, *args, **kwargs):
+        return cls.source_search(*args[:-1], *kwargs).filter(
+            Q(archived=False) & (Q(public=True) | Q(experiment_accession_id__in=args[-1]))
+        )
+
+    @classmethod
     def target_search(cls, source_id: str):
         reg_effects = (
             cast(RegulatoryEffectObservationSet, RegulatoryEffectObservation.objects)
@@ -88,6 +98,16 @@ class RegEffectSearch:
         )
 
         return reg_effects
+
+    @classmethod
+    def target_search_public(cls, *args, **kwargs):
+        return cls.target_search(*args, *kwargs).filter(public=True, archived=False)
+
+    @classmethod
+    def target_search_with_private(cls, *args, **kwargs):
+        return cls.target_search(*args[:-1], *kwargs).filter(
+            Q(archived=False) & (Q(public=True) | Q(experiment_accession_id__in=args[-1]))
+        )
 
     @classmethod
     def feature_search(cls, features: list[DNAFeature]):

--- a/cegs_portal/search/views/v1/reg_effects.py
+++ b/cegs_portal/search/views/v1/reg_effects.py
@@ -106,7 +106,12 @@ class SourceEffectsView(FeatureEffectsView):
     template = "search/v1/source_reg_effects.html"
 
     def get_data(self, options, feature_id) -> Pageable[RegulatoryEffectObservation]:
-        reg_effects = RegEffectSearch.source_search(feature_id)
+        if self.request.user.is_anonymous:
+            reg_effects = RegEffectSearch.source_search_public(feature_id)
+        elif self.request.user.is_superuser or self.request.user.is_portal_admin:
+            reg_effects = RegEffectSearch.source_search(feature_id)
+        else:
+            reg_effects = RegEffectSearch.source_search_with_private(feature_id, self.request.user.all_experiments())
         reg_effect_paginator = Paginator(reg_effects, options["per_page"])
         reg_effect_page = reg_effect_paginator.get_page(options["page"])
         return reg_effect_page
@@ -116,7 +121,12 @@ class TargetEffectsView(FeatureEffectsView):
     template = "search/v1/target_reg_effects.html"
 
     def get_data(self, options, feature_id) -> Pageable[RegulatoryEffectObservation]:
-        reg_effects = RegEffectSearch.target_search(feature_id)
+        if self.request.user.is_anonymous:
+            reg_effects = RegEffectSearch.target_search_public(feature_id)
+        elif self.request.user.is_superuser or self.request.user.is_portal_admin:
+            reg_effects = RegEffectSearch.target_search(feature_id)
+        else:
+            reg_effects = RegEffectSearch.target_search_with_private(feature_id, self.request.user.all_experiments())
         reg_effect_paginator = Paginator(reg_effects, options["per_page"])
         reg_effect_page = reg_effect_paginator.get_page(options["page"])
         return reg_effect_page

--- a/cegs_portal/search/views/v1/tests/test_source_reg_effects.py
+++ b/cegs_portal/search/views/v1/tests/test_source_reg_effects.py
@@ -27,6 +27,16 @@ def test_source_reg_effects_list_json(client: Client, source_reg_effects):
         assert json_reo["significance"] == reo.significance
 
 
+def test_hidden_source_reg_effects_list_json(client: Client, hidden_source_reg_effects):
+    source = hidden_source_reg_effects["source"]
+    response = client.get(f"/search/regeffect/source/{source.accession_id}?accept=application/json")
+
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    assert len(json_content["object_list"]) == 1
+
+
 def test_get_source_reg_effects_with_anonymous_client(client: Client, private_feature: DNAFeature):
     response = client.get(f"/search/regeffect/source/{private_feature.accession_id}?accept=application/json")
     assert response.status_code == 302

--- a/cegs_portal/search/views/v1/tests/test_target_reg_effects.py
+++ b/cegs_portal/search/views/v1/tests/test_target_reg_effects.py
@@ -27,6 +27,16 @@ def test_target_reg_effects_list_json(client: Client, target_reg_effects):
         assert json_reo["significance"] == reo.significance
 
 
+def test_hidden_target_reg_effects_list_json(client: Client, hidden_target_reg_effects):
+    target = hidden_target_reg_effects["target"]
+    response = client.get(f"/search/regeffect/target/{target.accession_id}?accept=application/json")
+
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    assert len(json_content["object_list"]) == 1
+
+
 def test_get_target_reg_effects_with_anonymous_client(client: Client, private_feature: DNAFeature):
     response = client.get(f"/search/regeffect/target/{private_feature.accession_id}?accept=application/json")
     assert response.status_code == 302


### PR DESCRIPTION
We do not want users who are not authorized to see data to be able
to use these enpoints to see it. This includes both DNA Features (like ccres
and genes) and REOs. 

anonymous users can see public features/REOs
admins can see all features/REOs
logged-in users can see public features/REOs and features/REOs associated with their own experiments.