### PR TITLE
Clean up reg effect page

### DIFF
--- a/cegs_portal/search/json_templates/v1/feature_reg_effects.py
+++ b/cegs_portal/search/json_templates/v1/feature_reg_effects.py
@@ -13,7 +13,7 @@ RegulatoryEffectObservationJson = TypedDict(
         "significance": Optional[float],
         "raw_p_value": Optional[float],
         "experiment": NotRequired[ExperimentJson],
-        "sources": list[tuple[str, str, tuple[int, int], str]],
+        "sources": list[tuple[str, str, tuple[int, int, str], str]],
         "targets": list[tuple[str, str]],
     },
 )
@@ -32,7 +32,7 @@ def regulatory_effect(
             (
                 source.accession_id,
                 source.chrom_name,
-                (source.location.lower, source.location.upper),
+                (source.location.lower, source.location.upper, source.strand),
                 source.get_feature_type_display(),
             )
             for source in reg_effect.sources.all()

--- a/cegs_portal/search/json_templates/v1/tests/test_feature_reg_effects.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_feature_reg_effects.py
@@ -39,7 +39,7 @@ def test_regulatory_effect(reg_effect: RegulatoryEffectObservation):
             (
                 source.accession_id,
                 source.chrom_name,
-                (source.location.lower, source.location.upper),
+                (source.location.lower, source.location.upper, source.strand),
                 source.get_feature_type_display(),
             )
             for source in reg_effect.sources.all()

--- a/cegs_portal/search/static/search/js/tables.js
+++ b/cegs_portal/search/static/search/js/tables.js
@@ -166,7 +166,9 @@ function reTargetTable(regeffects, regionID = "regeffect") {
                           e(
                               "a",
                               {href: `/search/feature/accession/${source_id}`},
-                              `${source_type} (${source_chrom}: ${source_loc[0].toLocaleString()}-${source_loc[1].toLocaleString()})`
+                              `${source_type} (${source_chrom}: ${source_loc[0].toLocaleString()}-${source_loc[1].toLocaleString()}:${
+                                  source_loc[2]
+                              })`
                           )
                       ),
                 e(

--- a/cegs_portal/search/templates/search/v1/partials/_reg_effect_source.html
+++ b/cegs_portal/search/templates/search/v1/partials/_reg_effect_source.html
@@ -1,0 +1,17 @@
+{% load humanize %}
+<div>
+    <table class="reg_data-table">
+        <tr>
+            <th>Element</th>
+            <th>Closest Gene</th>
+            <th>Reference Genome</th>
+        </tr>
+        {% for feature in features %}
+            <tr class="data-row" data-href="{% url 'search:dna_features' 'accession' feature.accession_id %}">
+                <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}">{{ feature.get_feature_type_display }} (<span>{{ feature.chrom_name }}</span>: <span>{{ feature.location.lower|intcomma }}-{{ feature.location.upper|add:"-1"|intcomma }}</span>:{{ feature.strand }})</a></td>
+                <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}">{{ feature.closest_gene_name }} ({{ feature.closest_gene_ensembl_id }})</a>{% else %}N/A{% endif %}</td>
+                <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>

--- a/cegs_portal/search/templates/search/v1/partials/_reg_effect_target.html
+++ b/cegs_portal/search/templates/search/v1/partials/_reg_effect_target.html
@@ -1,0 +1,17 @@
+{% load humanize %}
+<div>
+    <table class="reg_data-table">
+        <tr>
+            <th>Name</th>
+            <th>Location</th>
+            <th>Reference Genome</th>
+        </tr>
+        {% for feature in features %}
+            <tr class="data-row" data-href="{% url 'search:dna_features' 'accession' feature.accession_id %}">
+                <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}">{{ feature.name }}</a></td>
+                <td><span>{{ feature.chrom_name }}</span>: <span>{{ feature.location.lower|intcomma }}-{{ feature.location.upper|add:"-1"|intcomma }}</span>:{{ feature.strand }}</td>
+                <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>

--- a/cegs_portal/search/templates/search/v1/reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/reg_effect.html
@@ -162,37 +162,37 @@
         </table>
     </div>
 
