### PR TITLE
Replace sig reg effect JS with HTMX

### DIFF
--- a/cegs_portal/get_expr_data/conftest.py
+++ b/cegs_portal/get_expr_data/conftest.py
@@ -86,6 +86,11 @@ def _reg_effects(public=True, archived=False) -> list[RegulatoryEffectObservatio
                 experiment_accession=None,
             ),
         ),
+        facet_num_values={
+            RegulatoryEffectObservation.Facet.EFFECT_SIZE.value: 2.0760384670056446,
+            RegulatoryEffectObservation.Facet.RAW_P_VALUE.value: 7.19229500470051e-06,
+            RegulatoryEffectObservation.Facet.SIGNIFICANCE.value: 0.057767530629869,
+        },
         public=public,
         archived=archived,
         experiment=experiment,

--- a/cegs_portal/get_expr_data/tests.py
+++ b/cegs_portal/get_expr_data/tests.py
@@ -151,11 +151,11 @@ def test_retrieve_target_experiment_data():
 @pytest.mark.parametrize(
     "cat_facets,effect_size,sig,result_count",
     [
-        ([], (-10, 0), (None, None), 3),
-        ([], (0, 10), (None, None), 0),
+        ([], (-10, 0), (None, None), 2),
+        ([], (0, 10), (None, None), 1),
         ([], (None, None), (0.0, 0.00004), 0),
-        ([], (None, None), (0.0, 0.005), 3),
-        ([], (-10, 0), (0.0, 0.005), 3),
+        ([], (None, None), (0.0, 0.005), 2),
+        ([], (-10, 0), (0.0, 0.005), 2),
         ([], (0, 10), (0.0, 0.005), 0),
         ([], (-10, 0), (0.0, 0.00004), 0),
         ([], (0, 10), (0.0, 0.00004), 0),
@@ -245,9 +245,9 @@ def test_list_experiment_data(reg_effects):
         {
             "source locs": [],
             "targets": [{"gene sym": "LNLC-1", "gene id": "ENSG01124619313"}],
-            "p-val": 0.00000319229500470051,
-            "adj p-val": 0.000427767530629869,
-            "effect size": -0.0660384670056446,
+            "p-val": 0.00000719229500470051,
+            "adj p-val": 0.057767530629869,
+            "effect size": 2.0760384670056446,
             "expr id": "DCPEXPR00000002",
             "analysis id": analysis_accession_id,
         },
@@ -283,9 +283,9 @@ def test_list_analysis_data(reg_effects):
         {
             "source locs": [],
             "targets": [{"gene sym": "LNLC-1", "gene id": "ENSG01124619313"}],
-            "p-val": 0.00000319229500470051,
-            "adj p-val": 0.000427767530629869,
-            "effect size": -0.0660384670056446,
+            "p-val": 0.00000719229500470051,
+            "adj p-val": 0.057767530629869,
+            "effect size": 2.0760384670056446,
             "expr id": "DCPEXPR00000002",
             "analysis id": analysis_accession_id,
         },
@@ -322,9 +322,9 @@ def test_location_experiment_data(reg_effects, login_client: SearchClient):
             {
                 "source locs": [],
                 "targets": [{"gene sym": "LNLC-1", "gene id": "ENSG01124619313"}],
-                "p-val": 0.00000319229500470051,
-                "adj p-val": 0.000427767530629869,
-                "effect size": -0.0660384670056446,
+                "p-val": 0.00000719229500470051,
+                "adj p-val": 0.057767530629869,
+                "effect size": 2.0760384670056446,
                 "expr id": "DCPEXPR00000002",
                 "analysis id": analysis_accession_id,
             },
@@ -362,9 +362,9 @@ def test_location_analysis_data(reg_effects, login_client: SearchClient):
             {
                 "source locs": [],
                 "targets": [{"gene sym": "LNLC-1", "gene id": "ENSG01124619313"}],
-                "p-val": 0.00000319229500470051,
-                "adj p-val": 0.000427767530629869,
-                "effect size": -0.0660384670056446,
+                "p-val": 0.00000719229500470051,
+                "adj p-val": 0.057767530629869,
+                "effect size": 2.0760384670056446,
                 "expr id": "DCPEXPR00000002",
                 "analysis id": analysis_accession_id,
             },
@@ -428,7 +428,7 @@ def test_write_experiment_data(reg_effects):
     assert (
         output_file.getvalue()
         == f"Source Locs\tTarget Info\tp-value\tAdjusted p-value\tEffect Size\tExpr Accession Id\tAnalysis Accession Id\n"  # noqa: E501
-        f"\tLNLC-1:ENSG01124619313\t0.00000319229500470051\t0.000427767530629869\t-0.0660384670056446\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
+        f"\tLNLC-1:ENSG01124619313\t0.00000719229500470051\t0.057767530629869\t2.0760384670056444\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
         f"chr1:10-1000,chr1:20000-111000,chr2:22222-33333\t\t0.00000319229500470051\t0.000427767530629869\t-0.0660384670056446\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
         f"chr1:11-1001,chr2:22223-33334\tXUEQ-1:ENSG01124619313\t0.00000319229500470051\t0.000427767530629869\t-0.0660384670056446\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
     )
@@ -453,7 +453,7 @@ def test_write_analysis_data(reg_effects):
     assert (
         output_file.getvalue()
         == f"Source Locs\tTarget Info\tp-value\tAdjusted p-value\tEffect Size\tExpr Accession Id\tAnalysis Accession Id\n"  # noqa: E501
-        f"\tLNLC-1:ENSG01124619313\t0.00000319229500470051\t0.000427767530629869\t-0.0660384670056446\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
+        f"\tLNLC-1:ENSG01124619313\t0.00000719229500470051\t0.057767530629869\t2.0760384670056444\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
         f"chr1:10-1000,chr1:20000-111000,chr2:22222-33333\t\t0.00000319229500470051\t0.000427767530629869\t-0.0660384670056446\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
         f"chr1:11-1001,chr2:22223-33334\tXUEQ-1:ENSG01124619313\t0.00000319229500470051\t0.000427767530629869\t-0.0660384670056446\tDCPEXPR00000002\t{analysis_accession_id}\n"  # noqa: E501
     )
@@ -555,68 +555,3 @@ def test_private_sig_reo_loc_search(private_reg_effects):
     result = sig_reo_loc_search(("chr1", 1, 1000000), private_experiments=[experiment.accession_id])
 
     assert len(result[0][1]) == 2
-
-
-def test_sigdata(reg_effects, login_client: SearchClient):
-    effect_source, effect_target, effect_both, _, _, _, experiment = reg_effects
-    analysis_accession_id = experiment.analyses.first().accession_id
-
-    response = login_client.get("/exp_data/sigdata?region=chr1:1-100000")
-    assert response.status_code == 200
-
-    json_content = json.loads(response.content)
-    assert "significant reos" in json_content
-    assert len(json_content["significant reos"]) == 1
-    assert len(json_content["significant reos"][0]) == 2
-    assert json_content["significant reos"][0][0] == ["DCPEXPR00000002", analysis_accession_id]
-    assert len(json_content["significant reos"][0][1]) == 2
-    assert {
-        "source_locs": [],
-        "target_info": [["LNLC-1", "ENSG01124619313"]],
-        "reo_accesion_id": effect_target.accession_id,
-        "effect_size": -0.0660384670056446,
-        "p_value": 3.19229500470051e-06,
-        "sig": 0.000427767530629869,
-        "expr_accession_id": "DCPEXPR00000002",
-        "expr_name": experiment.name,
-        "analysis_accession_id": analysis_accession_id,
-    } in json_content["significant reos"][0][1]
-    assert {
-        "source_locs": [
-            ["chr1", 10, 1000, "DCPDHS00000000"],
-            ["chr1", 20000, 111000, "DCPDHS00000001"],
-            ["chr2", 22222, 33333, "DCPDHS00000002"],
-        ],
-        "target_info": [],
-        "reo_accesion_id": effect_source.accession_id,
-        "effect_size": -0.0660384670056446,
-        "p_value": 3.19229500470051e-06,
-        "sig": 0.000427767530629869,
-        "expr_accession_id": "DCPEXPR00000002",
-        "expr_name": experiment.name,
-        "analysis_accession_id": analysis_accession_id,
-    } in json_content["significant reos"][0][1]
-
-
-@pytest.mark.usefixtures("reg_effects")
-def test_sigdata_invalid_region(login_client: SearchClient):
-    response = login_client.get("/exp_data/sigdata?region=ch1:1-100000")
-    assert response.status_code == 400
-
-
-@pytest.mark.usefixtures("reg_effects")
-def test_sigdata_no_region(login_client: SearchClient):
-    response = login_client.get("/exp_data/sigdata?expr=DCPEXPR00000002&datasource=both")
-    assert response.status_code == 400
-
-
-@pytest.mark.usefixtures("reg_effects")
-def test_sigdata_oversize_region(login_client: SearchClient):
-    response = login_client.get("/exp_data/sigdata?region=chr1:1-10000000000")
-    assert response.status_code == 400
-
-
-@pytest.mark.usefixtures("reg_effects")
-def test_sigdata_backwards_region(login_client: SearchClient):
-    response = login_client.get("/exp_data/sigdata?region=chr1:10000-10")
-    assert response.status_code == 400

--- a/cegs_portal/get_expr_data/urls.py
+++ b/cegs_portal/get_expr_data/urls.py
@@ -5,14 +5,12 @@ from cegs_portal.get_expr_data.views import (
     ExperimentDataView,
     LocationExperimentDataView,
     RequestExperimentDataView,
-    SignificantExperimentDataView,
 )
 
 app_name = "get_expr_data"
 urlpatterns = [
     path("request", view=RequestExperimentDataView.as_view(), name="requestdata"),
     path("location", view=LocationExperimentDataView.as_view(), name="locationdata"),
-    path("sigdata", view=SignificantExperimentDataView.as_view(), name="sigdata"),
     path("file/<str:filename>", view=ExperimentDataView.as_view(), name="experimentdata"),
     path("status/<str:filename>", view=ExperimentDataProgressView.as_view(), name="dataprogress"),
 ]

--- a/cegs_portal/get_expr_data/views.py
+++ b/cegs_portal/get_expr_data/views.py
@@ -23,7 +23,6 @@ from cegs_portal.get_expr_data.view_models import (
     open_file,
     output_experiment_data_csv_task,
     output_experiment_data_list,
-    sig_reo_loc_search,
     validate_an,
     validate_expr,
     validate_filename,
@@ -257,37 +256,6 @@ class LocationExperimentDataView(LoginRequiredMixin, View):
 
         data = output_experiment_data_list(user_experiments, [region], experiments, analyses, data_source, assembly)
         return JsonResponse({"experiment data": data})
-
-
-class SignificantExperimentDataView(View):
-    """
-    Pull experiment data for a single region from the DB
-    """
-
-    def get(self, request, *args, **kwargs):
-        top_num = request.GET.get("num", 5)
-        assembly = get_assembly(request)
-
-        try:
-            region = get_region(request)
-            if region is None:
-                raise Http400("Must specify a region")
-        except Http400 as error:
-            raise BadRequest() from error
-
-        if request.user.is_anonymous:
-            user_experiments = []
-        else:
-            user_experiments = request.user.all_experiments()
-
-        results = sig_reo_loc_search(region, top_num, user_experiments, assembly)
-        return JsonResponse(
-            {
-                "significant reos": [
-                    (k, [parse_source_target_data_json(reo_data) for reo_data in reo_group]) for k, reo_group in results
-                ]
-            }
-        )
 
 
 class RequestExperimentDataView(LoginRequiredMixin, View):

--- a/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects.html
+++ b/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects.html
@@ -1,6 +1,9 @@
+<div class="content-container basis-3/4" id="sig-reg-effects">
+{% if sig_reg_effects|length > 0 %}
+<div class="text-xl font-bold">Most Significant Reg Effect Observations</div>
 <table class="data-table">
     <tr><th>Enahncer/Gene</th><th>Effect Size</th><th>Significance</th><th>Raw p-value</th><th>Experiment</th></tr>
-    {% for key, regeffects in rows %}
+    {% for key, regeffects in sig_reg_effects %}
         {% cycle '' 'bg-gray-100' as rowcolors silent %}
         {% for regeffect in regeffects %}
         <tr class="{{ rowcolors }}">
@@ -20,3 +23,7 @@
         {% endfor %}
     {% endfor %}
 </table>
+{% else %}
+No Relevant Reg Effect Observations Found
+{% endif %}
+</div>

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -160,9 +160,8 @@
             </div>
             {% endif %}
         </div>
-        <div class="content-container basis-3/4" id="sig-reg-effects">
-          {% include "search/v1/partials/_table.html" with data=sig_reg_effects name="Most Significant Reg Effect Observations" no_data="No Relevant Reg Effect Observations Found" table="search/v1/partials/_sig_reg_effects.html" %}
-        </div>
+
+        {% include "search/v1/partials/_sig_reg_effects.html" with sig_reg_effects=sig_reg_effects %}
     </div>
 
     {% switch "effect_plot" %}
@@ -234,18 +233,7 @@
         // Update the signficant effects table
         state.addCallback(STATE_REGION, (s, key) => {
             let region = state.g(STATE_REGION);
-
-            getJson(`/exp_data/sigdata?region=chr${region.chr}:${region.start}-${region.end}&assembly={{ assembly }}`).then(json => {
-                let sigRegEffects = json["significant reos"]
-                if(sigRegEffects.length == 0) {
-                    rc(g("sig-reg-effects"), t("No Relevant Reg Effect Observations Found"))
-                } else {
-                    let container = g("sig-reg-effects");
-                    rc(container, e("div", {class: "text-xl font-bold"}, t("Most Significant Reg Effect Observations")));
-                    a(container, sigReoTable(sigRegEffects));
-                }
-
-            }).catch(err => console.log(err));
+            htmx.ajax("GET", `/search/sigdata?region=chr${region.chr}:${region.start}-${region.end}&assembly={{ assembly }}`, {target:"#sig-reg-effects", swap:"outerHTML"});
         });
 
         state.addCallback(STATE_FACETS, throttle(

--- a/cegs_portal/search/urls.py
+++ b/cegs_portal/search/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     ),
     re_path(r"regeffect/(?P<re_id>DCPREO[A-F0-9]{8})$", views.v1.RegEffectView.as_view(), name="reg_effect"),
     path("feature_counts", views.v1.FeatureCountView.as_view(), name="feature_counts"),
+    path("sigdata", view=views.v1.SignificantExperimentDataView.as_view(), name="sigdata"),
     path("v1/results/", views.v1.SearchView.as_view()),
     re_path(
         r"v1/feature/(?P<id_type>\w+)/(?P<feature_id>[A-Za-z0-9][A-Za-z0-9\.\-]+)$", views.v1.DNAFeatureId.as_view()

--- a/cegs_portal/search/views/v1/__init__.py
+++ b/cegs_portal/search/views/v1/__init__.py
@@ -2,4 +2,4 @@ from .dna_features import DNAFeatureId, DNAFeatureLoc
 from .experiment import ExperimentListView, ExperimentView
 from .experiment_coverage import ExperimentCoverageView
 from .reg_effects import RegEffectView, SourceEffectsView, TargetEffectsView
-from .search import FeatureCountView, SearchView
+from .search import FeatureCountView, SearchView, SignificantExperimentDataView

--- a/cegs_portal/search/views/v1/tests/conftest.py
+++ b/cegs_portal/search/views/v1/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Iterable
 import pytest
 from psycopg2.extras import NumericRange
 
+from cegs_portal.get_expr_data.conftest import reg_effects  # noqa: F401
 from cegs_portal.search.models import (
     DNAFeature,
     DNAFeatureType,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-extend-ignore = E203
+extend-ignore = E203,E501
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv,cegs_portal/*/__init__.py,utils/__init__.py,scripts/*/__init__.py
 
 [pycodestyle]


### PR DESCRIPTION
Instead of using awkward JS, the updates happen via HTMX. With this it made sense to move the endpoint from the get_expr_data app to the search app.

Tests also had to move, and we removed the json template since it wasn't really necessary anymore.