### PR TITLE
Sets a default assembly for search

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -220,32 +220,33 @@ def features() -> Iterable[DNAFeature]:
 
 @pytest.fixture
 def feature() -> DNAFeature:
-    return DNAFeatureFactory(parent=None)
+    return DNAFeatureFactory(parent=None, ref_genome="GRCh38")
 
 
 @pytest.fixture
 def search_feature() -> DNAFeature:
-    return DNAFeatureFactory(parent=None, feature_type=DNAFeatureType.GENE)
+    return DNAFeatureFactory(parent=None, feature_type=DNAFeatureType.GENE, ref_genome="GRCh38")
 
 
 @pytest.fixture
 def private_feature() -> DNAFeature:
-    return DNAFeatureFactory(parent=None, public=False)
+    return DNAFeatureFactory(parent=None, public=False, ref_genome="GRCh38")
 
 
 @pytest.fixture
 def archived_feature() -> DNAFeature:
-    return DNAFeatureFactory(parent=None, archived=True)
+    return DNAFeatureFactory(parent=None, archived=True, ref_genome="GRCh38")
 
 
 @pytest.fixture
 def nearby_feature_mix() -> tuple[DNAFeature, DNAFeature, DNAFeature]:
-    pub_feature = DNAFeatureFactory(parent=None, feature_type=DNAFeatureType.GENE)
+    pub_feature = DNAFeatureFactory(parent=None, feature_type=DNAFeatureType.GENE, ref_genome="GRCh38")
     private_feature = DNAFeatureFactory(
         parent=None,
         feature_type=DNAFeatureType.CCRE,
         chrom_name=pub_feature.chrom_name,
         location=NumericRange(pub_feature.location.lower + 1000, pub_feature.location.upper + 1000),
+        ref_genome="GRCh38",
         public=False,
     )
     archived_feature = DNAFeatureFactory(
@@ -253,6 +254,7 @@ def nearby_feature_mix() -> tuple[DNAFeature, DNAFeature, DNAFeature]:
         feature_type=DNAFeatureType.DHS,
         chrom_name=pub_feature.chrom_name,
         location=NumericRange(private_feature.location.lower + 1000, private_feature.location.upper + 1000),
+        ref_genome="GRCh38",
         archived=True,
     )
 

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -88,17 +88,18 @@
 {% endblock %}
 {% block content %}
     <div class="grow flex flex-col items-center min-w-full">
-        <div class="flex flex-row justify-around search-wrapper">
+        <div class="flex flex-row justify-around search-wrapper items-baseline">
             <div class="header">
                 <svg xmlns="http://www.w3.org/2000/svg" role="img" viewBox="0 0 512 512">
                     <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
                     <path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/>
                 </svg>
-                Search Results
+                Search Results {% if not location %}in {{ assembly }}{% endif %}
             </div>
             {% if location %}
             <div class="header">
-                <div id="loc-header">{{ location.chromo }}: {{ location.range.lower }}-{{ location.range.upper }}</div>
+                <div class="inline" id="loc-header">{{ location.chromo }}: {{ location.range.lower }}-{{ location.range.upper }}</div>
+                <div class="inline text-2xl">({{ assembly }})</div>
             </div>
             {% endif %}
             <form action="{% url 'search:results' %}" method="get" class="flex items-center">

