### PR TITLE
Add signal for analysis access controls

### DIFF
--- a/cegs_portal/search/models/signals.py
+++ b/cegs_portal/search/models/signals.py
@@ -4,7 +4,7 @@ from django.db import connection
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from cegs_portal.search.models.experiment import Experiment
+from cegs_portal.search.models.experiment import Analysis, Experiment
 from cegs_portal.tasks.decorators import as_task
 from cegs_portal.tasks.models import ThreadTask
 from cegs_portal.utils.decorators import skip_receiver_in_testing
@@ -15,7 +15,7 @@ logger = logging.getLogger("django.task")
 @receiver(post_save, sender=Experiment)
 @skip_receiver_in_testing
 @as_task(pass_task_id=True)
-def set_access_controls(task_id, sender, instance, created, raw, using, update_fields, **kwargs):
+def update_experiment_access(task_id, sender, instance, created, raw, using, update_fields, **kwargs):
     """This reciever is run when access permissions are changed on an experiment. It updates
     the access permissions on the dna features and REOs associated with the experiment.
 
@@ -32,6 +32,12 @@ def set_access_controls(task_id, sender, instance, created, raw, using, update_f
 
     with connection.cursor() as cursor:
         cursor.execute(
+            """UPDATE search_analysis
+               SET public = %s, archived = %s
+               WHERE experiment_accession_id = %s""",
+            [instance.public, instance.archived, instance.accession_id],
+        )
+        cursor.execute(
             """UPDATE search_dnafeature
                SET public = %s, archived = %s
                WHERE experiment_accession_id = %s""",
@@ -41,5 +47,32 @@ def set_access_controls(task_id, sender, instance, created, raw, using, update_f
             """UPDATE search_regulatoryeffectobservation
                SET public = %s, archived = %s
                WHERE experiment_accession_id = %s""",
+            [instance.public, instance.archived, instance.accession_id],
+        )
+
+
+@receiver(post_save, sender=Analysis)
+@skip_receiver_in_testing
+@as_task(pass_task_id=True)
+def update_analysis_access(task_id, sender, instance, created, raw, using, update_fields, **kwargs):
+    """This reciever is run when access permissions are changed on an analysis. It updates
+    the access permissions on the dna features and REOs associated with the experiment.
+
+    :param task_id: The id of the ThreadTask associated with this thread.
+    :type task_id: int
+
+    The other paramaters all have to do with django signal recievers.
+    """
+    if created:
+        ThreadTask.set_description(task_id, "Analysis created")
+        return
+
+    ThreadTask.set_description(task_id, f"Modify access controls of {instance.accession_id}")
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """UPDATE search_regulatoryeffectobservation
+               SET public = %s, archived = %s
+               WHERE analysis_accession_id = %s""",
             [instance.public, instance.archived, instance.accession_id],
         )


### PR DESCRIPTION
When an analysis is marked private or archived, all associated REOs should also be marked as such.

Also, if an experiment is marked private/archived, all analyses for that experiment should be marked as such.