### PR TITLE
Update pip

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,9 @@ flake8:
   stage: lint
   tags:
     - kube-executor
-  image: python:3.11.2-bullseye
+  image: python:3.11.4-bookworm
   before_script:
+    - pip install -qU pip --no-warn-script-location
     - pip install -q flake8 --no-warn-script-location
   script:
     - PATH=${PATH}:/tmp/.local/bin flake8


### PR DESCRIPTION
The flake8 lint step keeps failing because "flake8 not found" even though it's obviously just been installed.