### PR TITLE
Update links in sig_reo table

### DIFF
--- a/cegs_portal/get_expr_data/conftest.py
+++ b/cegs_portal/get_expr_data/conftest.py
@@ -47,13 +47,25 @@ def _reg_effects(public=True, archived=False) -> list[RegulatoryEffectObservatio
     effect_source = RegEffectFactory(
         sources=(
             DNAFeatureFactory(
-                parent=None, chrom_name="chr1", location=NumericRange(10, 1_000), experiment_accession=None
+                parent=None,
+                accession_id="DCPDHS00000000",
+                chrom_name="chr1",
+                location=NumericRange(10, 1_000),
+                experiment_accession=None,
             ),
             DNAFeatureFactory(
-                parent=None, chrom_name="chr1", location=NumericRange(20_000, 111_000), experiment_accession=None
+                parent=None,
+                accession_id="DCPDHS00000001",
+                chrom_name="chr1",
+                location=NumericRange(20_000, 111_000),
+                experiment_accession=None,
             ),
             DNAFeatureFactory(
-                parent=None, chrom_name="chr2", location=NumericRange(22_222, 33_333), experiment_accession=None
+                parent=None,
+                accession_id="DCPDHS00000002",
+                chrom_name="chr2",
+                location=NumericRange(22_222, 33_333),
+                experiment_accession=None,
             ),
         ),
         public=public,

--- a/cegs_portal/get_expr_data/tests.py
+++ b/cegs_portal/get_expr_data/tests.py
@@ -582,7 +582,11 @@ def test_sigdata(reg_effects, login_client: SearchClient):
         "analysis_accession_id": analysis_accession_id,
     } in json_content["significant reos"][0][1]
     assert {
-        "source_locs": [["chr1", 10, 1000], ["chr1", 20000, 111000], ["chr2", 22222, 33333]],
+        "source_locs": [
+            ["chr1", 10, 1000, "DCPDHS00000000"],
+            ["chr1", 20000, 111000, "DCPDHS00000001"],
+            ["chr2", 22222, 33333, "DCPDHS00000002"],
+        ],
         "target_info": [],
         "reo_accesion_id": effect_source.accession_id,
         "effect_size": -0.0660384670056446,

--- a/cegs_portal/get_expr_data/view_models.py
+++ b/cegs_portal/get_expr_data/view_models.py
@@ -375,7 +375,8 @@ def sig_reo_loc_search(
 
     query = f"""SELECT ARRAY_AGG(DISTINCT
                             (reo_sources_targets_sig_only.source_chrom,
-                            reo_sources_targets_sig_only.source_loc)) AS sources,
+                            reo_sources_targets_sig_only.source_loc,
+                            reo_sources_targets_sig_only.source_accession)) AS sources,
                         ARRAY_AGG(DISTINCT
                             (reo_sources_targets_sig_only.target_chrom,
                             reo_sources_targets_sig_only.target_loc,
@@ -416,7 +417,7 @@ def sig_reo_loc_search(
     result = [
         {
             "source_locs": source_locs,
-            "target_info": target_info,
+            "target_info": target_info if target_info != '{"(,,,)"}' else None,
             "reo_accesion_id": reo_accesion_id,
             "effect_size": float(effect_size) if effect_size is not None else None,
             "p_value": float(p_value) if p_value is not None else None,

--- a/cegs_portal/get_expr_data/views.py
+++ b/cegs_portal/get_expr_data/views.py
@@ -178,19 +178,23 @@ def get_query_facets(request) -> list[int]:
     return int_facets
 
 
-def parse_source_locs_json(source_locs: str) -> list[str]:
+def parse_source_locs_json(source_locs: str) -> list[tuple[str, int, int, str]]:
     locs = []
-    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\"\)', source_locs):
+    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\",(\w+)\)', source_locs):
         chrom = match[1]
         start = int(match[2])
         end = int(match[3])
-        locs.append((chrom, start, end))
+        accession_id = match[4]
+        locs.append((chrom, start, end, accession_id))
         source_locs = source_locs[match.end() :]
 
     return locs
 
 
-def parse_target_info_json(target_info: str) -> list[str]:
+def parse_target_info_json(target_info: Optional[str]) -> list[tuple[str, str]]:
+    if target_info is None:
+        return []
+
     info = []
     while match := re.search(r'\(chr\w+,\\"\[\d+,\d+\)\\",([\w-]+),(\w+)\)', target_info):
         gene_symbol = match[1]

--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -162,7 +162,7 @@ def reo_source_target():
 def reo_source_targets():
     return [
         {
-            "source_locs": '{"(chr6,\\"[31577822,31578136)\\")"}',
+            "source_locs": '{"(chr6,\\"[31577822,31578136)\\",DCPDHS00000001)"}',
             "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
             "reo_accesion_id": "DCPREO000339D6",
             "effect_size": 0.010958133,
@@ -173,7 +173,7 @@ def reo_source_targets():
             "analysis_accession_id": "DCPAN00000002",
         },
         {
-            "source_locs": '{"(chr6,\\"[32182864,32183339)\\")"}',
+            "source_locs": '{"(chr6,\\"[32182864,32183339)\\",DCPDHS00000002)"}',
             "target_info": '{"(chr6,\\"[31830969,31846824)\\",SLC44A4,ENSG00000204385)"}',
             "reo_accesion_id": "DCPREO00033A96",
             "effect_size": -0.005418836,
@@ -184,7 +184,7 @@ def reo_source_targets():
             "analysis_accession_id": "DCPAN00000002",
         },
         {
-            "source_locs": '{"(chr13,\\"[40666345,40666366)\\")"}',
+            "source_locs": '{"(chr13,\\"[40666345,40666366)\\",DCPDHS00000003)"}',
             "target_info": '{"(chr6,\\"[31834608,31839767)\\",SNHG32,ENSG00000204387)"}',
             "reo_accesion_id": "DCPREO004F45A1",
             "effect_size": -1.2,

--- a/cegs_portal/search/json_templates/v1/search_results.py
+++ b/cegs_portal/search/json_templates/v1/search_results.py
@@ -20,19 +20,23 @@ SearchResults = TypedDict(
 )
 
 
-def parse_source_locs_json(source_locs: str) -> list[str]:
+def parse_source_locs_json(source_locs: str) -> list[tuple[str, int, int, str]]:
     locs = []
-    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\"\)', source_locs):
+    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\",(\w+)\)', source_locs):
         chrom = match[1]
         start = int(match[2])
         end = int(match[3])
-        locs.append((chrom, start, end))
+        accession_id = match[4]
+        locs.append((chrom, start, end, accession_id))
         source_locs = source_locs[match.end() :]
 
     return locs
 
 
-def parse_target_info_json(target_info: str) -> list[str]:
+def parse_target_info_json(target_info: Optional[str]) -> list[tuple[str, str]]:
+    if target_info is None:
+        return []
+
     info = []
     while match := re.search(r'\(chr\w+,\\"\[\d+,\d+\)\\",([\w-]+),(\w+)\)', target_info):
         gene_symbol = match[1]

--- a/cegs_portal/search/json_templates/v1/tests/test_search_results.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_search_results.py
@@ -28,7 +28,7 @@ def test_search_results(search_results: SearchResults):
                 ("DCPEXPR00000001", "DCPAN00000001"),
                 [
                     {
-                        "source_locs": [("chr6", 31577822, 31578136)],
+                        "source_locs": [("chr6", 31577822, 31578136, "DCPDHS00000001")],
                         "target_info": [("ZBTB12", "ENSG00000204366")],
                         "reo_accesion_id": "DCPREO000339D6",
                         "effect_size": 0.010958133,
@@ -39,7 +39,7 @@ def test_search_results(search_results: SearchResults):
                         "analysis_accession_id": "DCPAN00000002",
                     },
                     {
-                        "source_locs": [("chr6", 32182864, 32183339)],
+                        "source_locs": [("chr6", 32182864, 32183339, "DCPDHS00000002")],
                         "target_info": [("SLC44A4", "ENSG00000204385")],
                         "reo_accesion_id": "DCPREO00033A96",
                         "effect_size": -0.005418836,
@@ -50,7 +50,7 @@ def test_search_results(search_results: SearchResults):
                         "analysis_accession_id": "DCPAN00000002",
                     },
                     {
-                        "source_locs": [("chr13", 40666345, 40666366)],
+                        "source_locs": [("chr13", 40666345, 40666366, "DCPDHS00000003")],
                         "target_info": [("SNHG32", "ENSG00000204387")],
                         "reo_accesion_id": "DCPREO004F45A1",
                         "effect_size": -1.2,
@@ -82,7 +82,7 @@ def test_search_results(search_results: SearchResults):
                 ("DCPEXPR00000001", "DCPAN00000001"),
                 [
                     {
-                        "source_locs": [("chr6", 31577822, 31578136)],
+                        "source_locs": [("chr6", 31577822, 31578136, "DCPDHS00000001")],
                         "target_info": [("ZBTB12", "ENSG00000204366")],
                         "reo_accesion_id": "DCPREO000339D6",
                         "effect_size": 0.010958133,
@@ -93,7 +93,7 @@ def test_search_results(search_results: SearchResults):
                         "analysis_accession_id": "DCPAN00000002",
                     },
                     {
-                        "source_locs": [("chr6", 32182864, 32183339)],
+                        "source_locs": [("chr6", 32182864, 32183339, "DCPDHS00000002")],
                         "target_info": [("SLC44A4", "ENSG00000204385")],
                         "reo_accesion_id": "DCPREO00033A96",
                         "effect_size": -0.005418836,
@@ -104,7 +104,7 @@ def test_search_results(search_results: SearchResults):
                         "analysis_accession_id": "DCPAN00000002",
                     },
                     {
-                        "source_locs": [("chr13", 40666345, 40666366)],
+                        "source_locs": [("chr13", 40666345, 40666366, "DCPDHS00000003")],
                         "target_info": [("SNHG32", "ENSG00000204387")],
                         "reo_accesion_id": "DCPREO004F45A1",
                         "effect_size": -1.2,
@@ -125,19 +125,22 @@ def test_search_results(search_results: SearchResults):
 
 
 def test_parse_source_locs_json():
-    assert parse_source_locs_json('{(chr1,\\"[1,2)\\")}') == [("chr1", 1, 2)]
-    assert parse_source_locs_json('{(chr1,\\"[1,2)\\"),(chr2,\\"[2,4)\\")}') == [("chr1", 1, 2), ("chr2", 2, 4)]
+    assert parse_source_locs_json('{(chr1,\\"[1,2)\\",DCPDHS00000001)}') == [("chr1", 1, 2, "DCPDHS00000001")]
+    assert parse_source_locs_json('{(chr1,\\"[1,2)\\",DCPDHS00000001),(chr2,\\"[2,4)\\",DCPDHS00000002)}') == [
+        ("chr1", 1, 2, "DCPDHS00000001"),
+        ("chr2", 2, 4, "DCPDHS00000002"),
+    ]
 
 
 def test_parse_source_target_data_json():
     test_data = {
         "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
-        "source_locs": '{(chr1,\\"[1,2)\\")}',
+        "source_locs": '{(chr1,\\"[1,2)\\",DCPDHS00000001)}',
         "asdf": 1234,
     }
     assert parse_source_target_data_json(test_data) == {
         "target_info": [("ZBTB12", "ENSG00000204366")],
-        "source_locs": [("chr1", 1, 2)],
+        "source_locs": [("chr1", 1, 2, "DCPDHS00000001")],
         "asdf": 1234,
     }
 

--- a/cegs_portal/search/models/tests/dna_feature_factory.py
+++ b/cegs_portal/search/models/tests/dna_feature_factory.py
@@ -20,7 +20,6 @@ class DNAFeatureFactory(DjangoModelFactory):
     archived = False
     public = True
     experiment_accession = factory.SubFactory(ExperimentFactory)
-    accession_id = _faker.unique.hexify(text="DCPGENE^^^^^^^^", upper=True)
     ensembl_id = _faker.unique.numerify(text="ENSG###########")
     name = Faker("lexify", text="????-1", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ")
     cell_line = Faker("text", max_nb_chars=50)
@@ -47,8 +46,9 @@ class DNAFeatureFactory(DjangoModelFactory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         obj = model_class(*args, **kwargs)
-        obj.accession_id = cls._faker.unique.hexify(text="DCPGENE^^^^^^^^", upper=True)
-        obj.save()
+        if "accession_id" not in kwargs:
+            obj.accession_id = cls._faker.unique.hexify(text="DCPGENE^^^^^^^^", upper=True)
+            obj.save()
         return obj
 
     @post_generation

--- a/cegs_portal/search/static/search/js/tables.js
+++ b/cegs_portal/search/static/search/js/tables.js
@@ -148,21 +148,47 @@ function sigReoTable(reos, regionID = "sig-reg-effects") {
         let [_, reoData] = reos[reoSetIdx];
         let rowClass = reoSetIdx % 2 == 0 ? "" : "bg-gray-100";
         for (const reo of reoData) {
-            let sourceLocations = reo["source_locs"]
-                .map((location) => `${location[0]}:${location[1].toLocaleString()}-${location[2].toLocaleString()}`)
-                .join(", ");
-            let targetGenes = reo["target_info"].map((gene) => gene[0]).join(", ");
+            let features = [];
+            let sources = ["Source Locations: "];
+            for (let location of reo["source_locs"]) {
+                sources.push(
+                    e(
+                        "a",
+                        {href: `/search/feature/accession/${location[3]}`},
+                        `${location[0]}:\u00A0${location[1].toLocaleString()}-${location[2].toLocaleString()}`
+                    )
+                );
+                sources.push(", ");
+            }
+
+            sources.pop(); // remove that last comma
+
+            features.push(e("div", sources));
+
+            if (reo["target_info"].length > 0) {
+                let targetGene = reo["target_info"][0];
+                features.push(
+                    e("div", [
+                        `Target Genes: `,
+                        e("a", {href: `/search/feature/ensembl/${targetGene[1]}`}, targetGene[0]),
+                    ])
+                );
+            }
+
             let rowData = e("tr", {class: rowClass}, [
+                e("td", features),
                 e(
                     "td",
-                    e("a", {href: `/search/regeffect/${reo["reo_accesion_id"]}`}, [
-                        e("div", `Source Locations: ${sourceLocations}`),
-                        e("div", `Target Genes: ${targetGenes}`),
-                    ])
+                    reo["effect_size"] != null
+                        ? e(
+                              "a",
+                              {href: `/search/regeffect/${reo["reo_accesion_id"]}`},
+                              reo["effect_size"].toPrecision(6)
+                          )
+                        : ""
                 ),
-                e("td", reo["effect_size"] != null ? reo["effect_size"].toPrecision(6) : ""),
-                e("td", reo["sig"].toPrecision(6)),
-                e("td", reo["p_value"].toPrecision(6)),
+                e("td", e("a", {href: `/search/regeffect/${reo["reo_accesion_id"]}`}, reo["sig"].toPrecision(6))),
+                e("td", e("a", {href: `/search/regeffect/${reo["reo_accesion_id"]}`}, reo["p_value"].toPrecision(6))),
             ]);
 
             if (reo == reoData[0]) {

--- a/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects.html
+++ b/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects.html
@@ -4,10 +4,15 @@
         {% cycle '' 'bg-gray-100' as rowcolors silent %}
         {% for regeffect in regeffects %}
         <tr class="{{ rowcolors }}">
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accesion_id %}"><div>Source Locations: {{ regeffect.source_locs }}</div><div>Target Genes: {{ regeffect.target_info }}</div></a></td>
-            <td>{{ regeffect.effect_size|stringformat:".6e" }}</td>
-            <td>{% if regeffect.sig < 0.000001 %}{{ regeffect.sig|stringformat:".6e" }}{% else %}{{ regeffect.sig|stringformat:".6f" }}{% endif %}</td>
-            <td>{% if regeffect.p_value < 0.000001 %}{{ regeffect.p_value|stringformat:".6e" }}{% else %}{{ regeffect.p_value|stringformat:".6f" }}{% endif %}</td>
+            <td>
+                <div>Source Locations: {% for source in regeffect.source_locs %}<a href="{% url 'search:dna_features' 'accession' source.1 %}">{{ source.0 }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</div>
+                {% if regeffect.target_info %}
+                <div>Target Genes: {% for gene in regeffect.target_info %}<a href="{% url 'search:dna_features' 'ensembl' gene.1 %}">{{ gene.0 }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</div>
+                {% endif %}
+            </td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accesion_id %}">{{ regeffect.effect_size|stringformat:".6e" }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accesion_id %}">{% if regeffect.sig < 0.000001 %}{{ regeffect.sig|stringformat:".6e" }}{% else %}{{ regeffect.sig|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accesion_id %}">{% if regeffect.p_value < 0.000001 %}{{ regeffect.p_value|stringformat:".6e" }}{% else %}{{ regeffect.p_value|stringformat:".6f" }}{% endif %}</a></td>
             {% if forloop.first %}
             <td rowspan="{{ regeffects|length }}"><a href="{% url 'search:experiment' regeffect.expr_accession_id %}">{{ regeffect.expr_name }}</a></td>
             {% endif %}

--- a/cegs_portal/search/views/v1/search.py
+++ b/cegs_portal/search/views/v1/search.py
@@ -121,25 +121,30 @@ def parse_query(
     return search_type, terms, location, assembly, warnings
 
 
-def parse_source_locs_html(source_locs: str) -> list[str]:
+def parse_source_locs_html(source_locs: str) -> list[tuple[str, str]]:
     locs = []
-    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\"\)', source_locs):
+    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\",(\w+)\)', source_locs):
         chrom = match[1]
-        start = match[2]
-        end = match[3]
-        locs.append(f"{chrom}:{start}-{end}")
+        start = int(match[2])
+        end = int(match[3])
+        accession_id = match[4]
+        locs.append((f"{chrom}:{start:,}-{end:,}", accession_id))
         source_locs = source_locs[match.end() :]
 
-    return ", ".join(locs)
+    return locs
 
 
-def parse_target_info_html(target_info: str) -> list[str]:
+def parse_target_info_html(target_info: Optional[str]) -> list[tuple[str, str]]:
+    if target_info is None:
+        return []
+
     info = []
     while match := re.search(r'\(chr\w+,\\"\[\d+,\d+\)\\",([\w-]+),(\w+)\)', target_info):
         gene_symbol = match[1]
-        info.append(gene_symbol)
+        ensembl_id = match[2]
+        info.append((gene_symbol, ensembl_id))
         target_info = target_info[match.end() :]
-    return ", ".join(info)
+    return info
 
 
 def parse_source_target_data_html(reo_data):

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -536,28 +536,30 @@ def test_experiment_no_query_html(client: Client):
 
 
 def test_parse_source_locs_html():
-    assert parse_source_locs_html('{(chr1,\\"[1,2)\\")}') == "chr1:1-2"
-    assert parse_source_locs_html('{(chr1,\\"[1,2)\\"),(chr2,\\"[2,4)\\")}') == "chr1:1-2, chr2:2-4"
+    assert parse_source_locs_html('{(chr1,\\"[1,2)\\",DCPDHS00000001)}') == [("chr1:1-2", "DCPDHS00000001")]
+    assert parse_source_locs_html('{(chr1,\\"[1,2)\\",DCPDHS00000001),(chr2,\\"[2,4)\\",DCPDHS00000002)}') == [
+        ("chr1:1-2", "DCPDHS00000001"),
+        ("chr2:2-4", "DCPDHS00000002"),
+    ]
 
 
 def test_parse_source_target_data_html():
     test_data = {
         "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
-        "source_locs": '{(chr1,\\"[1,2)\\")}',
+        "source_locs": '{(chr1,\\"[1,2)\\",DCPDHS00000001)}',
         "asdf": 1234,
     }
     assert parse_source_target_data_html(test_data) == {
-        "target_info": "ZBTB12",
-        "source_locs": "chr1:1-2",
+        "target_info": [("ZBTB12", "ENSG00000204366")],
+        "source_locs": [("chr1:1-2", "DCPDHS00000001")],
         "asdf": 1234,
     }
 
 
 def test_parse_target_info_html():
-    assert parse_target_info_html('{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}') == "ZBTB12"
-    assert (
-        parse_target_info_html(
-            '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)","(chr6,\\"[8386234,2389234)\\",HLA-A,ENSG00000204367)"}'  # noqa: E501
-        )
-        == "ZBTB12, HLA-A"
-    )
+    assert parse_target_info_html('{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}') == [
+        ("ZBTB12", "ENSG00000204366")
+    ]
+    assert parse_target_info_html(
+        '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)","(chr6,\\"[8386234,2389234)\\",HLA-A,ENSG00000204367)"}'  # noqa: E501
+    ) == [("ZBTB12", "ENSG00000204366"), ("HLA-A", "ENSG00000204367")]


### PR DESCRIPTION
Each source location is now a link to the source page. Each gene name is a link to said gene. To get to the actual REO the Effect Size, Significance, and Raw p-value are now links to the REO page.

<img width="1022" alt="Screenshot 2023-08-29 at 10 32 48 AM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/e3ba75f1-4e29-43f7-beb9-b8ed9b47a922">
