### PR TITLE
Update script shebang lines to work on more systems

### DIFF
--- a/scripts/data_generation/DCPEXPR00000002_dhs_bed_klann_2021_scceres.sh
+++ b/scripts/data_generation/DCPEXPR00000002_dhs_bed_klann_2021_scceres.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Requires bedtools (https://bedtools.readthedocs.io/en/latest/)

--- a/scripts/data_generation/gen_experiment_coverage_viz.sh
+++ b/scripts/data_generation/gen_experiment_coverage_viz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 gen_dir() {

--- a/scripts/data_generation/qc_plots/gen_qc_plots.sh
+++ b/scripts/data_generation/qc_plots/gen_qc_plots.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 DATA_DIR=$1
@@ -31,7 +31,7 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 # DCPEXPR00000003
 echo DCPEXPR00000003
 # python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/vpdata.bin \
-#     --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/supplementary_table_13_DHS_summary_results.txt \
+#     --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/supplementary_table_5_DHS_summary_results.tsv \
 #     -x avg_logFC \
 #     -y pValue \
 #     -g geneSymbol
@@ -43,7 +43,7 @@ echo DCPEXPR00000003
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/ipsc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
-python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/supplementary_table_13_DHS_summary_results.txt \
+python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/supplementary_table_5_DHS_summary_results.tsv \
     --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/qqplot.bin \
     -p pValue \
     -q 10_000

--- a/scripts/data_loading/load_all.sh
+++ b/scripts/data_loading/load_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 DATA_DIR=$1

--- a/scripts/data_loading/load_facets.sh
+++ b/scripts/data_loading/load_facets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 INPUT_FILE=$1

--- a/scripts/data_loading/load_gencode_gff3_data.sh
+++ b/scripts/data_loading/load_gencode_gff3_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 INPUT_FILE=$1
 GENOME=${2:-GRCh38}
 PATCH=${3:-}

--- a/scripts/data_loading/load_screen_ccres.sh
+++ b/scripts/data_loading/load_screen_ccres.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 INPUT_FILE=$1


### PR DESCRIPTION
"#!/bin/bash" doesn't work in windows WSL2 terminals, as bash is at /usr/bin/bash. #!/usr/bin/env bash should work and make the scripts more universal.