### PR TITLE
Show reo,target,source counts in experiment coverage

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -223,7 +223,11 @@
 
             <div class="basis-3/4 content-container">
                 <!-- content section container for ChromCov -->
-                <div id="chrom-data-legend"></div>
+                <div class="flex flex-row gap-x-4 items-center">
+                    <div id="chrom-data-legend"></div>
+                    <div class="flex flex-col">
+                        <div id="reo-count"></div> <div id="source-count"></div> <div id="target-count"></div></div>
+                    </div>
                 <div id="chrom-data"></div>
             </div>
         </div>

--- a/cegs_portal/search/views/v1/experiment_coverage.py
+++ b/cegs_portal/search/views/v1/experiment_coverage.py
@@ -83,17 +83,17 @@ class ExperimentCoverageView(TemplateJsonView):
         try:
             body = json.loads(request.body)
         except Exception as e:
-            raise Http400(f"Invalid request body:\n{request.body}\n\nError:\n{e}")
+            raise Http400(f"Invalid request body:\n{request.body}") from e
 
         try:
             options["filters"] = body["filters"]
         except Exception as e:
-            raise Http400(f'Invalid request body, no "filters" object:\n{request.body}\n\nError:\n{e}')
+            raise Http400(f'Invalid request body, no "filters" object:\n{request.body}') from e
 
         try:
             options["chromosomes"] = body["chromosomes"]
         except Exception as e:
-            raise Http400(f'Invalid request body, no "chromosomes" object:\n{request.body}\n\nError:\n{e}')
+            raise Http400(f'Invalid request body, no "chromosomes" object:\n{request.body}') from e
 
         if (zoom_chr := body.get("zoom", None)) is not None and zoom_chr not in CHROM_NAMES:
             raise Http400(f"Invalid chromosome in zoom: {zoom_chr}")

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1021,6 +1021,12 @@ input[type="submit"], input[type="button"], button {
           column-gap: 2.5rem;
 }
 
+.gap-x-4 {
+  -webkit-column-gap: 1rem;
+     -moz-column-gap: 1rem;
+          column-gap: 1rem;
+}
+
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--tw-space-y-reverse)));

