### PR TITLE
Removes reoaccession, adds source loc info

### DIFF
--- a/cegs_portal/search/json_templates/v1/feature_reg_effects.py
+++ b/cegs_portal/search/json_templates/v1/feature_reg_effects.py
@@ -13,7 +13,7 @@ RegulatoryEffectObservationJson = TypedDict(
         "significance": Optional[float],
         "raw_p_value": Optional[float],
         "experiment": NotRequired[ExperimentJson],
-        "source_ids": list[str],
+        "sources": list[tuple[str, str, tuple[int, int], str]],
         "targets": list[tuple[str, str]],
     },
 )
@@ -28,7 +28,15 @@ def regulatory_effect(
         "effect_size": reg_effect.effect_size,
         "significance": reg_effect.significance,
         "raw_p_value": reg_effect.raw_p_value,
-        "source_ids": [source.accession_id for source in reg_effect.sources.all()],
+        "sources": [
+            (
+                source.accession_id,
+                source.chrom_name,
+                (source.location.lower, source.location.upper),
+                source.get_feature_type_display(),
+            )
+            for source in reg_effect.sources.all()
+        ],
         "targets": [(target.accession_id, target.name) for target in reg_effect.targets.all()],
     }
 

--- a/cegs_portal/search/json_templates/v1/tests/test_feature_reg_effects.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_feature_reg_effects.py
@@ -35,7 +35,15 @@ def test_regulatory_effect(reg_effect: RegulatoryEffectObservation):
         "significance": reg_effect.significance,
         "raw_p_value": reg_effect.raw_p_value,
         "experiment": {"accession_id": reg_effect.experiment.accession_id, "name": reg_effect.experiment.name},
-        "source_ids": [source.accession_id for source in reg_effect.sources.all()],
+        "sources": [
+            (
+                source.accession_id,
+                source.chrom_name,
+                (source.location.lower, source.location.upper),
+                source.get_feature_type_display(),
+            )
+            for source in reg_effect.sources.all()
+        ],
         "targets": [(target.accession_id, target.name) for target in reg_effect.targets.all()],
     }
 

