### PR TITLE
Change plot data and experiment cov data extensions 

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -486,7 +486,7 @@
             });
     };
 
-    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/vpdata.bin")
+    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/vpdata.pd")
         .then((response) => {
             if (!response.ok && response.status == 404) {
                 return; // This is often okay and expected, not every analysis has this data
@@ -601,7 +601,7 @@
     vl.register(vega, vegaLite, vegaGrnaHistogramOptions);
 
     // now you can use the API!
-    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/g_per_c.bin")
+    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/g_per_c.pd")
         .then((response) => {
             if (!response.ok && response.status == 404) {
                 return; // This is often okay and expected, not every analysis has this data
@@ -636,7 +636,7 @@
 
     // now you can use the API!
 
-    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/qqplot.bin")
+    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/qqplot.pd")
         .then((response) => {
                 if (!response.ok && response.status == 404) {
                     return; // This is often okay and expected, not every analysis has this data
@@ -730,7 +730,7 @@
     vl.register(vega, vegaLite, vegaCellsHistogramOptions);
 
     // now you can use the API!
-    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/c_per_g.bin")
+    fetch("{% get_static_prefix %}search/experiments/{{ experiment.accession_id }}/c_per_g.pd")
         .then((response) => {
             if (!response.ok && response.status == 404) {
                 return; // This is often okay and expected, not every analysis has this data

--- a/cegs_portal/search/views/v1/experiment_coverage.py
+++ b/cegs_portal/search/views/v1/experiment_coverage.py
@@ -52,9 +52,9 @@ CHROM_NAMES = {
 @lru_cache(maxsize=100)
 def load_coverage(exp_acc_id, analysis_acc_id, chrom):
     if chrom is None:
-        filename = finders.find(join("search", "experiments", exp_acc_id, analysis_acc_id, "level1.bin"))
+        filename = finders.find(join("search", "experiments", exp_acc_id, analysis_acc_id, "level1.ecd"))
     else:
-        filename = finders.find(join("search", "experiments", exp_acc_id, analysis_acc_id, f"level2_{chrom}.bin"))
+        filename = finders.find(join("search", "experiments", exp_acc_id, analysis_acc_id, f"level2_{chrom}.ecd"))
 
     return load_coverage_data_allow_threads(filename)
 

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput --ignore "*.bin"
+python /app/manage.py collectstatic --noinput --ignore "*.ecd"
 
 
 /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput
+python /app/manage.py collectstatic --noinput --ignore "*.bin"
 
 
 /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -157,7 +157,14 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
 # https://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # MEDIA
 # ------------------------------------------------------------------------------

--- a/scripts/data_generation/qc_plots/gen_qc_plots.sh
+++ b/scripts/data_generation/qc_plots/gen_qc_plots.sh
@@ -7,22 +7,22 @@ DATA_DIR=$1
 
 # DCPEXPR00000002
 echo DCPEXPR00000002
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000002_klann_scCERES_K562_2021/supplementary_table_17_grna.de.markers.all.filtered.empirical_pvals.w_gene_info.csv \
     -x avg_logFC \
     -y pval_fdr_corrected \
     -g gene_symbol \
     -d ,
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/c_per_g.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/c_per_g.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000002_klann_scCERES_K562_2021/ipsc.run_negbinom.ncells_per_grna.txt \
 #     --bin-size 4
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/g_per_c.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/g_per_c.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000002_klann_scCERES_K562_2021/ipsc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000002_klann_scCERES_K562_2021/supplementary_table_17_grna.de.markers.all.filtered.empirical_pvals.w_gene_info.csv \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000002/qqplot.pd \
     -p p_val \
     --log-p-value \
     -d , \
@@ -30,27 +30,27 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 
 # DCPEXPR00000003
 echo DCPEXPR00000003
-# python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/vpdata.bin \
+# python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/vpdata.pd \
 #     --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/supplementary_table_5_DHS_summary_results.tsv \
 #     -x avg_logFC \
 #     -y pValue \
 #     -g geneSymbol
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/c_per_g.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/c_per_g.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/ipsc.run_negbinom.ncells_per_grna.txt \
 #     --bin-size 4
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/g_per_c.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/g_per_c.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/ipsc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000003_klann_wgCERES_K562_2021/supplementary_table_5_DHS_summary_results.tsv \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000003/qqplot.pd \
     -p pValue \
     -q 10_000
 
 # DCPEXPR00000004
 echo DCPEXPR00000004
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000004_bounds_scCERES_mhc_ipsc_2021/ipsc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
     -x avg_logFC \
     -y pval_fdr_corrected \
@@ -58,16 +58,16 @@ python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_porta
     -c type \
     --control-value nontargeting \
     --non-control-value targeting
-python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/c_per_g.bin \
+python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/c_per_g.pd \
     --header \
     --input ${DATA_DIR}/DCPEXPR00000004_bounds_scCERES_mhc_ipsc_2021/ipsc.run_negbinom.ncells_per_grna.txt \
     --bin-size 4
-python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/g_per_c.bin \
+python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/g_per_c.pd \
     --header \
     --input ${DATA_DIR}/DCPEXPR00000004_bounds_scCERES_mhc_ipsc_2021/ipsc.run_negbinom.ngrnas_per_cell.txt \
     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000004_bounds_scCERES_mhc_ipsc_2021/ipsc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000004/qqplot.pd \
     -p p_val \
     --log-p-value \
     --category-column type \
@@ -77,7 +77,7 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 
 # DCPEXPR00000005
 echo DCPEXPR00000005
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000005_bounds_scCERES_mhc_k562_2021/k562.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
     -x avg_logFC \
     -y pval_fdr_corrected \
@@ -85,16 +85,16 @@ python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_porta
     -c type \
     --control-value nontargeting \
     --non-control-value targeting
-python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/c_per_g.bin \
+python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/c_per_g.pd \
     --header \
     --input ${DATA_DIR}/DCPEXPR00000005_bounds_scCERES_mhc_k562_2021/k562.run_negbinom.ncells_per_grna.txt \
     --bin-size 4
-python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/g_per_c.bin \
+python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/g_per_c.pd \
     --header \
     --input ${DATA_DIR}/DCPEXPR00000005_bounds_scCERES_mhc_k562_2021/k562.run_negbinom.ngrnas_per_cell.txt \
     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000005_bounds_scCERES_mhc_k562_2021/k562.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000005/qqplot.pd \
     -p p_val \
     --log-p-value \
     --category-column type \
@@ -104,7 +104,7 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 
 # DCPEXPR00000006
 echo DCPEXPR00000006
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000006_bounds_scCERES_mhc_npc_2021/npc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
     -x avg_logFC \
     -y pval_fdr_corrected \
@@ -112,16 +112,16 @@ python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_porta
     -c type \
     --control-value nontargeting \
     --non-control-value targeting
-python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/c_per_g.bin \
+python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/c_per_g.pd \
     --header \
     --input ${DATA_DIR}/DCPEXPR00000006_bounds_scCERES_mhc_npc_2021/npc.run_negbinom.ncells_per_grna.txt \
     --bin-size 4
-python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/g_per_c.bin \
+python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/g_per_c.pd \
     --header \
     --input ${DATA_DIR}/DCPEXPR00000006_bounds_scCERES_mhc_npc_2021/npc.run_negbinom.ngrnas_per_cell.txt \
     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000006_bounds_scCERES_mhc_npc_2021/npc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000006/qqplot.pd \
     -p p_val \
     --log-p-value \
     --category-column type \
@@ -131,61 +131,61 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 
 # DCPEXPR00000007
 echo DCPEXPR00000007
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.txt \
     -x logFC \
     -y minusLog10PValue
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/c_per_g.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/c_per_g.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000007_siklenka_atac-starr-seq_K562_2022/npc.run_negbinom.ncells_per_grna.txt \
 #     --bin-size 4
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/g_per_c.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/g_per_c.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000007_siklenka_atac-starr-seq_K562_2022/npc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.txt \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000007/qqplot.pd \
     -p minusLog10PValue \
     -q 10_000
 
 # DCPEXPR00000008
 echo DCPEXPR00000008
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.txt \
     -x avg_log2FC \
     -y p_val \
     -g target_gene
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/c_per_g.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/c_per_g.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000008_mccutcheon_scCERES_cd8_CRISPRa_2022/npc.run_negbinom.ncells_per_grna.txt \
 #     --bin-size 4
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/g_per_c.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/g_per_c.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000008_mccutcheon_scCERES_cd8_CRISPRa_2022/npc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.txt \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000008/qqplot.pd \
     -p p_val \
     --log-p-value \
     -q 10_000
 
 # DCPEXPR00000009
 echo DCPEXPR00000009
-python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/vpdata.bin \
+python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/vpdata.pd \
     --input ${DATA_DIR}/DCPEXPR00000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.txt \
     -x avg_log2FC \
     -y p_val \
     -g target_gene
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/c_per_g.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/c_per_g.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000009_mccutcheon_scCERES_cd8_CRISPRi_2022/npc.run_negbinom.ncells_per_grna.txt \
 #     --bin-size 4
-# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/g_per_c.bin \
+# python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/g_per_c.pd \
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR00000009_mccutcheon_scCERES_cd8_CRISPRi_2022/npc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
 python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR00000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.txt \
-    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/qqplot.bin \
+    --output ./cegs_portal/static_data/search/experiments/DCPEXPR00000009/qqplot.pd \
     -p p_val \
     --log-p-value \
     -q 10_000


### PR DESCRIPTION
plot data now has the extension .pd. experiment coverage data
now has the extension .ecd.

This is mainly so "manage.py collecstatic" can be set up to ignore .ecd
files that it doesn't need to do anything with but are VERY slow to process.