### PR TITLE
Use analysis accession for expr cov data

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -24,8 +24,9 @@ const STATE_HIGHLIGHT_REGIONS = "state-highlight-regions";
 const STATE_SELECTED_EXPERIMENTS = "state-selected-experiments";
 const STATE_ITEM_COUNTS = "state-item-counts";
 const STATE_SOURCE_TYPE = "state-source-type";
+const STATE_ANALYSIS = "state-analysis";
 
-function build_state(manifest, genomeRenderer, exprAccessionID, sourceType) {
+function build_state(manifest, genomeRenderer, exprAccessionID, analysisAccessionID, sourceType) {
     let coverageData = manifest.chromosomes;
     let facets = manifest.facets;
     let default_facets = manifest.hasOwnProperty("default_facets") ? manifest.default_facets : [];
@@ -56,17 +57,22 @@ function build_state(manifest, genomeRenderer, exprAccessionID, sourceType) {
         [STATE_SELECTED_EXPERIMENTS]: [exprAccessionID],
         [STATE_ITEM_COUNTS]: [reoCount, sourceCount, targetCount],
         [STATE_SOURCE_TYPE]: sourceType,
+        [STATE_ANALYSIS]: analysisAccessionID,
     });
 
     return state;
 }
 
-async function getCoverageData(staticRoot, exprAccessionID) {
+async function getCoverageData(staticRoot, exprAccessionID, analysisAccessionID) {
     let manifest;
     let genome;
     try {
-        manifest = await getJson(`${staticRoot}search/experiments/${exprAccessionID}/coverage_manifest.json`);
-        genome = await getJson(`${staticRoot}search/experiments/${exprAccessionID}/${manifest.genome.file}`);
+        manifest = await getJson(
+            `${staticRoot}search/experiments/${exprAccessionID}/${analysisAccessionID}/coverage_manifest.json`
+        );
+        genome = await getJson(
+            `${staticRoot}search/experiments/${exprAccessionID}/${analysisAccessionID}/${manifest.genome.file}`
+        );
     } catch (error) {
         throw new Error("Files necessary to load coverage not found");
     }
@@ -344,10 +350,10 @@ function getHighlightRegions(regionUploadInput, regionReader) {
     regionReader.readAsText(regionUploadInput.files[0]);
 }
 
-export async function exp_viz(staticRoot, exprAccessionID, csrfToken, sourceType, loggedIn) {
+export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, csrfToken, sourceType, loggedIn) {
     let genome, manifest;
     try {
-        [genome, manifest] = await getCoverageData(staticRoot, exprAccessionID);
+        [genome, manifest] = await getCoverageData(staticRoot, exprAccessionID, analysisAccessionID);
     } catch (error) {
         console.log(error);
         return;
@@ -358,7 +364,7 @@ export async function exp_viz(staticRoot, exprAccessionID, csrfToken, sourceType
 
     const genomeRenderer = new GenomeRenderer(genome);
 
-    let state = build_state(manifest, genomeRenderer, exprAccessionID, sourceType);
+    let state = build_state(manifest, genomeRenderer, exprAccessionID, analysisAccessionID, sourceType);
 
     render(state, genomeRenderer);
 

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -754,7 +754,7 @@
 
 <script type="module">
     import {exp_viz} from "{% static 'search/js/exp_viz/exp_viz.js' %}";
-    exp_viz("{% get_static_prefix %}", "{{ experiment.accession_id }}", "{{ csrf_token }}", "{{ experiment.get_source_type_display }}", "{{ logged_in }}" == "True");
+    exp_viz("{% get_static_prefix %}", "{{ experiment.accession_id }}", "{{ experiment.default_analysis.accession_id }}", "{{ csrf_token }}", "{{ experiment.get_source_type_display }}", "{{ logged_in }}" == "True");
 </script>
 <script src="{% static 'js/tw-elements/index.min.js' %}"></script>
 {% endblock %}

--- a/cegs_portal/search/view_models/v1/__init__.py
+++ b/cegs_portal/search/view_models/v1/__init__.py
@@ -1,4 +1,5 @@
 from .dna_features import DNAFeatureSearch, IdType, LocSearchType
 from .experiment import ExperimentSearch
+from .experiment_coverage import ExperimentCoverageSearch
 from .reg_effects import RegEffectSearch
 from .search import Search

--- a/cegs_portal/search/view_models/v1/experiment.py
+++ b/cegs_portal/search/view_models/v1/experiment.py
@@ -30,6 +30,7 @@ class ExperimentSearch:
     def accession_search(cls, accession_id):
         experiment = (
             Experiment.objects.filter(accession_id=accession_id)
+            .select_related("default_analysis")
             .prefetch_related("data_files", "biosamples__cell_line", "biosamples__cell_line__tissue_type", "files")
             .first()
         )

--- a/cegs_portal/search/view_models/v1/experiment_coverage.py
+++ b/cegs_portal/search/view_models/v1/experiment_coverage.py
@@ -1,0 +1,11 @@
+from cegs_portal.search.models import Experiment
+
+
+class ExperimentCoverageSearch:
+    @classmethod
+    def default_analyses(cls, expr_ids: list[str]) -> list[tuple[str, str]]:
+        return list(
+            Experiment.objects.filter(accession_id__in=expr_ids)
+            .select_related("default_analysis")
+            .values_list("accession_id", "default_analysis__accession_id")
+        )

--- a/cegs_portal/search/views/v1/experiment_coverage.py
+++ b/cegs_portal/search/views/v1/experiment_coverage.py
@@ -15,6 +15,7 @@ from exp_viz import (
 
 from cegs_portal.search.json_templates.v1.experiment_coverage import experiment_coverage
 from cegs_portal.search.models.validators import validate_accession_id
+from cegs_portal.search.view_models.v1 import ExperimentCoverageSearch
 from cegs_portal.search.views.custom_views import TemplateJsonView
 from cegs_portal.search.views.view_utils import JSON_MIME
 from cegs_portal.utils.http_exceptions import Http400
@@ -49,13 +50,30 @@ CHROM_NAMES = {
 
 
 @lru_cache(maxsize=100)
-def load_coverage(exp_acc_id, chrom):
+def load_coverage(exp_acc_id, analysis_acc_id, chrom):
     if chrom is None:
-        filename = finders.find(join("search", "experiments", exp_acc_id, "level1.bin"))
+        filename = finders.find(join("search", "experiments", exp_acc_id, analysis_acc_id, "level1.bin"))
     else:
-        filename = finders.find(join("search", "experiments", exp_acc_id, f"level2_{chrom}.bin"))
+        filename = finders.find(join("search", "experiments", exp_acc_id, analysis_acc_id, f"level2_{chrom}.bin"))
 
     return load_coverage_data_allow_threads(filename)
+
+
+def get_analyses(exp_acc_ids: list[str]) -> list[tuple[str, str]]:
+    exp_analysis_pairs = []
+    exps_only = []
+    for exp_id in exp_acc_ids:
+        ids = exp_id.split("/")
+        if len(ids) == 2:
+            validate_accession_id(ids[0])
+            validate_accession_id(ids[1])
+            exp_analysis_pairs.append((ids[0], ids[1]))
+        else:
+            validate_accession_id(ids[0])
+            exps_only.append(ids[0])
+
+    exp_analysis_pairs.extend(ExperimentCoverageSearch.default_analyses(exps_only))
+    return exp_analysis_pairs
 
 
 class ExperimentCoverageView(TemplateJsonView):
@@ -113,8 +131,7 @@ class ExperimentCoverageView(TemplateJsonView):
         return HttpResponse(data.to_json(), content_type=JSON_MIME)
 
     def post_data(self, options):
-        for exp_acc_id in options["exp_acc_ids"]:
-            validate_accession_id(exp_acc_id)
+        accession_ids = get_analyses(options["exp_acc_ids"])
 
         filters = options["filters"]
 
@@ -130,8 +147,11 @@ class ExperimentCoverageView(TemplateJsonView):
 
         with ThreadPoolExecutor() as executor:
             load_to_acc_id = {
-                executor.submit(load_coverage, exp_acc_id, options["zoom_chr"]): exp_acc_id
-                for exp_acc_id in options["exp_acc_ids"]
+                executor.submit(load_coverage, exp_acc_id, analysis_acc_id, options["zoom_chr"]): (
+                    exp_acc_id,
+                    analysis_acc_id,
+                )
+                for exp_acc_id, analysis_acc_id in accession_ids
             }
             loaded_data = wait(load_to_acc_id, return_when=ALL_COMPLETED)
             filter_to_acc_id = {

--- a/cegs_portal/search/views/v1/tests/test_experiment_coverage.py
+++ b/cegs_portal/search/views/v1/tests/test_experiment_coverage.py
@@ -12,7 +12,7 @@ from cegs_portal.search.models import Experiment
 pytestmark = pytest.mark.django_db
 
 
-def mock_load_coverage(exp_acc_id, chrom):
+def mock_load_coverage(exp_acc_id, analysis_acc_id, chrom):
     current_dir = os.path.dirname(os.path.realpath(__file__))
     return load_coverage_data_allow_threads(os.path.join(current_dir, "level2_1.bin"))
 

--- a/scripts/data_generation/gen_experiment_coverage_viz.sh
+++ b/scripts/data_generation/gen_experiment_coverage_viz.sh
@@ -10,12 +10,12 @@ gen_dir() {
 }
 
 gen_data() {
-    local EXPERIMENT=$1
+    local ANALYSIS=$1
     local GENOME=$2
     local OUTPUT_DIR=$3
     local DEFAULT_FACETS=$4
 
-    echo $EXPERIMENT
+    echo $ANALYSIS
     gen_dir "${OUTPUT_DIR}"
 
     # Install cov_viz from github: https://github.com/ReddyLab/cov_viz
@@ -30,48 +30,48 @@ gen_data() {
         cp "./scripts/data_generation/data/grch38.json" $OUTPUT_DIR
     fi
 
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME}
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME}
     cov_viz_manifest ${GENOME} ${OUTPUT_DIR}/level1.bin ${OUTPUT_DIR} ${DEFAULT_FACETS}
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr1
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr2
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr3
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr4
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr5
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr6
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr7
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr8
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr9
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr10
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr11
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr12
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr13
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr14
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr15
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr16
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr17
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr18
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr19
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr20
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr21
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chr22
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chrX
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chrY
-    cov_viz ${OUTPUT_DIR} ${EXPERIMENT} ${GENOME} 100000 chrMT
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr1
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr2
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr3
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr4
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr5
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr6
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr7
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr8
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr9
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr10
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr11
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr12
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr13
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr14
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr15
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr16
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr17
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr18
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr19
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr20
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr21
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chr22
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chrX
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chrY
+    cov_viz ${OUTPUT_DIR} ${ANALYSIS} ${GENOME} 100000 chrMT
 }
 
 default_facets=`python manage.py shell -c "from cegs_portal.search.models import FacetValue; print(' '.join(str(facet.id) for facet in FacetValue.objects.filter(value__in=['Depleted Only', 'Enriched Only', 'Mixed']).all()))"`
 
-gen_data DCPEXPR00000001 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR00000001 "${default_facets}"
-gen_data DCPEXPR00000002 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR00000002 "${default_facets}"
+gen_data DCPAN00000000 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR00000001/DCPAN00000000 "${default_facets}"
+gen_data DCPAN00000002 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/DCPAN00000002 "${default_facets}"
 
 # gen_data DCPEXPR00000003 needs some changes to the cov_viz and related programs to work. Some
 # of the  REOs have null effect sizes because the "direction" of the effect is "both". Deferring
 # for now. It's also not clear how to surface that in the facet filter.
-# gen_data DCPEXPR00000003 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR00000003 "${default_facets}"
+# gen_data DCPAN00000001 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/DCPAN00000001 "${default_facets}"
 
-gen_data DCPEXPR00000004 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000004 "${default_facets}"
-gen_data DCPEXPR00000005 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000005 "${default_facets}"
-gen_data DCPEXPR00000006 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000006 "${default_facets}"
-gen_data DCPEXPR00000007 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000007 "${default_facets}"
-gen_data DCPEXPR00000008 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000008 "${default_facets}"
-gen_data DCPEXPR00000009 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000009 "${default_facets}"
+gen_data DCPAN00000003 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/DCPAN00000003 "${default_facets}"
+gen_data DCPAN00000004 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/DCPAN00000004 "${default_facets}"
+gen_data DCPAN00000005 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/DCPAN00000005 "${default_facets}"
+gen_data DCPAN00000006 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/DCPAN00000006 "${default_facets}"
+gen_data DCPAN00000007 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/DCPAN00000007 "${default_facets}"
+gen_data DCPAN00000008 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/DCPAN00000008 "${default_facets}"


### PR DESCRIPTION
An experiment may have multiple analyses associated with it. Each analysis should have its own coverage map because the numbers involved can change.

These changes change the code to support per-analysis coverage maps.