### PR TITLE
Modify decimal number displays

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -5,7 +5,7 @@ import {getJson, postJson} from "../files.js";
 import {Legend} from "./obsLegend.js";
 import {GenomeRenderer} from "./chromosomeSvg.js";
 import {getDownloadRegions, getDownloadAll} from "./downloads.js";
-import {debounce} from "../utils.js"
+import {debounce} from "../utils.js";
 
 const STATE_ZOOMED = "state-zoomed";
 const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
@@ -387,14 +387,14 @@ let tooltipDataSelectors = [
         if (d.max_log10_sig >= 0.001) {
             return d.max_log10_sig.toFixed(3); // e.g., 12.34567890 -> 12.345
         } else {
-            return d.max_log10_sig.toExponential(3); // e.g., 0.0000000000345345345 -> 3.453e-11
+            return d.max_log10_sig.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
         }
     },
     (d) => {
         if (Math.abs(d.max_abs_effect) >= 0.001) {
             return d.max_abs_effect.toFixed(3); // e.g., 12.34567890 -> 12.345
         } else {
-            return d.max_abs_effect.toExponential(3); // e.g., 0.0000000000345345345 -> 3.453e-11
+            return d.max_abs_effect.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
         }
     },
 ];

--- a/cegs_portal/search/static/search/js/tables.js
+++ b/cegs_portal/search/static/search/js/tables.js
@@ -78,9 +78,23 @@ function reTable(regeffects, regionID = "regeffect") {
         for (const target of effect.target_ids) {
             let row = e("tr", {"data-href": `/search/regeffect/${effect.accession_id}`}, [
                 e("td", e("a", {href: `/search/regeffect/${effect.accession_id}`}, effect.accession_id)),
-                e("td", `${effect.effect_size.toExponential(3)}`),
+                e(
+                    "td",
+                    `${
+                        Math.abs(effect.effect_size) > 0.0000001
+                            ? effect.effect_size.toFixed(6)
+                            : effect.effect_size.toExponential(2)
+                    }`
+                ),
                 e("td", `${effect.direction}`),
-                e("td", `${effect.significance.toExponential(3)}`),
+                e(
+                    "td",
+                    `${
+                        effect.significance > 0.0000001
+                            ? effect.significance.toFixed(6)
+                            : effect.significance.toExponential(2)
+                    }`
+                ),
                 e("td", e("a", {href: `/search/experiment/${effect.experiment.accession_id}`}, effect.experiment.name)),
                 target == null ? e("td", "-") : e("td", e("a", {href: `/search/feature/accession/${target}`}, target)),
             ]);
@@ -112,9 +126,23 @@ function reTargetTable(regeffects, regionID = "regeffect") {
         for (const source of effect.source_ids) {
             let row = e("tr", {"data-href": `/search/regeffect/${effect.accession_id}`}, [
                 e("td", e("a", {href: `/search/regeffect/${effect.accession_id}`}, effect.accession_id)),
-                e("td", `${effect.effect_size.toExponential(3)}`),
+                e(
+                    "td",
+                    `${
+                        Math.abs(effect.effect_size) > 0.0000001
+                            ? effect.effect_size.toFixed(6)
+                            : effect.effect_size.toExponential(2)
+                    }`
+                ),
                 e("td", `${effect.direction}`),
-                e("td", `${effect.significance.toExponential(3)}`),
+                e(
+                    "td",
+                    `${
+                        effect.significance > 0.0000001
+                            ? effect.significance.toFixed(6)
+                            : effect.significance.toExponential(2)
+                    }`
+                ),
                 e("td", e("a", {href: `/search/experiment/${effect.experiment.accession_id}`}, effect.experiment.name)),
                 source == null ? e("td", "-") : e("td", e("a", {href: `/search/feature/accession/${source}`}, source)),
             ]);
@@ -148,9 +176,23 @@ function reoNonTargetTable(regeffects, regionID = "regeffect") {
             newTable.append(
                 e("tr", [
                     e("td", e("a", {href: `/search/regeffect/${effect.accession_id}`}, effect.accession_id)),
-                    e("td", `${effect.effect_size.toExponential(3)}`),
+                    e(
+                        "td",
+                        `${
+                            Math.abs(effect.effect_size) > 0.0000001
+                                ? effect.effect_size.toFixed(6)
+                                : effect.effect_size.toExponential(2)
+                        }`
+                    ),
                     e("td", `${effect.direction}`),
-                    e("td", `${effect.significance.toExponential(3)}`),
+                    e(
+                        "td",
+                        `${
+                            effect.significance > 0.0000001
+                                ? effect.significance.toFixed(6)
+                                : effect.significance.toExponential(2)
+                        }`
+                    ),
                 ])
             );
         }
@@ -212,15 +254,11 @@ function sigReoTable(reos, regionID = "sig-reg-effects") {
                 e(
                     "td",
                     reo["effect_size"] != null
-                        ? e(
-                              "a",
-                              {href: `/search/regeffect/${reo["reo_accession_id"]}`},
-                              reo["effect_size"].toPrecision(6)
-                          )
+                        ? e("a", {href: `/search/regeffect/${reo["reo_accession_id"]}`}, reo["effect_size"].toFixed(6))
                         : ""
                 ),
-                e("td", e("a", {href: `/search/regeffect/${reo["reo_accession_id"]}`}, reo["sig"].toPrecision(6))),
-                e("td", e("a", {href: `/search/regeffect/${reo["reo_accession_id"]}`}, reo["p_value"].toPrecision(6))),
+                e("td", e("a", {href: `/search/regeffect/${reo["reo_accession_id"]}`}, reo["sig"].toFixed(6))),
+                e("td", e("a", {href: `/search/regeffect/${reo["reo_accession_id"]}`}, reo["p_value"].toFixed(6))),
             ]);
 
             if (reo == reoData[0]) {

--- a/cegs_portal/search/templates/search/v1/partials/_feature_sig_reg_effects.html
+++ b/cegs_portal/search/templates/search/v1/partials/_feature_sig_reg_effects.html
@@ -23,9 +23,9 @@
                 <div>Target Genes: {% for gene in regeffect.targets.all %}<a href="{% url 'search:dna_features' 'accession' gene.accession_id %}">{{ gene.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</div>
                 {% endif %}
             </td>
-            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{% if regeffect.effect_size < 0.000001 and regeffect.effect_size > -0.000001 %}{{ regeffect.effect_size|stringformat:".6e" }}{% else %}{{ regeffect.effect_size|stringformat:".6f" }}{% endif %}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{% if regeffect.significance < 0.000001 %}{{ regeffect.significance|stringformat:".6e" }}{% else %}{{ regeffect.significance|stringformat:".6f" }}{% endif %}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{% if regeffect.raw_p_value < 0.000001 %}{{ regeffect.raw_p_value|stringformat:".6e" }}{% else %}{{ regeffect.raw_p_value|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{% if regeffect.effect_size < 0.000001 and regeffect.effect_size > -0.000001 %}{{ regeffect.effect_size|stringformat:".2e" }}{% else %}{{ regeffect.effect_size|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{% if regeffect.significance < 0.000001 %}{{ regeffect.significance|stringformat:".2e" }}{% else %}{{ regeffect.significance|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{% if regeffect.raw_p_value < 0.000001 %}{{ regeffect.raw_p_value|stringformat:".2e" }}{% else %}{{ regeffect.raw_p_value|stringformat:".6f" }}{% endif %}</a></td>
             <td><a href="{% url 'search:experiment' regeffect.experiment_accession_id %}">{{ regeffect.experiment.name }}</a></td>
         </tr>
         {% endfor %}

--- a/cegs_portal/search/templates/search/v1/partials/_non_targeting_reo.html
+++ b/cegs_portal/search/templates/search/v1/partials/_non_targeting_reo.html
@@ -38,7 +38,7 @@
             </td>
             <td>{{ reo.effect_size }}</td>
             <td>{{ reo.direction }}</td>
-            <td>{% if reo.significance < 0.000001 %}{{ reo.significance|stringformat:".6e" }}{% else %}{{ reo.significance|stringformat:".6f" }}{% endif %}</td>
+            <td>{% if reo.significance < 0.000001 %}{{ reo.significance|stringformat:".2e" }}{% else %}{{ reo.significance|stringformat:".6f" }}{% endif %}</td>
             <td>{{ first_source.closest_gene_distance|intcomma }}</td>
             <td>
                 <div class="w-[100px]">

--- a/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects_table.html
+++ b/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects_table.html
@@ -10,9 +10,9 @@
                 <div>Target Genes: {% for gene in regeffect.target_info %}<a href="{% url 'search:dna_features' 'ensembl' gene.1 %}">{{ gene.0 }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</div>
                 {% endif %}
             </td>
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{% if regeffect.effect_size < 0.000001 and regeffect.effect_size > -0.000001 %}{{ regeffect.effect_size|stringformat:".6e" }}{% else %}{{ regeffect.effect_size|stringformat:".6f" }}{% endif %}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{% if regeffect.sig < 0.000001 %}{{ regeffect.sig|stringformat:".6e" }}{% else %}{{ regeffect.sig|stringformat:".6f" }}{% endif %}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{% if regeffect.p_value < 0.000001 %}{{ regeffect.p_value|stringformat:".6e" }}{% else %}{{ regeffect.p_value|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{% if regeffect.effect_size < 0.000001 and regeffect.effect_size > -0.000001 %}{{ regeffect.effect_size|stringformat:".2e" }}{% else %}{{ regeffect.effect_size|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{% if regeffect.sig < 0.000001 %}{{ regeffect.sig|stringformat:".2e" }}{% else %}{{ regeffect.sig|stringformat:".6f" }}{% endif %}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{% if regeffect.p_value < 0.000001 %}{{ regeffect.p_value|stringformat:".2e" }}{% else %}{{ regeffect.p_value|stringformat:".6f" }}{% endif %}</a></td>
             {% if forloop.first %}
             <td rowspan="{{ regeffects|length }}"><a href="{% url 'search:experiment' regeffect.expr_accession_id %}">{{ regeffect.expr_name }}</a></td>
             {% endif %}

--- a/cegs_portal/search/templates/search/v1/reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/reg_effect.html
@@ -152,8 +152,8 @@
             <tr>
                 <td>{{ regulatory_effect.direction }}</td>
                 <td>{{ regulatory_effect.effect_size }}</td>
-                <td>{% if regulatory_effect.significance < 0.000001 %}{{ regulatory_effect.significance|stringformat:".6e" }}{% else %}{{ regulatory_effect.significance|stringformat:".6f" }}{% endif %}</td>
-                <td>{% if regulatory_effect.raw_p_value < 0.000001 %}{{ regulatory_effect.raw_p_value|stringformat:".6e" }}{% else %}{{ regulatory_effect.raw_p_value|stringformat:".6f" }}{% endif %}</td>
+                <td>{% if regulatory_effect.significance < 0.000001 %}{{ regulatory_effect.significance|stringformat:".2e" }}{% else %}{{ regulatory_effect.significance|stringformat:".6f" }}{% endif %}</td>
+                <td>{% if regulatory_effect.raw_p_value < 0.000001 %}{{ regulatory_effect.raw_p_value|stringformat:".2e" }}{% else %}{{ regulatory_effect.raw_p_value|stringformat:".6f" }}{% endif %}</td>
                 <td>{{ regulatory_effect.cell_lines|join:", " }}</td>
                 {% if regulatory_effect.tissue_types.exist %}
                 <td>{{ regulatory_effect.tissue_types|join:", " }}</td>


### PR DESCRIPTION
If the values are displayed in exponential format (because it's small) only show two decimal places. Otherwise generally use 6 fixed decimal places.