### PR TITLE
Improve the DNA Feature tab tests

### DIFF
--- a/cegs_portal/search/models/tests/dna_feature_factory.py
+++ b/cegs_portal/search/models/tests/dna_feature_factory.py
@@ -33,7 +33,7 @@ class DNAFeatureFactory(DjangoModelFactory):
     location = NumericRange(_start, _end)
     strand = random.choice(["+", "-", None])
     ref_genome = Faker("text", max_nb_chars=20)
-    ref_genome_patch = Faker("text", max_nb_chars=10)
+    ref_genome_patch = Faker("numerify", text="##")
     feature_type = random.choice(list(DNAFeatureType))
     feature_subtype = Faker("text", max_nb_chars=50)
     misc = {"other id": "id value"}

--- a/cegs_portal/search/views/v1/dna_features.py
+++ b/cegs_portal/search/views/v1/dna_features.py
@@ -86,14 +86,18 @@ class DNAFeatureId(ExperimentAccessMixin, TemplateJsonView):
             raise Http404(f"DNA Feature {id_type}/{feature_id} not found.")
 
         tabs = []
-        first_feature = feature_reos[0]
-        if len(first_feature[0].children.all()) > 0:
+        # According to the documentation
+        # (https://docs.djangoproject.com/en/4.2/ref/models/querysets/#django.db.models.query.QuerySet.exists),
+        # calling .exists on something you are going to use anyway is unnecessary work. It results in two queries,
+        # the `exists` query and the data loading query, instead of one data-loading query. So you can, instead,
+        # wrap the property access that does the data loading in a `bool` to get basically the same result.
+        if any(bool(f[0].children) for f in feature_reos):
             tabs.append("children")
 
-        if len(first_feature[1]["page"].object_list) > 0 or len(first_feature[2]["page"].object_list) > 0:
+        if any(bool(f[1]["page"].object_list) or bool(f[2]["page"].object_list) for f in feature_reos):
             tabs.append("source target")
 
-        if len(first_feature[0].closest_features.all()) > 0:
+        if any(bool(f[0].closest_features) for f in feature_reos):
             tabs.append("closest features")
 
         tabs.append("find nearby")


### PR DESCRIPTION
The previous test only checked the first returned result to see if a tab should be shown. This could result in a tab not being shown even if it should be. For example, if the first result had no children but the second result did then no "Children" tab would be shown.

The new tests check all returned results so this doesn't happen.