### PR TITLE
Fix genoverse menu for transcripts/genes

### DIFF
--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -59,6 +59,7 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
         "type": feature_obj.get_feature_type_display(),
         "subtype": feature_obj.feature_subtype,
         "parent_accession_id": feature_obj.parent_accession_id,
+        "parent_ensembl_id": feature_obj.parent.ensembl_id if feature_obj.parent else None,
         "parent": feature_obj.parent.name if feature_obj.parent else None,
         "name": feature_obj.name,
         "ids": feature_obj.ids,

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -39,6 +39,7 @@ def test_feature(feature: DNAFeature):
         "ref_genome_patch": feature.ref_genome_patch,
         "parent": feature.parent if feature.parent is not None else None,
         "parent_accession_id": feature.parent_accession_id if feature.parent is not None else None,
+        "parent_ensembl_id": feature.parent_ensembl_id if feature.parent is not None else None,
         "misc": feature.misc,
     }
     if feature.closest_gene is not None:

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -300,15 +300,19 @@ Genoverse.Track.Model.Transcript.Portal = Genoverse.Track.Model.Transcript.exten
                     model.geneIds[transcript.parent_accession_id] =
                         model.geneIds[transcript.parent_accession_id] || ++model.seenGenes;
                     geneObj = {
-                        chr: transcript.chr,
                         id: transcript.parent_accession_id,
                         accession_id: transcript.parent_accession_id,
+                        ensembl_id: transcript.parent_ensembl_id,
+                        name: transcript.parent,
+                        chr: transcript.chr,
                         start: transcript.start,
                         end: transcript.end,
                         strand: transcript.strand,
+                        ref_genome: transcript.ref_genome,
                         exons: {},
                         subFeatures: [],
-                        subtype: transcript.subtype
+                        subtype: transcript.subtype,
+                        type: transcript.type
                     }
                     geneObj.label =
                         parseInt(transcript.strand, 10) === 1
@@ -430,13 +434,12 @@ Genoverse.Track.Gene = Genoverse.Track.extend({
         name: "Results Legend",
     }),
     populateMenu: function (feature) {
-        if (["gene", "exon", "transcript"].includes(feature.type)) {
-            var url = `/search/feature/ensembl/${feature.ensembl_id}`;
+        if (["Gene", "Exon", "Transcript"].includes(feature.type)) {
+            var url = `/search/feature/accession/${feature.accession_id}`;
             var menu = {
                 title: `<a target="_blank" href="${url}">${feature.name} (${feature.ensembl_id})</a>`,
                 Location: `chr${feature.chr}:${feature.start}-${feature.end}`,
-                Strand: feature.strand,
-                Assembly: `${feature.ref_genome} ${feature.ref_genome_patch}`,
+                Strand: feature.strand
             };
 
             return menu;

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -112,7 +112,6 @@ def test_genoverse_track_model_transcript_portal(client: Client, genoverse_trans
         assert transcript.get("ensembl_id", None) is not None
         assert transcript.get("subtype", None) is not None
         assert transcript.get("start", None) is not None
-        assert transcript.get("start", None) is not None
         assert transcript.get("parent", None) is not None
         assert transcript.get("parent_accession_id", None) is not None
         assert transcript.get("parent_ensembl_id", None) is not None

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -107,12 +107,15 @@ def test_genoverse_track_model_transcript_portal(client: Client, genoverse_trans
     for transcript in transcripts:
         assert transcript.get("id", None) is not None
         assert transcript.get("accession_id", None) is not None
-        assert transcript.get("parent_accession_id", None) is not None
         assert transcript.get("strand", None) is not None
         assert transcript.get("name", None) is not None
         assert transcript.get("ensembl_id", None) is not None
         assert transcript.get("subtype", None) is not None
         assert transcript.get("start", None) is not None
+        assert transcript.get("start", None) is not None
+        assert transcript.get("parent", None) is not None
+        assert transcript.get("parent_accession_id", None) is not None
+        assert transcript.get("parent_ensembl_id", None) is not None
 
     for exon in exons:
         assert exon.get("parent_accession_id", None) is not None


### PR DESCRIPTION
The menu wasn't showing up due to changes in capitalization *d'oh* but also, since transcripts were all compacted some other changes needed to made.