### PR TITLE
Disable the upload app

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -81,7 +81,6 @@ LOCAL_APPS = [
     "cegs_portal.hide_admin.apps.HideAdminConfig",
     "cegs_portal.users.apps.UsersConfig",
     "cegs_portal.search.apps.SearchConfig",
-    "cegs_portal.uploads.apps.UploadsConfig",
     "cegs_portal.tools.apps.ToolsConfig",
     "cegs_portal.get_expr_data.apps.GetExprDataConfig",
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,7 +22,6 @@ urlpatterns: list[Union[URLPattern, URLResolver]] = cast(
         path("accounts/", include("allauth.urls")),
         path("search/", include("cegs_portal.search.urls")),
         path("exp_data/", include("cegs_portal.get_expr_data.urls")),
-        path("upload/", include("cegs_portal.uploads.urls")),
         path("", include("django_prometheus.urls")),
     ],
 ) + cast(list[Union[URLPattern, URLResolver]], static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT))


### PR DESCRIPTION
This upload functionality isn't used and may even be a security problem so for now we're disabling it.