### PR TITLE
Adds UI for when no exp. coverage found

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -96,6 +96,15 @@ async function getCoverageData(staticRoot, exprAccessionID, analysisAccessionID)
             `${staticRoot}search/experiments/${exprAccessionID}/${analysisAccessionID}/${manifest.genome.file}`
         );
     } catch (error) {
+        let coverage = g("tabs-coverage");
+        rc(
+            coverage,
+            e(
+                "div",
+                {class: "flex flex-row justify-center"},
+                e("div", {class: "content-container grow-0"}, "No experiment coverage information found.")
+            )
+        );
         throw new Error("Files necessary to load coverage not found");
     }
 


### PR DESCRIPTION
When no experiment coverage data is found the UI is modified so the user knows that it's probably on purpose.

![Screenshot 2023-10-10 at 2 40 20 PM](https://github.com/ReddyLab/cegs-portal/assets/719958/4a9e67ca-3377-4e8f-b316-babfe09136e0)
