### PR TITLE
Improve test for who can view tasks

### DIFF
--- a/cegs_portal/tasks/views.py
+++ b/cegs_portal/tasks/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
 
@@ -11,10 +11,17 @@ from cegs_portal.tasks.view_models import ThreadTaskSearch
 logger = logging.getLogger("django.request")
 
 
-class TaskStatusView(LoginRequiredMixin, TemplateJsonView):
+class TaskStatusView(UserPassesTestMixin, TemplateJsonView):
     json_renderer = task
     template = "tasks/v1/task_status.html"
     template_data_name = "task"
+
+    def test_func(self):
+        # Only portal admins should have access to tasks
+        user = self.request.user
+        # An anonymous user won't have the is_portal_admin property, but also definitely isn't
+        # a portal admin.
+        return not user.is_anonymous and user.is_portal_admin
 
     def get_data(self, _options, task_id):
         try:


### PR DESCRIPTION
Previously anyone who was logged in could see all the tasks. This modifies the permission check to only allow portal admins to see the tasks.

We'll add back some permissions as needed -- there are cases where we want non-admins to see tasks. But there's no need to let users see tasks they didn't start.