--- a/cegs_portal/search/view_models/v1/search.py
+++ b/cegs_portal/search/view_models/v1/search.py
@@ -62,7 +62,7 @@ class Search:
 
     @classmethod
     def dnafeature_loc_search_with_private(
-        cls, location: ChromosomeLocation, assembly: Optional[str], facets: list[int], private_experiments: list[str]
+        cls, location: ChromosomeLocation, assembly: str, facets: list[int], private_experiments: list[str]
     ):
         return DNAFeatureSearch.loc_search_with_private(
             location.chromo,

--- a/cegs_portal/search/views/v1/search.py
+++ b/cegs_portal/search/views/v1/search.py
@@ -23,6 +23,9 @@ ENSEMBL_RE = re.compile(r"(ENS[0-9a-z]+)(\s+|$)", re.IGNORECASE)
 ASSEMBLY_RE = re.compile(r"(hg19|hg38|grch37|grch38)(\s+|$)", re.IGNORECASE)
 POSSIBLE_GENE_NAME_RE = re.compile(r"([A-Z0-9][A-Z0-9\.\-]+)(\s+|$)", re.IGNORECASE)
 
+GRCH37 = "GRCh37"
+GRCH38 = "GRCh38"
+
 
 class ParseWarning(Enum):
     TOO_MANY_LOCS = auto()
@@ -55,7 +58,7 @@ def parse_query(
 ]:
     terms: list[tuple[IdType, str]] = []
     location: Optional[ChromosomeLocation] = None
-    assembly: Optional[str] = None
+    assembly: str = GRCH38
     warnings: set[ParseWarning] = set()
     search_type = None
 
@@ -103,10 +106,10 @@ def parse_query(
 
             # Normalize token
             if token in ("hg19", "grch37"):
-                token = "GRCh37"
+                assembly = GRCH37
             elif token in ("hg38", "grch38"):
-                token = "GRCh38"
-            assembly = token
+                assembly = GRCH38
+
             query = query[match.end() :]
             continue
 

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -20,24 +20,24 @@ from cegs_portal.search.views.v1.search import (
 @pytest.mark.parametrize(
     "query, result",
     [
-        ("", (None, [], None, None, set())),
+        ("", (None, [], None, "GRCh38", set())),
         ("hg38", (None, [], None, "GRCh38", set())),
         ("hg19", (None, [], None, "GRCh37", set())),
-        ("BRCA2", (SearchType.ID, [(IdType.GENE_NAME, "BRCA2")], None, None, set())),
-        ("brca2", (SearchType.ID, [(IdType.GENE_NAME, "brca2")], None, None, set())),
-        ("chr1:1-100", (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), None, set())),
-        ("ch1:1-100", (None, [], None, None, set())),
+        ("BRCA2", (SearchType.ID, [(IdType.GENE_NAME, "BRCA2")], None, "GRCh38", set())),
+        ("brca2", (SearchType.ID, [(IdType.GENE_NAME, "brca2")], None, "GRCh38", set())),
+        ("chr1:1-100", (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), "GRCh38", set())),
+        ("ch1:1-100", (None, [], None, "GRCh38", set())),
         (
             "chr1:1-100 chr2: 2-200",
-            (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), None, {ParseWarning.TOO_MANY_LOCS}),
+            (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), "GRCh38", {ParseWarning.TOO_MANY_LOCS}),
         ),
         (
             "   chr1:1-100    chr2: 2-200   ",
-            (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), None, {ParseWarning.TOO_MANY_LOCS}),
+            (SearchType.LOCATION, [], ChromosomeLocation("chr1", "1", "100"), "GRCh38", {ParseWarning.TOO_MANY_LOCS}),
         ),
         ("   hg38   ", (None, [], None, "GRCh38", set())),
         ("   hg19 hg38   ", (None, [], None, "GRCh38", set())),
-        ("DCPGENE00000000", (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, None, set())),
+        ("DCPGENE00000000", (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, "GRCh38", set())),
         (
             "DCPGENE00000000 hg19",
             (SearchType.ID, [IdType.ACCESSION.associate("DCPGENE00000000")], None, "GRCh37", set()),
@@ -160,7 +160,7 @@ def test_experiment_feature_loc_json(client: Client, search_feature: DNAFeature)
     json_content = json.loads(response.content)
 
     assert json_content["location"] == {
-        "assembly": None,
+        "assembly": "GRCh38",
         "chromosome": search_feature.chrom_name,
         "start": search_feature.location.lower - 10,
         "end": search_feature.location.upper + 10,

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -705,6 +705,10 @@ input[type="submit"], input[type="button"], button {
   visibility: visible;
 }
 
+.collapse {
+  visibility: collapse;
+}
+
 .static {
   position: static;
 }
@@ -953,6 +957,10 @@ input[type="submit"], input[type="button"], button {
       flex-basis: 75%;
 }
 
+.border-collapse {
+  border-collapse: collapse;
+}
+
 .transform {
   -webkit-transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
           transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
@@ -996,6 +1004,12 @@ input[type="submit"], input[type="button"], button {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
+}
+
+.items-baseline {
+  -webkit-box-align: baseline;
+      -ms-flex-align: baseline;
+          align-items: baseline;
 }
 
 .justify-center {


### PR DESCRIPTION
If no assembly is specified, GRCh38 will be used. Since this is no longer explicit in the search, it has been added to the search results page so users know what assembly they are looking at results from.