### PR TITLE
Update storages and speed up collectstatic

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput
+python /app/manage.py collectstatic --noinput --ignore "*.bin"
 
 
 /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -157,7 +157,14 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 # https://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # MEDIA
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
STORAGES should now be used instead of STATICFILES_STORAGE, which is deprecated.

collectstatic chokes on the .bin files used for the experiment coverage. The .bin files aren't ever transmitted to the client anyway, so they should be left out of the collectstatic process.