### PR TITLE
Add UI to experiment page for downloading data

### DIFF
--- a/cegs_portal/search/static/search/js/downloadStatusWorker.js
+++ b/cegs_portal/search/static/search/js/downloadStatusWorker.js
@@ -6,7 +6,7 @@ onmessage = function (statusURLData) {
             let progress = json["file progress"];
             postMessage(progress);
             if (progress == "in_preparation") {
-                setTimeout(getStatus(url, tries - 1), 500);
+                setTimeout(() => getStatus(url, tries - 1), 500);
             }
         } catch (err) {
             console.log(err);

--- a/cegs_portal/search/static/search/js/downloadStatusWorker.js
+++ b/cegs_portal/search/static/search/js/downloadStatusWorker.js
@@ -1,18 +1,18 @@
 onmessage = function (statusURLData) {
-    let statusURL = statusURLData.data;
-    let getStatus = (url, tries) => {
-        return fetch(url)
-            .then((response) => response.json())
-            .then((json) => {
-                let progress = json["file progress"];
-                postMessage(progress);
-                if (progress == "in_preparation") {
-                    setTimeout(getStatus(url, tries - 1), 500);
-                }
-            })
-            .catch((err) => {
-                console.log(err);
-            });
+    let getStatus = async (url, tries) => {
+        try {
+            const response = await fetch(url);
+            const json = await response.json();
+            let progress = json["file progress"];
+            postMessage(progress);
+            if (progress == "in_preparation") {
+                setTimeout(getStatus(url, tries - 1), 500);
+            }
+        } catch (err) {
+            console.log(err);
+        }
     };
-    Promise.all([getStatus(statusURL, 5)]);
+
+    let statusURL = statusURLData.data;
+    getStatus(statusURL, 5);
 };

--- a/cegs_portal/search/static/search/js/downloadStatusWorker.js
+++ b/cegs_portal/search/static/search/js/downloadStatusWorker.js
@@ -1,0 +1,18 @@
+onmessage = function (statusURLData) {
+    let statusURL = statusURLData.data;
+    let getStatus = (url, tries) => {
+        return fetch(url)
+            .then((response) => response.json())
+            .then((json) => {
+                let progress = json["file progress"];
+                postMessage(progress);
+                if (progress == "in_preparation") {
+                    setTimeout(getStatus(url, tries - 1), 500);
+                }
+            })
+            .catch((err) => {
+                console.log(err);
+            });
+    };
+    Promise.all([getStatus(statusURL, 5)]);
+};

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -200,6 +200,16 @@
                         </div>
                     </form>
                 </div>
+
+                <div class="facet-content-section content-container">
+                    <form name="dataDownloadForm">
+                        <div>
+                            <label class="font-bold" for="dataDlFile">Download Data</label>
+                            <input id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
+                        </div>
+                    </form>
+                    <div id="dataDownloadLink"></div>
+                </div>
             </div>
 
             <div class="basis-3/4 content-container">
@@ -674,6 +684,56 @@
         });
     });
 </script>
+
+<script type="module">
+    import {a, cc, e, g, rc, t} from "{% static 'search/js/dom.js' %}";
+    function getDownloadRegions() {
+        if (this.files.length != 1) {
+            return;
+        }
+        rc(g("dataDownloadLink"), t("Getting your data..."));
+
+        let url = "{% url 'get_expr_data:requestdata' %}?expr={{ experiment.accession_id }}&datasource=both";
+        let requestBody = new FormData();
+        requestBody.set("regions", this.files[0]);
+        requestBody.set("csrfmiddlewaretoken", "{{ csrf_token }}");
+
+        let request = {
+            method: "POST",
+            credentials: "include",
+            mode: "same-origin",
+            body: requestBody
+        }
+
+        let dlDataWorker;
+        fetch(url, request)
+            .then((response) => response.json())
+            .then((json) => {
+                dlDataWorker = new Worker("{% static 'search/js/downloadStatusWorker.js' %}");
+                dlDataWorker.onmessage = (statusData) => {
+                    let status = statusData.data;
+                    if(status == "ready") {
+                        let filePath = json["file location"].split("/");
+                        rc(g("dataDownloadLink"),
+                            e("a",
+                                {href: json["file location"]},
+                                t(filePath[filePath.length - 1])
+                            )
+                        );
+                    } else if(status == "in_preparation") {
+                        // keep spinning
+                    } else {
+                        rc(g("dataDownloadLink"), t("Sorry, something went wrong"));
+                    }
+                }
+                dlDataWorker.postMessage(json["file progress"]);
+            })
+            .catch((err) => console.log(err))
+    }
+
+    g("dataDownloadInput").addEventListener("change", getDownloadRegions, false);
+</script>
+
 <script type="module">
     import {a, cc, e, g, rc, t} from "{% static 'search/js/dom.js' %}";
     import {State} from "{% static 'search/js/state.js' %}";

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -201,6 +201,7 @@
                     </form>
                 </div>
 
+                {% if logged_in %}
                 <div class="facet-content-section content-container">
                     <form name="dataDownloadForm">
                         <div>
@@ -210,6 +211,7 @@
                     </form>
                     <div id="dataDownloadLink"></div>
                 </div>
+                {% endif %}
             </div>
 
             <div class="basis-3/4 content-container">
@@ -685,6 +687,7 @@
     });
 </script>
 
+{% if logged_in %}
 <script type="module">
     import {a, cc, e, g, rc, t} from "{% static 'search/js/dom.js' %}";
     function getDownloadRegions() {
@@ -733,6 +736,7 @@
 
     g("dataDownloadInput").addEventListener("change", getDownloadRegions, false);
 </script>
+{% endif %}
 
 <script type="module">
     import {a, cc, e, g, rc, t} from "{% static 'search/js/dom.js' %}";

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -36,6 +36,7 @@ class ExperimentView(ExperimentAccessMixin, TemplateJsonView):
             request,
             options,
             {
+                "logged_in": not request.user.is_anonymous,
                 "experiment": data[0],
                 "other_experiments": {
                     "id": "other_experiments",


### PR DESCRIPTION
A new widget has been added to the experiment page. This allows users to upload a .bed file and get back data from the experiment associated with the regions defined in the .bed file.