### PR TITLE
Removes underscores from dna feature subtype

### DIFF
--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% load static i18n %} {% load humanize %} {% block css %} {{ block.super }}
+{% extends "base.html" %} {% load static i18n %} {% load humanize %} {% load custom_helpers %} {% block css %} {{ block.super }}
 <style>
     .closest-gene {
         font-weight: bold;
@@ -297,7 +297,8 @@ HEADER -->
                 <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
                 <td>{{ feature.get_feature_type_display }}</td>
                 {% if feature.feature_subtype %}
-                <td> {{ feature.feature_subtype }}</td>
+                <td>{{ feature.feature_subtype|remove_underscores }}</td>
+
                 {% endif %}
             </tr>
             {% endfor %}

--- a/cegs_portal/search/templatetags/custom_helpers.py
+++ b/cegs_portal/search/templatetags/custom_helpers.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def remove_underscores(value):
+    return value.replace('_', ' ')


### PR DESCRIPTION
Added django templatetags directory to create custom_helpers to apply throughout the application. The django "filter" or "helper method"(rails) that was added is used to remove underscores from dna_feature subtype and any other text.