### PR TITLE
Filter experiment list by discrete facet

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -34,7 +34,7 @@ from cegs_portal.search.models.tests.file_factory import FileFactory
 from cegs_portal.search.models.tests.reg_effects_factory import RegEffectFactory
 from cegs_portal.search.models.utils import ChromosomeLocation
 from cegs_portal.users.conftest import group_extension  # noqa: F401
-from cegs_portal.utils.pagination_types import MockPaginator, Pageable, Paginateable
+from cegs_portal.utils.pagination_types import MockPaginator, Pageable
 
 
 @pytest.fixture
@@ -70,7 +70,7 @@ def access_control_experiments() -> tuple[Experiment, Experiment, Experiment]:
 
 
 @pytest.fixture
-def paged_experiments() -> Pageable[Experiment]:
+def experiment_list_data():
     e1 = ExperimentFactory(biosamples=(BiosampleFactory(),))
     _ = (_file(experiment=e1), _file(experiment=e1, data_file_info=data_file_info()))
     e2 = ExperimentFactory(biosamples=(BiosampleFactory(),))
@@ -84,8 +84,9 @@ def paged_experiments() -> Pageable[Experiment]:
     e6 = ExperimentFactory(biosamples=(BiosampleFactory(),))
     _ = (_file(experiment=e6), _file(experiment=e6, data_file_info=data_file_info()))
     experiments = sorted([e1, e2, e3, e4, e5, e6], key=lambda x: x.accession_id)
-    pages: Paginateable[Experiment] = MockPaginator(experiments, 3)
-    return pages.page(1)
+    f1 = FacetValueFactory()
+    f2 = FacetValueFactory()
+    return experiments, [f1, f2]
 
 
 def data_file_info() -> ExperimentDataFileInfo:

--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -86,6 +86,13 @@ def experiment_list_data():
     experiments = sorted([e1, e2, e3, e4, e5, e6], key=lambda x: x.accession_id)
     f1 = FacetValueFactory()
     f2 = FacetValueFactory()
+
+    e1.facet_values.add(f1)
+    e2.facet_values.add(f1)
+    e3.facet_values.add(f1)
+    e4.facet_values.add(f2)
+    e5.facet_values.add(f2)
+    e6.facet_values.add(f2)
     return experiments, [f1, f2]
 
 

--- a/cegs_portal/search/json_templates/v1/experiment.py
+++ b/cegs_portal/search/json_templates/v1/experiment.py
@@ -1,24 +1,20 @@
 from typing import Any, Optional
 
 from cegs_portal.search.models import Biosample, Experiment, File
