### PR TITLE
Genoverse improvements on search results page

### DIFF
--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -377,7 +377,8 @@
             tracks: [
                 Genoverse.Track.Scaleline.extend({ strand: false }),
                 Genoverse.Track.Scalebar,
-                Genoverse.Track.DHS.Effects.extend({children: [Genoverse.Track.Gene]}),
+                Genoverse.Track.DHS.Effects,
+                Genoverse.Track.Gene,
             ]
         });
         {% endif %}

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -239,11 +239,13 @@ class DNAFeatureSearch:
                     "source_for",
                     "source_for__facet_values",
                     "source_for__facet_values__facet",
+                    "source_for__sources",
                     "source_for__targets",
                     "target_of",
                     "target_of__facet_values",
                     "target_of__facet_values__facet",
                     "target_of__sources",
+                    "target_of__targets",
                 ]
             )
 

--- a/cegs_portal/search/view_models/v1/search.py
+++ b/cegs_portal/search/view_models/v1/search.py
@@ -23,7 +23,7 @@ from cegs_portal.search.view_models.v1 import DNAFeatureSearch, LocSearchType
 from cegs_portal.users.models import UserType
 
 EXPERIMENT_SOURCES = [DNAFeatureType.CAR.value, DNAFeatureType.GRNA.value, DNAFeatureType.DHS.value]
-EXPERIMENT_SOURCES_TEXT = "Experiment Regulatory Effect Source"
+EXPERIMENT_SOURCES_TEXT = "Experimentally Tested Element"
 
 
 class Search:

--- a/cegs_portal/search/views/v1/tests/test_feature_counts.py
+++ b/cegs_portal/search/views/v1/tests/test_feature_counts.py
@@ -27,7 +27,7 @@ def test_feature_counts_json(client: Client):
     assert json_content["region"] == {"chromo": "chr1", "start": 1, "end": 1000000}
     assert json_content["assembly"] == "GRCh38"
     assert json_content["counts"] == [
-        {"feature_type": "Experiment Regulatory Effect Source", "count": 2, "sig_reo_count": 2},
+        {"feature_type": "Experimentally Tested Element", "count": 2, "sig_reo_count": 2},
         {"feature_type": "Gene", "count": 2, "sig_reo_count": 1},
         {"feature_type": "Transcript", "count": 0, "sig_reo_count": 0},
         {"feature_type": "Exon", "count": 0, "sig_reo_count": 0},
@@ -44,7 +44,7 @@ def test_feature_counts_with_assembly_json(client: Client):
     assert json_content["region"] == {"chromo": "chr1", "start": 1, "end": 1000000}
     assert json_content["assembly"] == "GRCh37"
     assert json_content["counts"] == [
-        {"feature_type": "Experiment Regulatory Effect Source", "count": 2, "sig_reo_count": 2},
+        {"feature_type": "Experimentally Tested Element", "count": 2, "sig_reo_count": 2},
         {"feature_type": "Gene", "count": 2, "sig_reo_count": 1},
         {"feature_type": "Transcript", "count": 0, "sig_reo_count": 0},
         {"feature_type": "Exon", "count": 0, "sig_reo_count": 0},


### PR DESCRIPTION
* No non-assayed elements
* Distinguish between elements with significant and non-significant observations
* Change "Regulatory Effects Sources" to "Experimentally Tested Elements"
* Squishable Elements view (the gene view shouldn't need squishing)
* Fixes an n+1 query issue