### PR TITLE
Link to the experiment from JS Sig REO table

### DIFF
--- a/cegs_portal/search/static/search/js/tables.js
+++ b/cegs_portal/search/static/search/js/tables.js
@@ -145,7 +145,7 @@ function sigReoTable(reos, regionID = "sig-reg-effects") {
         ]),
     ]);
     for (const reoSetIdx in reos) {
-        let [accessionIds, reoData] = reos[reoSetIdx];
+        let [_, reoData] = reos[reoSetIdx];
         let rowClass = reoSetIdx % 2 == 0 ? "" : "bg-gray-100";
         for (const reo of reoData) {
             let sourceLocations = reo["source_locs"]
@@ -166,7 +166,13 @@ function sigReoTable(reos, regionID = "sig-reg-effects") {
             ]);
 
             if (reo == reoData[0]) {
-                rowData.append(e("td", {rowspan: `${reoData.length}`}, accessionIds[0]));
+                rowData.append(
+                    e(
+                        "td",
+                        {rowspan: `${reoData.length}`},
+                        e("a", {href: `/search/experiment/${reo["expr_accession_id"]}`}, reo["expr_name"])
+                    )
+                );
             }
             newTable.append(rowData);
         }


### PR DESCRIPTION
The Javascript version of the significant REO table on the search results page didn't link to the experiment, it just showed the accession ID.

These changes add a link, which matches the behavior for the non-js table.

<img width="1022" alt="Screenshot 2023-08-25 at 12 06 42 PM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/d0095b51-ec93-4d9b-9a8a-17a49641a0e2">