--- a/cegs_portal/search/static/search/js/tables.js
+++ b/cegs_portal/search/static/search/js/tables.js
@@ -63,12 +63,12 @@ function emptyRETable(emptyString, regionID = "regeffect") {
 function reTable(regeffects, regionID = "regeffect") {
     let newTable = e("table", {id: regionID, class: "data-table"}, [
         e("tr", [
-            e("th", "Accession ID"),
             e("th", "Effect Size (log2FC)"),
             e("th", "Direction"),
             e("th", "Significance (p-value)"),
             e("th", "Experiment"),
             e("th", "Target"),
+            e("th", "REO Page"),
         ]),
     ]);
     for (let effect of regeffects) {
@@ -79,7 +79,6 @@ function reTable(regeffects, regionID = "regeffect") {
             let target_id = target_info[0];
             let target_name = target_info[1];
             let row = e("tr", {"data-href": `/search/regeffect/${effect.accession_id}`}, [
-                e("td", e("a", {href: `/search/regeffect/${effect.accession_id}`}, effect.accession_id)),
                 e(
                     "td",
                     `${
@@ -101,6 +100,32 @@ function reTable(regeffects, regionID = "regeffect") {
                 target_id == null
                     ? e("td", "-")
                     : e("td", e("a", {href: `/search/feature/accession/${target_id}`}, target_name)),
+                e(
+                    "td",
+                    e(
+                        "a",
+                        {href: `/search/regeffect/${effect.accession_id}`},
+                        e(
+                            "svg",
+                            {
+                                xmlns: "http://www.w3.org/2000/svg",
+                                width: "16",
+                                height: "16",
+                                fill: "currentColor",
+                                class: "svg-link-arrow bi bi-arrow-up-right-square-fill",
+                                viewBox: "0 0 16 16",
+                            },
+                            e(
+                                "path",
+                                {
+                                    "fill-rule": "evenodd",
+                                    d: "M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm5.854 8.803a.5.5 0 1 1-.708-.707L9.243 6H6.475a.5.5 0 1 1 0-1h3.975a.5.5 0 0 1 .5.5v3.975a.5.5 0 1 1-1 0V6.707l-4.096 4.096z",
+                                },
+                                []
+                            )
+                        )
+                    )
+                ),
             ]);
             row.onclick = function () {
                 window.location = row.getAttribute("data-href");
@@ -115,21 +140,35 @@ function reTable(regeffects, regionID = "regeffect") {
 function reTargetTable(regeffects, regionID = "regeffect") {
     let newTable = e("table", {id: regionID, class: "data-table"}, [
         e("tr", [
-            e("th", "Accession ID"),
+            e("th", "Tested Element(s)"),
             e("th", "Effect Size (log2FC)"),
             e("th", "Direction"),
             e("th", ["Significance", e("br"), "(p-value)"]),
             e("th", "Experiment"),
-            e("th", "Source"),
+            e("th", "REO Page"),
         ]),
     ]);
     for (let effect of regeffects) {
-        if (effect.source_ids == 0) {
-            effect.source_ids = [null];
+        if (effect.sources == 0) {
+            effect.sources = [[null, null, null]];
         }
-        for (const source of effect.source_ids) {
+        for (const source of effect.sources) {
+            console.log(source);
+            let source_id = source[0];
+            let source_chrom = source[1];
+            let source_loc = source[2];
+            let source_type = source[3];
             let row = e("tr", {"data-href": `/search/regeffect/${effect.accession_id}`}, [
-                e("td", e("a", {href: `/search/regeffect/${effect.accession_id}`}, effect.accession_id)),
+                source_id == null
+                    ? e("td", "-")
+                    : e(
+                          "td",
+                          e(
+                              "a",
+                              {href: `/search/feature/accession/${source_id}`},
+                              `${source_type} (${source_chrom}: ${source_loc[0].toLocaleString()}-${source_loc[1].toLocaleString()})`
+                          )
+                      ),
                 e(
                     "td",
                     `${
@@ -148,7 +187,32 @@ function reTargetTable(regeffects, regionID = "regeffect") {
                     }`
                 ),
                 e("td", e("a", {href: `/search/experiment/${effect.experiment.accession_id}`}, effect.experiment.name)),
-                source == null ? e("td", "-") : e("td", e("a", {href: `/search/feature/accession/${source}`}, source)),
+                e(
+                    "td",
+                    e(
+                        "a",
+                        {href: `/search/regeffect/${effect.accession_id}`},
+                        e(
+                            "svg",
+                            {
+                                xmlns: "http://www.w3.org/2000/svg",
+                                width: "16",
+                                height: "16",
+                                fill: "currentColor",
+                                class: "svg-link-arrow bi bi-arrow-up-right-square-fill",
+                                viewBox: "0 0 16 16",
+                            },
+                            e(
+                                "path",
+                                {
+                                    "fill-rule": "evenodd",
+                                    d: "M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm5.854 8.803a.5.5 0 1 1-.708-.707L9.243 6H6.475a.5.5 0 1 1 0-1h3.975a.5.5 0 0 1 .5.5v3.975a.5.5 0 1 1-1 0V6.707l-4.096 4.096z",
+                                },
+                                []
+                            )
+                        )
+                    )
+                ),
             ]);
             row.onclick = function () {
                 window.location = row.getAttribute("data-href");

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -256,15 +256,19 @@
     }
 
     .source-file-name:hover {
-    overflow: visible;
-    white-space: normal;
-    background: #ffffff;
-    box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
-    padding: 20px 40px;
-    border-radius: 10px;
-    width: 550px;
-    position: absolute;
-    left: 500px;
+        overflow: visible;
+        white-space: normal;
+        background: #ffffff;
+        box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
+        padding: 20px 40px;
+        border-radius: 10px;
+        width: 550px;
+        position: absolute;
+        left: 500px;
+    }
+
+    .svg-link-arrow {
+        font-size: 14pt;
     }
 
 </style>

--- a/cegs_portal/search/templates/search/v1/partials/_target_reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/partials/_target_reg_effect.html
@@ -1,3 +1,5 @@
+{% load humanize %}
+
 <style>
     .target_data-table {
         border-collapse: collapse;
@@ -83,15 +85,21 @@
     </div>
     <div class="faded-line"></div>
     <tr>
-        <th>Accession ID</th>
+        <th>Tested Element(s)</th>
         <th>Effect Size</th>
         <th>Direction</th>
         <th>Significance</th>
         <th>Experiment</th>
-        <th>Source</th>
+        <th>REO Page</th>
     </tr>
-    {% for regeffect in features %} {% for re_source in regeffect.sources.all %}
+    {% for regeffect in features %}
+    {% for re_source in regeffect.sources.all %}
     <tr>
+        <td>
+            <a href="{% url 'search:dna_features' 'accession' re_source.accession_id %}"
+                >{{ re_source.get_feature_type_display }} ({{ re_source.chrom_name }}: {{ re_source.location.lower|intcomma }}-{{ re_source.location.upper|intcomma }})</a
+            >
+        </td>
         {% if forloop.first %}
         <td rowspan="{% firstof regeffect.sources.all|length 1 %}" scope="rowgroup">
             <a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.accession_id }}</a>
@@ -108,25 +116,33 @@
                 >{{ regeffect.experiment.name }}</a
             >
         </td>
-        {% endif %}
-        <td>
-            <a href="{% url 'search:dna_features' 'accession' re_source.accession_id %}"
-                >{{ re_source.accession_id }}</a
-            >
+        <td rowspan="{% firstof regeffect.sources.all|length 1 %}" scope="rowgroup">
+            <a href="{% url 'search:reg_effect' regeffect.accession_id %}">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="svg-link-arrow bi bi-arrow-up-right-square-fill" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm5.854 8.803a.5.5 0 1 1-.708-.707L9.243 6H6.475a.5.5 0 1 1 0-1h3.975a.5.5 0 0 1 .5.5v3.975a.5.5 0 1 1-1 0V6.707l-4.096 4.096z"/>
+              </svg>
+            </a>
         </td>
+        {% endif %}
     </tr>
     {% empty %}
     <tr>
-        <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.accession_id }}</a></td>
+        <td>-</td>
         <td>{{ regeffect.effect_size }}</td>
         <td>{{ regeffect.direction }}</td>
         <td>{{ regeffect.significance }}</td>
         <td>
             <a href="{% url 'search:experiment' regeffect.experiment.accession_id %}"
-                >{{ regeffect.experiment.name }}</a
+            >{{ regeffect.experiment.name }}</a
             >
         </td>
-        <td>-</td>
+        <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="svg-link-arrow bi bi-arrow-up-right-square-fill" viewBox="0 0 16 16">
+                <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm5.854 8.803a.5.5 0 1 1-.708-.707L9.243 6H6.475a.5.5 0 1 1 0-1h3.975a.5.5 0 0 1 .5.5v3.975a.5.5 0 1 1-1 0V6.707l-4.096 4.096z"/>
+            </svg>
+            </a>
+        </td>
     </tr>
-    {% endfor %} {% endfor %}
+    {% endfor %}
+    {% endfor %}
 </table>


### PR DESCRIPTION
Targeting REO tables now have information about the type and location of the sources of the REO. They also have explicit links to the REO that don't show the REO accession ID.

![Screenshot 2023-10-10 at 1 32 52 PM](https://github.com/ReddyLab/cegs-portal/assets/719958/48b1a857-cd79-4d2d-826c-ed3018c727de)