-from cegs_portal.utils.pagination_types import Pageable
 
 
-def experiments(experiments_obj: Pageable[Experiment], options: Optional[dict[str, Any]] = None):
+def experiments(experiments_data: tuple[Any, Any], options: Optional[dict[str, Any]] = None):
+    experiments_obj, _ = experiments_data
     return {
-        "object_list": [
+        "experiments": [
             {
                 "accession_id": e.accession_id,
                 "name": e.name,
                 "description": e.description,
                 "biosamples": [biosample(b) for b in e.biosamples.all()],
             }
-            for e in experiments_obj.object_list
+            for e in experiments_obj
         ],
-        "page": experiments_obj.number,
-        "has_next_page": experiments_obj.has_next(),
-        "has_prev_page": experiments_obj.has_previous(),
-        "num_pages": experiments_obj.paginator.num_pages,
     }
 
 

--- a/cegs_portal/search/json_templates/v1/tests/test_experiment.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_experiment.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from cegs_portal.search.json_templates.v1.experiment import biosample as b_json
@@ -6,29 +8,25 @@ from cegs_portal.search.json_templates.v1.experiment import experiments as exps_
 from cegs_portal.search.json_templates.v1.experiment import file as f_json
 from cegs_portal.search.models import Experiment, File
 from cegs_portal.search.models.experiment import Biosample
-from cegs_portal.utils.pagination_types import Pageable
 
 pytestmark = pytest.mark.django_db
 
 
-def test_experiments_json(paged_experiments: Pageable[Experiment]):
+def test_experiments_json(experiment_list_data: tuple[Any, Any]):
+    experiments_obj, _ = experiment_list_data
     result = {
-        "object_list": [
+        "experiments": [
             {
                 "accession_id": e.accession_id,
                 "name": e.name,
                 "description": e.description,
                 "biosamples": [b_json(b) for b in e.biosamples.all()],
             }
-            for e in paged_experiments.object_list
-        ],
-        "page": paged_experiments.number,
-        "has_next_page": paged_experiments.has_next(),
-        "has_prev_page": paged_experiments.has_previous(),
-        "num_pages": paged_experiments.paginator.num_pages,
+            for e in experiments_obj
+        ]
     }
 
-    assert exps_json(paged_experiments) == result
+    assert exps_json(experiment_list_data) == result
 
 
 def test_experiment_json(experiment: Experiment):

--- a/cegs_portal/search/models/experiment.py
+++ b/cegs_portal/search/models/experiment.py
@@ -47,6 +47,9 @@ class Experiment(Accessioned, Faceted, AccessControlled):
 
     class Facet(Enum):
         ASSAYS = "Experiment Assays"
+        SOURCE_TYPES = "Experiment Source Type"
+        CELL_LINE = "Cell Line"
+        TISSUE_TYPE = "Tissue Type"
 
     description = models.CharField(max_length=4096, null=True, blank=True)
     experiment_type = models.CharField(max_length=100, null=True, blank=True)

--- a/cegs_portal/search/static/search/js/dom.js
+++ b/cegs_portal/search/static/search/js/dom.js
@@ -53,7 +53,13 @@ function cc(p) {
 // Replace Children
 function rc(p, c) {
     cc(p);
-    a(p, c);
+    if (Array.isArray(c)) {
+        for (let child of c) {
+            a(p, child);
+        }
+    } else {
+        a(p, c);
+    }
 }
 
 export {a, cc, e, g, rc, t};

--- a/cegs_portal/search/static/search/js/experiment_list/download_data.js
+++ b/cegs_portal/search/static/search/js/experiment_list/download_data.js
@@ -1,0 +1,11 @@
+import {g} from "../dom.js";
+import {getDownloadRegions} from "../exp_viz/downloads.js";
+
+export function downloadDataSetup(csrfToken) {
+    let dataDownloadInput = g("dataDownloadInput");
+    dataDownloadInput.addEventListener(
+        "change",
+        () => getDownloadRegions(null, dataDownloadInput, JSON.parse(g("experiment-id-list").textContent), csrfToken),
+        false
+    );
+}

--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -1,0 +1,42 @@
+import {e, g, rc} from "../dom.js";
+import {getJson} from "../files.js";
+
+export function facetFilterSetup() {
+    let facetCheckboxes = g("discrete-facets").querySelectorAll("input[type=checkbox]");
+    facetCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", (_event) => {
+            let facetQuery = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
+                .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
+                .map((i) => `facet=${i.id}`)
+                .join("&");
+
+            getJson(`/search/experiment?${facetQuery}&accept=application/json`).then((response_json) => {
+                let experimentListNode = g("experiment-list");
+                let experimentNodes = response_json["experiments"].map((expr) => {
+                    return e(
+                        "a",
+                        {href: `/search/experiment/${expr.accession_id}`, class: "content-container-link"},
+                        e("div", {class: "content-container"}, [
+                            e("div", {class: "name"}, expr.name),
+                            e("div", {class: "description"}, expr.description),
+                            e("div", {class: "flex justify-between"}, [
+                                e(
+                                    "div",
+                                    {class: "cell-lines"},
+                                    `Cell Lines: ${expr.biosamples.map((b) => b.cell_line).join(", ")}`
+                                ),
+                                e("div", {class: "accession-id"}, expr.accession_id),
+                            ]),
+                        ])
+                    );
+                });
+                rc(experimentListNode, experimentNodes);
+
+                let experimentIdList = g("experiment-id-list");
+                experimentIdList.textContent = JSON.stringify(
+                    response_json["experiments"].map((expr) => expr.accession_id)
+                );
+            });
+        });
+    });
+}

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -1,10 +1,17 @@
-{% extends "base.html" %} {% load static i18n %} {% block css %} {{ block.super }}
+{% extends "base.html" %}
+{% load static i18n %}
+{% block javascript %}
+{{ block.super }}
+<script type="text/javascript" src="{% static 'js/lodash.min.js' %}"></script>
+{% endblock %}
+{% block css %}
+{{ block.super }}
 <style>
     .content-container {
         background: #ffffff;
         box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
         align-items: center;
-        padding: 20px 40px;
+        padding: 20px 30px;
         margin-bottom: 20px;
         border-radius: 10px;
     }
@@ -60,18 +67,21 @@
         align-items: center;
     }
 