--- a/extensions/exp_viz/Cargo.lock
+++ b/extensions/exp_viz/Cargo.lock
@@ -31,8 +31,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cov_viz_ds"
-version = "0.1.1"
-source = "git+https://github.com/ReddyLab/cov_viz_ds?rev=e3a4b84903d23bdbc7e4f88fd24c6e5f6a91aa11#e3a4b84903d23bdbc7e4f88fd24c6e5f6a91aa11"
+version = "0.2.0"
+source = "git+https://github.com/ReddyLab/cov_viz_ds?rev=6a93d8fae232fd16a6de025841d30aae6f3493e3#6a93d8fae232fd16a6de025841d30aae6f3493e3"
 dependencies = [
  "bincode",
  "rustc-hash",

--- a/extensions/exp_viz/Cargo.toml
+++ b/extensions/exp_viz/Cargo.toml
@@ -10,7 +10,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.3"
-cov_viz_ds = { git = "https://github.com/ReddyLab/cov_viz_ds", rev = "e3a4b84903d23bdbc7e4f88fd24c6e5f6a91aa11" }
+cov_viz_ds = { git = "https://github.com/ReddyLab/cov_viz_ds", rev = "6a93d8fae232fd16a6de025841d30aae6f3493e3" }
+# cov_viz_ds = { path = "../cov_viz_ds" }  # For working with a local copy during development
 pyo3 = { version = "0.17.1", features = ["extension-module"] }
 rustc-hash = "1.1.0"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/extensions/exp_viz/src/filter.rs
+++ b/extensions/exp_viz/src/filter.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 use rustc_hash::FxHashSet;
 
 use crate::filter_data_structures::*;
-use cov_viz_ds::{ChromosomeData, DbID, FacetCoverage, FacetRange};
+use cov_viz_ds::{BucketLoc, ChromosomeData, DbID, FacetCoverage, FacetRange};
 
 fn is_disjoint(a: &Vec<DbID>, b: &Vec<DbID>) -> bool {
     for val_a in a {
@@ -107,174 +107,202 @@ pub fn filter_coverage_data(filters: &Filter, data: &PyCoverageData) -> PyResult
         .map(|f| (*f & &coverage_data_disc_facets).into_iter().collect())
         .collect();
 
-    let filtered_data: Vec<(FilteredChromosome, f32, f32, f32, f32)> = data
+    let filtered_data: Vec<(
+        FilteredChromosome,
+        f32,
+        f32,
+        f32,
+        f32,
+        FxHashSet<DbID>,
+        FxHashSet<DbID>,
+        FxHashSet<DbID>,
+    )> = data
         .chromosomes
         .iter()
-        .map(|chromosome| -> (FilteredChromosome, f32, f32, f32, f32) {
-            let mut min_effect = f32::INFINITY;
-            let mut max_effect = f32::NEG_INFINITY;
+        .map(
+            |chromosome| -> (
+                FilteredChromosome,
+                f32,
+                f32,
+                f32,
+                f32,
+                FxHashSet<DbID>,
+                FxHashSet<DbID>,
+                FxHashSet<DbID>,
+            ) {
+                let mut reo_ids = FxHashSet::<DbID>::default();
+                let mut source_ids = FxHashSet::<DbID>::default();
+                let mut target_ids = FxHashSet::<DbID>::default();
+                let mut min_effect = f32::INFINITY;
+                let mut max_effect = f32::NEG_INFINITY;
 
-            let mut min_sig = f32::INFINITY;
-            let mut max_sig = f32::NEG_INFINITY;
+                let mut min_sig = f32::INFINITY;
+                let mut max_sig = f32::NEG_INFINITY;
 
-            let mut chrom_data = FilteredChromosome {
-                chrom: chromosome.chrom.clone(),
-                index: chromosome.index,
-                bucket_size: chromosome.bucket_size,
-                target_intervals: Vec::new(),
-                source_intervals: Vec::new(),
-            };
-            let chrom_info: Vec<(&ChromosomeData, &usize)> =
-                zip(&data.chromosomes, &data.chrom_lengths).collect();
-            let bucket_list = BucketList::new(&chrom_info, chromosome.bucket_size as usize);
-            if skip_cont_facet_check && sf_with_selections.is_empty() {
-                // do no filtering
-                chrom_data.source_intervals = chromosome
-                    .source_intervals
-                    .iter()
-                    .map(|i| {
-                        let interval = &i.values;
-                        FilteredBucket {
-                            start: i.start,
-                            count: interval.len(),
-                            associated_buckets: interval
-                                .iter()
-                                .fold(FxHashSet::default(), |mut acc, f| {
-                                    for bucket in &f.associated_buckets {
-                                        acc.insert(*bucket);
-                                    }
-
-                                    acc
-                                })
-                                .iter()
-                                .fold(Vec::new(), |mut acc, b| {
-                                    acc.push(b.0 as u32);
-                                    acc.push(b.1);
-
-                                    acc
-                                }),
-                        }
-                    })
-                    .collect();
-            } else {
-                for interval in &chromosome.source_intervals {
-                    let sources = &interval.values;
-                    let mut new_source_count: usize = 0;
-                    let mut new_target_buckets = bucket_list.clone();
-
-                    for source in sources {
-                        let mut new_regeffects = false;
-                        for facet in &source.facets {
-                            if skip_disc_facet_check
-                                || selected_sf.iter().all(|sf| !is_disjoint(&facet.0, sf))
-                            {
-                                min_effect = facet.1.min(min_effect);
-                                max_effect = facet.1.max(max_effect);
-                                min_sig = facet.2.min(min_sig);
-                                max_sig = facet.2.max(max_sig);
-
-                                if !new_regeffects
-                                    && (skip_cont_facet_check
-                                        || (facet.1 >= effect_size_interval.0
-                                            && facet.1 <= effect_size_interval.1
-                                            && facet.2 >= sig_interval.0
-                                            && facet.2 <= sig_interval.1))
-                                {
-                                    new_regeffects = true;
-                                }
+                let mut chrom_data = FilteredChromosome {
+                    chrom: chromosome.chrom.clone(),
+                    index: chromosome.index,
+                    bucket_size: chromosome.bucket_size,
+                    target_intervals: Vec::new(),
+                    source_intervals: Vec::new(),
+                };
+                let chrom_info: Vec<(&ChromosomeData, &usize)> =
+                    zip(&data.chromosomes, &data.chrom_lengths).collect();
+                let bucket_list = BucketList::new(&chrom_info, chromosome.bucket_size as usize);
+                if skip_cont_facet_check && sf_with_selections.is_empty() {
+                    // do no filtering
+                    for interval in &chromosome.source_intervals {
+                        let mut associated_bucket = FxHashSet::<BucketLoc>::default();
+                        for feature in &interval.values {
+                            source_ids.insert(feature.id);
+                            associated_bucket.extend(feature.associated_buckets.clone());
+                            for observation in &feature.facets {
+                                reo_ids.insert(observation.reo_id);
                             }
                         }
-                        if new_regeffects {
-                            new_target_buckets.insert_from(&source.associated_buckets);
-                            new_source_count += 1;
-                        }
-                    }
-
-                    if new_source_count > 0 {
                         chrom_data.source_intervals.push(FilteredBucket {
                             start: interval.start,
-                            count: new_source_count,
-                            associated_buckets: new_target_buckets.flat_list(),
-                        })
+                            count: interval.values.len(),
+                            associated_buckets: associated_bucket.iter().fold(
+                                Vec::new(),
+                                |mut acc, b| {
+                                    acc.push(b.chrom as u32);
+                                    acc.push(b.idx);
+
+                                    acc
+                                },
+                            ),
+                        });
                     }
-                }
-            }
+                } else {
+                    for interval in &chromosome.source_intervals {
+                        let sources = &interval.values;
+                        let mut new_source_count: usize = 0;
+                        let mut new_target_buckets = bucket_list.clone();
 
-            if skip_cont_facet_check && tf_with_selections.is_empty() {
-                // do no filtering
-                chrom_data.target_intervals = chromosome
-                    .target_intervals
-                    .iter()
-                    .map(|i| {
-                        let interval = &i.values;
-                        FilteredBucket {
-                            start: i.start,
-                            count: interval.len(),
-                            associated_buckets: interval
-                                .iter()
-                                .fold(FxHashSet::default(), |mut acc, f| {
-                                    for bucket in &f.associated_buckets {
-                                        acc.insert(*bucket);
-                                    }
-
-                                    acc
-                                })
-                                .iter()
-                                .fold(Vec::new(), |mut acc, b| {
-                                    acc.push(b.0 as u32);
-                                    acc.push(b.1);
-
-                                    acc
-                                }),
-                        }
-                    })
-                    .collect();
-            } else {
-                for interval in &chromosome.target_intervals {
-                    let targets = &interval.values;
-                    let mut new_target_count: usize = 0;
-                    let mut new_source_buckets = bucket_list.clone();
-
-                    for target in targets {
-                        let mut new_regeffects = false;
-                        for facet in &target.facets {
-                            if skip_disc_facet_check
-                                || selected_tf.iter().all(|tf| !is_disjoint(&facet.0, tf))
-                            {
-                                min_effect = facet.1.min(min_effect);
-                                max_effect = facet.1.max(max_effect);
-                                min_sig = facet.2.min(min_sig);
-                                max_sig = facet.2.max(max_sig);
-
-                                if !new_regeffects
-                                    && (skip_cont_facet_check
-                                        || (facet.1 >= effect_size_interval.0
-                                            && facet.1 <= effect_size_interval.1
-                                            && facet.2 >= sig_interval.0
-                                            && facet.2 <= sig_interval.1))
+                        for source in sources {
+                            let mut new_regeffects = false;
+                            for facet in &source.facets {
+                                if skip_disc_facet_check
+                                    || selected_sf
+                                        .iter()
+                                        .all(|sf| !is_disjoint(&facet.facet_ids, sf))
                                 {
-                                    new_regeffects = true;
+                                    min_effect = facet.effect_size.min(min_effect);
+                                    max_effect = facet.effect_size.max(max_effect);
+                                    min_sig = facet.significance.min(min_sig);
+                                    max_sig = facet.significance.max(max_sig);
+
+                                    if skip_cont_facet_check
+                                        || (facet.effect_size >= effect_size_interval.0
+                                            && facet.effect_size <= effect_size_interval.1
+                                            && facet.significance >= sig_interval.0
+                                            && facet.significance <= sig_interval.1)
+                                    {
+                                        if !new_regeffects {
+                                            new_regeffects = true;
+                                            source_ids.insert(source.id);
+                                        }
+                                        reo_ids.insert(facet.reo_id);
+                                    }
                                 }
                             }
+                            if new_regeffects {
+                                new_target_buckets.insert_from(&source.associated_buckets);
+                                new_source_count += 1;
+                            }
                         }
-                        if new_regeffects {
-                            new_source_buckets.insert_from(&target.associated_buckets);
-                            new_target_count += 1;
-                        }
-                    }
 
-                    if new_target_count > 0 {
-                        chrom_data.target_intervals.push(FilteredBucket {
-                            start: interval.start,
-                            count: new_target_count,
-                            associated_buckets: new_source_buckets.flat_list(),
-                        })
+                        if new_source_count > 0 {
+                            chrom_data.source_intervals.push(FilteredBucket {
+                                start: interval.start,
+                                count: new_source_count,
+                                associated_buckets: new_target_buckets.flat_list(),
+                            })
+                        }
                     }
                 }
-            }
 
-            return (chrom_data, min_effect, max_effect, min_sig, max_sig);
-        })
+                if skip_cont_facet_check && tf_with_selections.is_empty() {
+                    // do no filtering
+                    for interval in &chromosome.target_intervals {
+                        let mut associated_bucket = FxHashSet::<BucketLoc>::default();
+                        for feature in &interval.values {
+                            target_ids.insert(feature.id);
+                            associated_bucket.extend(feature.associated_buckets.clone());
+                            for observation in &feature.facets {
+                                reo_ids.insert(observation.reo_id);
+                            }
+                        }
+                        chrom_data.target_intervals.push(FilteredBucket {
+                            start: interval.start,
+                            count: interval.values.len(),
+                            associated_buckets: associated_bucket.iter().fold(
+                                Vec::new(),
+                                |mut acc, b| {
+                                    acc.push(b.chrom as u32);
+                                    acc.push(b.idx);
+
+                                    acc
+                                },
+                            ),
+                        });
+                    }
+                } else {
+                    for interval in &chromosome.target_intervals {
+                        let targets = &interval.values;
+                        let mut new_target_count: usize = 0;
+                        let mut new_source_buckets = bucket_list.clone();
+
+                        for target in targets {
+                            let mut new_regeffects = false;
+                            for facet in &target.facets {
+                                if skip_disc_facet_check
+                                    || selected_tf
+                                        .iter()
+                                        .all(|tf| !is_disjoint(&facet.facet_ids, tf))
+                                {
+                                    min_effect = facet.effect_size.min(min_effect);
+                                    max_effect = facet.effect_size.max(max_effect);
+                                    min_sig = facet.significance.min(min_sig);
+                                    max_sig = facet.significance.max(max_sig);
+
+                                    if skip_cont_facet_check
+                                        || (facet.effect_size >= effect_size_interval.0
+                                            && facet.effect_size <= effect_size_interval.1
+                                            && facet.significance >= sig_interval.0
+                                            && facet.significance <= sig_interval.1)
+                                    {
+                                        if !new_regeffects {
+                                            target_ids.insert(target.id);
+                                            new_regeffects = true;
+                                        }
+                                        reo_ids.insert(facet.reo_id);
+                                    }
+                                }
+                            }
+                            if new_regeffects {
+                                new_source_buckets.insert_from(&target.associated_buckets);
+                                new_target_count += 1;
+                            }
+                        }
+
+                        if new_target_count > 0 {
+                            chrom_data.target_intervals.push(FilteredBucket {
+                                start: interval.start,
+                                count: new_target_count,
+                                associated_buckets: new_source_buckets.flat_list(),
+                            })
+                        }
+                    }
+                }
+
+                return (
+                    chrom_data, min_effect, max_effect, min_sig, max_sig, reo_ids, source_ids,
+                    target_ids,
+                );
+            },
+        )
         .collect();
 
     let mut min_effect = f32::INFINITY;
@@ -312,12 +340,31 @@ pub fn filter_coverage_data(filters: &Filter, data: &PyCoverageData) -> PyResult
         max_sig
     };
 
+    let item_sets = filtered_data.iter().fold(
+        [
+            FxHashSet::<DbID>::default(),
+            FxHashSet::<DbID>::default(),
+            FxHashSet::<DbID>::default(),
+        ],
+        |mut acc, data| {
+            acc[0].extend(data.5.clone());
+            acc[1].extend(data.6.clone());
+            acc[2].extend(data.7.clone());
+            acc
+        },
+    );
+
     let new_data = FilteredData {
         chromosomes: filtered_data.into_iter().map(|x| x.0).collect(),
         continuous_intervals: FilterIntervals {
             effect: (min_effect, max_effect),
             sig: (min_sig, max_sig),
         },
+        item_counts: [
+            item_sets[0].len() as u64,
+            item_sets[1].len() as u64,
+            item_sets[2].len() as u64,
+        ],
     };
 
     println!("Time to filter data: {}ms", now.elapsed().as_millis());

--- a/extensions/exp_viz/src/filter_data_structures.rs
+++ b/extensions/exp_viz/src/filter_data_structures.rs
@@ -1,6 +1,6 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use cov_viz_ds::{Bucket, ChromosomeData, CoverageData, DbID};
+use cov_viz_ds::{BucketLoc, ChromosomeData, CoverageData, DbID};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,8 @@ pub struct FilteredData {
     pub chromosomes: Vec<FilteredChromosome>,
     #[pyo3(get, set)]
     pub continuous_intervals: FilterIntervals,
+    #[pyo3(get, set)]
+    pub item_counts: [u64; 3],
 }
 
 impl FilteredData {
@@ -103,6 +105,7 @@ impl FilteredData {
                 })
                 .collect(),
             continuous_intervals: FilterIntervals::new(),
+            item_counts: [0, 0, 0],
         }
     }
 }
@@ -139,10 +142,10 @@ impl BucketList {
 
     pub fn insert_from<'a, I>(&mut self, from: I)
     where
-        I: IntoIterator<Item = &'a Bucket>,
+        I: IntoIterator<Item = &'a BucketLoc>,
     {
         for bucket in from {
-            self.insert(bucket.0, bucket.1 as usize);
+            self.insert(bucket.chrom, bucket.idx as usize);
         }
     }
 

--- a/extensions/exp_viz/src/merge.rs
+++ b/extensions/exp_viz/src/merge.rs
@@ -166,7 +166,11 @@ pub fn merge_filtered_data(
     );
 
     Ok(FilteredData {
-        chromosomes: chromosomes,
-        continuous_intervals: continuous_intervals,
+        chromosomes,
+        continuous_intervals,
+        item_counts: result_data
+            .get(0)
+            .and_then(|fd| Some(fd.item_counts))
+            .unwrap_or([1, 2, 3]),
     })
 }


### PR DESCRIPTION
The experiment coverage visualization now includes a count for the number of REOs, sources, and targets currently included in the visualization.