-        {% if regulatory_effect.targets.exists %}
-        <div class="reg-effect-content-container">
-            <div class="table-title flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-icon mr-1.5">
-                    <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
-                    <path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM241 119c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l31 31H120c-13.3 0-24 10.7-24 24s10.7 24 24 24H238.1l-31 31c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l72-72c9.4-9.4 9.4-24.6 0-33.9l-72-72z"/>
-                </svg>
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="svg-icon mr-1.5">
-                    <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
-                    <path d="M416 0c17.7 0 32 14.3 32 32c0 59.8-30.3 107.5-69.4 146.6c-28 28-62.5 53.5-97.3 77.4l-2.5 1.7c-11.9 8.1-23.8 16.1-35.5 23.9l0 0 0 0 0 0-1.6 1c-6 4-11.9 7.9-17.8 11.9c-20.9 14-40.8 27.7-59.3 41.5H283.3c-9.8-7.4-20.1-14.7-30.7-22.1l7-4.7 3-2c15.1-10.1 30.9-20.6 46.7-31.6c25 18.1 48.9 37.3 69.4 57.7C417.7 372.5 448 420.2 448 480c0 17.7-14.3 32-32 32s-32-14.3-32-32H64c0 17.7-14.3 32-32 32s-32-14.3-32-32c0-59.8 30.3-107.5 69.4-146.6c28-28 62.5-53.5 97.3-77.4c-34.8-23.9-69.3-49.3-97.3-77.4C30.3 139.5 0 91.8 0 32C0 14.3 14.3 0 32 0S64 14.3 64 32H384c0-17.7 14.3-32 32-32zM338.6 384H109.4c-10.1 10.6-18.6 21.3-25.5 32H364.1c-6.8-10.7-15.3-21.4-25.5-32zM109.4 128H338.6c10.1-10.7 18.6-21.3 25.5-32H83.9c6.8 10.7 15.3 21.3 25.5 32zm55.4 48c18.4 13.8 38.4 27.5 59.3 41.5c20.9-14 40.8-27.7 59.3-41.5H164.7z"/>
-                </svg>
-                Target Genes
-            </div>
-            <div class="faded-line"></div>
-            {% include "search/v1/partials/_features.html" with features=regulatory_effect.targets.all %}
+    {% if regulatory_effect.sources.exists %}
+    <div class="reg-effect-content-container">
+        <div class="table-title flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512" class="svg-icon mr-1.5">
+                <!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+                <path d="M315.4 15.5C309.7 5.9 299.2 0 288 0s-21.7 5.9-27.4 15.5l-96 160c-5.9 9.9-6.1 22.2-.4 32.2s16.3 16.2 27.8 16.2H384c11.5 0 22.2-6.2 27.8-16.2s5.5-22.3-.4-32.2l-96-160zM288 312V456c0 22.1 17.9 40 40 40H472c22.1 0 40-17.9 40-40V312c0-22.1-17.9-40-40-40H328c-22.1 0-40 17.9-40 40zM128 512a128 128 0 1 0 0-256 128 128 0 1 0 0 256z"/>
+            </svg>
+            Tested Elements
         </div>
-        {% endif %}
+        <div class="faded-line"></div>
+        {% include "search/v1/partials/_reg_effect_source.html" with features=regulatory_effect.sources.all %}
+    </div>
+    {% endif %}
 
-        {% if regulatory_effect.sources.exists %}
-        <div class="reg-effect-content-container">
-            <div class="table-title flex items-center justify-center">
-                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512" class="svg-icon mr-1.5">
-                    <!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
-                    <path d="M315.4 15.5C309.7 5.9 299.2 0 288 0s-21.7 5.9-27.4 15.5l-96 160c-5.9 9.9-6.1 22.2-.4 32.2s16.3 16.2 27.8 16.2H384c11.5 0 22.2-6.2 27.8-16.2s5.5-22.3-.4-32.2l-96-160zM288 312V456c0 22.1 17.9 40 40 40H472c22.1 0 40-17.9 40-40V312c0-22.1-17.9-40-40-40H328c-22.1 0-40 17.9-40 40zM128 512a128 128 0 1 0 0-256 128 128 0 1 0 0 256z"/>
-                </svg>
-                Source Features
-            </div>
-            <div class="faded-line"></div>
-            {% include "search/v1/partials/_features.html" with features=regulatory_effect.sources.all %}
+    {% if regulatory_effect.targets.exists %}
+    <div class="reg-effect-content-container">
+        <div class="table-title flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-icon mr-1.5">
+                <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+                <path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM241 119c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l31 31H120c-13.3 0-24 10.7-24 24s10.7 24 24 24H238.1l-31 31c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l72-72c9.4-9.4 9.4-24.6 0-33.9l-72-72z"/>
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="svg-icon mr-1.5">
+                <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->
+                <path d="M416 0c17.7 0 32 14.3 32 32c0 59.8-30.3 107.5-69.4 146.6c-28 28-62.5 53.5-97.3 77.4l-2.5 1.7c-11.9 8.1-23.8 16.1-35.5 23.9l0 0 0 0 0 0-1.6 1c-6 4-11.9 7.9-17.8 11.9c-20.9 14-40.8 27.7-59.3 41.5H283.3c-9.8-7.4-20.1-14.7-30.7-22.1l7-4.7 3-2c15.1-10.1 30.9-20.6 46.7-31.6c25 18.1 48.9 37.3 69.4 57.7C417.7 372.5 448 420.2 448 480c0 17.7-14.3 32-32 32s-32-14.3-32-32H64c0 17.7-14.3 32-32 32s-32-14.3-32-32c0-59.8 30.3-107.5 69.4-146.6c28-28 62.5-53.5 97.3-77.4c-34.8-23.9-69.3-49.3-97.3-77.4C30.3 139.5 0 91.8 0 32C0 14.3 14.3 0 32 0S64 14.3 64 32H384c0-17.7 14.3-32 32-32zM338.6 384H109.4c-10.1 10.6-18.6 21.3-25.5 32H364.1c-6.8-10.7-15.3-21.4-25.5-32zM109.4 128H338.6c10.1-10.7 18.6-21.3 25.5-32H83.9c6.8 10.7 15.3 21.3 25.5 32zm55.4 48c18.4 13.8 38.4 27.5 59.3 41.5c20.9-14 40.8-27.7 59.3-41.5H164.7z"/>
+            </svg>
+            Target Genes
         </div>
-        {% endif %}
+        <div class="faded-line"></div>
+        {% include "search/v1/partials/_reg_effect_target.html" with features=regulatory_effect.targets.all %}
+    </div>
+    {% endif %}
     {% endspaceless %}
 </div>
 {% endblock content %}


### PR DESCRIPTION
Swap location of source/target tables

removes many extraneous columns

Uses "element" or "tested element" instead of "source"

![Screenshot 2023-10-10 at 1 55 35 PM](https://github.com/ReddyLab/cegs-portal/assets/719958/08b34d45-109e-4780-a4f2-20215f2a2ef9)
