### PR TITLE
Add the huey task queue to the project

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -77,6 +77,10 @@ COPY --chown=django:root ./compose/local/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
+COPY --chown=django:root ./compose/production/django/start_hugo /start_hugo
+RUN sed -i 's/\r$//g' /start_hugo
+RUN chmod +x /start_hugo
+
 # copy application code to WORKDIR
 COPY --chown=django:root . ${APP_HOME}
 

--- a/compose/local/django/start_hugo
+++ b/compose/local/django/start_hugo
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+python /app/manage.py run_hugo

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -77,6 +77,10 @@ COPY --chown=django:root ./compose/production/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
+COPY --chown=django:root ./compose/production/django/start_hugo /start_hugo
+RUN sed -i 's/\r$//g' /start_hugo
+RUN chmod +x /start_hugo
+
 # copy application code to WORKDIR
 COPY --chown=django:root . ${APP_HOME}
 

--- a/compose/production/django/start_hugo
+++ b/compose/production/django/start_hugo
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+python /app/manage.py run_hugo

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -73,6 +73,7 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount",
     "waffle",
     "django_prometheus",
+    "huey.contrib.djhuey",
 ]
 
 # Your stuff: custom apps go here
@@ -276,6 +277,16 @@ SOCIALACCOUNT_ADAPTER = "cegs_portal.users.adapters.SocialAccountAdapter"
 
 # https://docs.djangoproject.com/en/4.1/releases/4.1/#forms-4-1
 FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
+
+
+# huey
+HUEY = {
+    "name": "ccgr-portal",
+    "url": env.str("REDIS_URL", default="redis://localhost:6379/?db=1"),
+    "consumer": {
+        "workers": 4,
+    },
+}
 
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ channels==4.0.0  # https://github.com/django/channels
 daphne==4.0.0  # https://github.com/django/daphne
 requests==2.28.1  # https://docs.python-requests.org/en/master/
 maturin==0.14.8 # https://maturin.rs
+huey==2.4.5 # https://github.com/coleifer/huey/
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Because we want more robust task management and we want task scheduling (like "do X once a week") we need a real task queue rather than the hacked-together system we have now.

Adding huey and its configuration to the project is the first step in replacing the old tasks with new ones.