-    h1 svg {
+    .header-icon {
         margin-right: 10px;
         fill: currentColor;
         height: 1em;
     }
 </style>
-{% endblock %} {% block title %}Experiments{% endblock %} {% block content %}
+{% endblock %}
 
-<div>
+{% block title %}Experiments{% endblock %}
+
+{% block content %}
+<div class="min-w-full">
     <div style="display: flex; justify-content: space-between; align-items: center">
         <h1>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="header-icon">
                 <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
                 <path
                     d="M175 389.4c-9.8 16-15 34.3-15 53.1c-10 3.5-20.8 5.5-32 5.5c-53 0-96-43-96-96V64C14.3 64 0 49.7 0 32S14.3 0 32 0H96h64 64c17.7 0 32 14.3 32 32s-14.3 32-32 32V309.9l-49 79.6zM96 64v96h64V64H96zM352 0H480h32c17.7 0 32 14.3 32 32s-14.3 32-32 32V214.9L629.7 406.2c6.7 10.9 10.3 23.5 10.3 36.4c0 38.3-31.1 69.4-69.4 69.4H261.4c-38.3 0-69.4-31.1-69.4-69.4c0-12.8 3.6-25.4 10.3-36.4L320 214.9V64c-17.7 0-32-14.3-32-32s14.3-32 32-32h32zm32 64V224c0 5.9-1.6 11.7-4.7 16.8L330.5 320h171l-48.8-79.2c-3.1-5-4.7-10.8-4.7-16.8V64H384z"
@@ -81,18 +91,40 @@
         </h1>
     </div>
     <div class="flex gap-x-10 items-start">
-        {% if logged_in %}
-        <div class="content-container">
-            <form name="dataDownloadForm">
-                <div class="mt-5">
-                    <label class="font-bold" for="dataDlFile">Download Data from Selected Experiments</label>
-                    <input id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
+        <div class="flex flex-col basis-1/4">
+            <div class="content-container">
+                <div class="text-xl font-bold text-slate-500">Experiment Filters</div>
+                <div class="faded-line"></div>
+                <div id="discrete-facets">
+                    {% for facet, values in facets.items %}
+                    <fieldset class="my-4" name="facetfield">
+                        <legend class="font-bold">{{ facet }}</legend>
+                        <div class="flex flex-row flex-wrap gap-1">
+                            {% for value in values %}
+                                <div class="ml-1">
+                                    <input id="{{ value.id }}" type="checkbox" name="{{ facet }}"/>
+                                    <label for="{{ value.id }}">{{ value.value }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </fieldset>
+                    {% endfor %}
                 </div>
-            </form>
-            <div id="dataDownloadLink" class="mt-5 mb-5"></div>
+            </div>
+            {% if logged_in %}
+            <div class="content-container">
+                <form name="dataDownloadForm">
+                    <div>
+                        <label class="font-bold" for="dataDlFile">Download Data from Selected Experiments</label>
+                        <input id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
+                    </div>
+                </form>
+                <div id="dataDownloadLink" class="mt-5 mb-5"></div>
+            </div>
+            {% endif %}
         </div>
-        {% endif %}
-        <div>
+
+        <div id="experiment-list" class="basis-3/4">
             {% for experiment in experiments %}
             <a href="{% url 'search:experiment' experiment.accession_id %}" class="content-container-link">
                 <div class="content-container">
@@ -105,25 +137,6 @@
                 </div>
             </a>
             {% endfor %}
-            <div style="display: flex; justify-content: center; margin-top: 1rem">
-                <div class="pagination">
-                    <span class="step-links">
-                        {% if experiments.has_previous %}
-                        <a href="?page=1">&laquo; first</a>
-                        <a href="?page={{ experiments.previous_page_number }}">previous</a>
-                        {% endif %}
-
-                        <span class="current">
-                            Page {{ experiments.number }} of {{ experiments.paginator.num_pages }}
-                        </span>
-
-                        {% if experiments.has_next %}
-                        <a href="?page={{ experiments.next_page_number }}">next</a>
-                        <a href="?page={{ experiments.paginator.num_pages }}">last &raquo;</a>
-                        {% endif %}
-                    </span>
-                </div>
-            </div>
         </div>
     </div>
 </div>
@@ -131,25 +144,16 @@
 {% endblock %}
 
 {% block inline_javascript %}
+<script type="module">
+    import { facetFilterSetup } from "{% static 'search/js/experiment_list/facet_filter.js' %}";
+    facetFilterSetup();
+</script>
 {% if logged_in %}
-{{ experiment_ids|json_script:"experiment_id_list" }}
+{{ experiment_ids|json_script:"experiment-id-list" }}
 
 <script type="module">
-    import { g } from "{% static 'search/js/dom.js' %}";
-    import { getDownloadRegions } from "{% static 'search/js/exp_viz/downloads.js' %}";
-
-    let dataDownloadInput = g("dataDownloadInput");
-    dataDownloadInput.addEventListener(
-        "change",
-        () =>
-            getDownloadRegions(
-                null,
-                dataDownloadInput,
-                JSON.parse(document.getElementById("experiment_id_list").textContent),
-                "{{ csrf_token }}"
-            ),
-        false
-    );
+    import { downloadDataSetup } from "{% static 'search/js/experiment_list/download_data.js' %}";
+    downloadDataSetup("{{ csrf_token }}");
 </script>
 {% endif %}
 {% endblock %}

--- a/cegs_portal/search/view_models/v1/experiment.py
+++ b/cegs_portal/search/view_models/v1/experiment.py
@@ -3,7 +3,7 @@ from typing import cast
 from django.contrib.postgres.aggregates import StringAgg
 from django.db.models import Q, Value
 
-from cegs_portal.search.models import Experiment
+from cegs_portal.search.models import Experiment, FacetValue
 from cegs_portal.search.view_models.errors import ObjectNotFoundError
 
 
@@ -57,3 +57,9 @@ class ExperimentSearch:
     @classmethod
     def all_except(cls, accession_id):
         return Experiment.objects.exclude(accession_id=accession_id).order_by("accession_id")
+
+    @classmethod
+    def experiment_facets(cls):
+        return FacetValue.objects.filter(id__in=Experiment.objects.only("facet_values__id").all()).select_related(
+            "facet"
+        )

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -1,15 +1,12 @@
-from django.core.paginator import Paginator
 from django.http import Http404
 
 from cegs_portal.search.json_templates.v1.experiment import experiment, experiments
-from cegs_portal.search.models import Experiment
 from cegs_portal.search.view_models.errors import ObjectNotFoundError
 from cegs_portal.search.view_models.v1 import ExperimentSearch
 from cegs_portal.search.views.custom_views import (
     ExperimentAccessMixin,
     TemplateJsonView,
 )
-from cegs_portal.utils.pagination_types import Pageable
 
 
 class ExperimentView(ExperimentAccessMixin, TemplateJsonView):
@@ -84,35 +81,29 @@ class ExperimentListView(TemplateJsonView):
         GET queries used:
             accept
                 * application/json
-            page
-                * int - the "page" of experiments to return, 1 indexed
-            per_page
-                * int - how many experiments to include per page
         """
         options = super().request_options(request)
-        options["page"] = int(request.GET.get("page", 1))
-        options["per_page"] = int(request.GET.get("per_page", 20))
         return options
 
     def get(self, request, options, data):
+        experiment_objects, facet_values = data
         return super().get(
             request,
             options,
             {
                 "logged_in": not request.user.is_anonymous,
-                "experiments": data,
-                "experiment_ids": [expr.accession_id for expr in data.object_list],
+                "experiments": experiment_objects,
+                "experiment_ids": [expr.accession_id for expr in experiment_objects],
             },
         )
 
-    def get_data(self, options) -> Pageable[Experiment]:
-        if self.request.user.is_anonymous:
-            experiment_set = ExperimentSearch.all_public()
-        elif self.request.user.is_superuser or self.request.user.is_portal_admin:
-            experiment_set = ExperimentSearch.all()
-        else:
-            experiment_set = ExperimentSearch.all_with_private(self.request.user.all_experiments())
+    def get_data(self, options):
+        facets = ExperimentSearch.experiment_facets()
 
-        experiments_paginator = Paginator(experiment_set, options["per_page"])
-        experiments_page = experiments_paginator.get_page(options["page"])
-        return experiments_page
+        if self.request.user.is_anonymous:
+            return ExperimentSearch.all_public(), facets
+
+        if self.request.user.is_superuser or self.request.user.is_portal_admin:
+            return ExperimentSearch.all(), facets
+
+        return ExperimentSearch.all_with_private(self.request.user.all_experiments()), facets

--- a/cegs_portal/search/views/v1/tests/test_experiment.py
+++ b/cegs_portal/search/views/v1/tests/test_experiment.py
@@ -11,8 +11,8 @@ pytestmark = pytest.mark.django_db
 
 
 def test_experiment_list_json(client: Client, experiment_list_data: tuple[Any, Any]):
-    response = client.get("/search/experiment?accept=application/json")
     experiments, _ = experiment_list_data
+    response = client.get("/search/experiment?accept=application/json")
     assert response.status_code == 200
     json_content = json.loads(response.content)
 
@@ -22,6 +22,24 @@ def test_experiment_list_json(client: Client, experiment_list_data: tuple[Any, A
         assert json_expr["accession_id"] == expr.accession_id
         assert json_expr["name"] == expr.name
         assert json_expr["description"] == expr.description
+
+
+def test_experiment_list_facet_json(client: Client, experiment_list_data: tuple[Any, Any]):
+    _, facets = experiment_list_data
+    response = client.get(f"/search/experiment?accept=application/json&facet={facets[0].id}")
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    assert len(json_content["experiments"]) == 3
+
+
+def test_experiment_list_all_facets_json(client: Client, experiment_list_data: tuple[Any, Any]):
+    experiments, facets = experiment_list_data
+    response = client.get(f"/search/experiment?accept=application/json&facet={facets[0].id}&facet={facets[1].id}")
+    assert response.status_code == 200
+    json_content = json.loads(response.content)
+
+    assert len(json_content["experiments"]) == len(experiments)
 
 
 def test_experiment_list_html(client: Client):

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1129,6 +1129,11 @@ input[type="submit"], input[type="button"], button {
   border-color: transparent;
 }
 
+.bg-blue-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 246 255 / var(--tw-bg-opacity));
+}
+
 .bg-gray-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
@@ -1152,11 +1157,6 @@ input[type="submit"], input[type="button"], button {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
-.bg-blue-50 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 246 255 / var(--tw-bg-opacity));
 }
 
 .fill-current {

--- a/utils/experiment.py
+++ b/utils/experiment.py
@@ -212,6 +212,10 @@ class ExperimentMetadata:
         for biosample in self.biosamples:
             bios = biosample.db_save()
             experiment.biosamples.add(bios)
+            cell_line_facet = FacetValue.objects.get(value__iexact=biosample.cell_line)
+            tissue_type_facet = FacetValue.objects.get(value__iexact=biosample.tissue_type)
+            experiment.facet_values.add(cell_line_facet)
+            experiment.facet_values.add(tissue_type_facet)
         return experiment
 
     def db_del(self):

--- a/utils/experiment.py
+++ b/utils/experiment.py
@@ -13,6 +13,7 @@ from cegs_portal.search.models import (
     DNAFeatureSourceType,
     Experiment,
     ExperimentDataFileInfo,
+    FacetValue,
     TissueType,
 )
 
@@ -164,7 +165,7 @@ class AnalysisMetadata:
 
 class ExperimentMetadata:
     description: str
-    experiment_type: str
+    assay: str
     name: str
     filename: str
     accession_id: str
@@ -174,7 +175,7 @@ class ExperimentMetadata:
 
     def __init__(self, experiment_dict: dict[str, Any], experiment_filename: str):
         self.description = experiment_dict.get("description", None)
-        self.experiment_type = experiment_dict.get("type", None)
+        self.assay = experiment_dict.get("assay", None)
         self.name = experiment_dict["name"]
         self.accession_id = experiment_dict["accession_id"]
         self.source_type = get_source_type(experiment_dict["source type"])
@@ -190,9 +191,14 @@ class ExperimentMetadata:
             name=self.name,
             accession_id=self.accession_id,
             description=self.description,
-            experiment_type=self.experiment_type,
+            experiment_type=self.assay,
             source_type=self.source_type,
         )
+        experiment.save()
+        assay_facet = FacetValue.objects.get(value=self.assay)
+        source_facet = FacetValue.objects.get(value__iexact=self.source_type)
+        experiment.facet_values.add(assay_facet)
+        experiment.facet_values.add(source_facet)
         experiment.save()
         for file in self.file_metadata:
             file.db_save(experiment)


### PR DESCRIPTION
Adds the ability to filter the experiment list by discrete facet. Experiments don't currently have any continuous facets so that's not implemented.

The experiment page is no longer paginated, because (hopefully) facet filtering removes the need to do so.

The experiment data loading script has been updated to add facets to experiments.

Javascript on the experiment loading page has been moved into separate files, which makes editing/formatting/sharing easier.

Tests have been updated to remove pagination stuff and take into account facet filtering.



