### PR TITLE
Add new methods for selecting experiments

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/downloads.js
+++ b/cegs_portal/search/static/search/js/exp_viz/downloads.js
@@ -24,7 +24,10 @@ function getDownload(url, body) {
                         filePath =
                             filePath.substring(0, 15) + "…" + filePath.substring(filePath.length - 15, filePath.length);
                     }
-                    rc(g("dataDownloadLink"), e("a", {href: json["file location"]}, t(filePath)));
+                    rc(
+                        g("dataDownloadLink"),
+                        e("a", {href: json["file location"], class: "text-blue-700"}, t(filePath))
+                    );
                 } else if (status == "in_preparation") {
                     // keep spinning
                 } else {

--- a/cegs_portal/search/static/search/js/experiment_list/download_data.js
+++ b/cegs_portal/search/static/search/js/experiment_list/download_data.js
@@ -1,11 +1,24 @@
-import {g} from "../dom.js";
+import {g, rc, t} from "../dom.js";
 import {getDownloadRegions} from "../exp_viz/downloads.js";
 
 export function downloadDataSetup(csrfToken) {
     let dataDownloadInput = g("dataDownloadInput");
     dataDownloadInput.addEventListener(
         "change",
-        () => getDownloadRegions(null, dataDownloadInput, JSON.parse(g("experiment-id-list").textContent), csrfToken),
+        () => {
+            let experimentListItems = document.getElementsByClassName("experiment-list-item");
+            if (experimentListItems.length == 0) {
+                rc(g("dataDownloadLink"), t("Please select at least one experiment."));
+                return;
+            }
+
+            getDownloadRegions(
+                null,
+                dataDownloadInput,
+                Array.from(experimentListItems, (item) => item.dataset.accession),
+                csrfToken
+            );
+        },
         false
     );
 }

--- a/cegs_portal/search/static/search/js/experiment_list/drag_drop.js
+++ b/cegs_portal/search/static/search/js/experiment_list/drag_drop.js
@@ -1,0 +1,114 @@
+import {a, cc, e, g, rc, t} from "../dom.js";
+
+function closeButton() {
+    return e(
+        "span",
+        {class: "close-button inline-block mr-2"},
+        e(
+            "svg",
+            {
+                xmlns: "http://www.w3.org/2000/svg",
+                width: "24",
+                height: "24",
+                fill: "currentColor",
+                class: "bi bi-x-lg",
+                viewBox: "0 0 16 16",
+            },
+            e(
+                "path",
+                {
+                    d: "M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z",
+                },
+                []
+            )
+        )
+    );
+}
+
+function addRemoveListener(node, accession) {
+    node.addEventListener("click", (evt) => {
+        g(`${accession}-list-item`).remove();
+
+        let experimentListItems = document.getElementsByClassName("experiment-list-item");
+        if (experimentListItems.length == 0) {
+            let noExperiments = e(
+                "div",
+                {class: "italic", id: "no-selected-experiments"},
+                "Drag experiments here to select"
+            );
+            g("selected-experiment-list").before(noExperiments);
+
+            rc(g("dataDownloadLink"), t("Please select at least one experiment."));
+        }
+    });
+}
+
+function addToExperimentList(experimentItemText) {
+    let wrapper = e("template");
+    wrapper.innerHTML = experimentItemText;
+    let experimentItem = wrapper.content.firstChild;
+    let selectedExperimentList = g("selected-experiment-list");
+
+    // Don't add an experiment more than once
+    let newAccession = experimentItem.dataset.accession;
+    let experimentListItems = document.getElementsByClassName("experiment-list-item");
+    let accessionIds = Array.from(experimentListItems, (item) => item.dataset.accession);
+    if (accessionIds.includes(newAccession)) return;
+
+    let close = closeButton();
+    addRemoveListener(close, newAccession);
+    experimentItem.before(close);
+    a(selectedExperimentList, e("div", {id: `${newAccession}-list-item`}, [close, experimentItem]));
+    cc(g("dataDownloadLink"));
+}
+
+export function addDropListeners() {
+    let selectedExperiments = g("selected-experiments");
+    selectedExperiments.addEventListener("dragover", (evt) => {
+        evt.preventDefault();
+        evt.dataTransfer.dropEffect = "copy";
+    });
+    selectedExperiments.addEventListener("drop", (evt) => {
+        evt.preventDefault();
+        let noExperiments = g("no-selected-experiments");
+        if (noExperiments) {
+            noExperiments.remove();
+        }
+
+        addToExperimentList(evt.dataTransfer.getData("text/html"));
+    });
+}
+
+function experimentListItemText(name, accession) {
+    return `<span class="experiment-list-item" data-accession="${accession}"><span class="name">${name}</span> <span class="accession-id">${accession}</span></span>`;
+}
+
+export function addSelectListeners() {
+    let experimentSummaries = document.getElementsByClassName("select-experiment");
+
+    for (let summary of experimentSummaries) {
+        summary.addEventListener("click", (evt) => {
+            evt.preventDefault();
+            addToExperimentList(experimentListItemText(evt.target.dataset.name, evt.target.dataset.accession));
+
+            let noExperiments = g("no-selected-experiments");
+            if (noExperiments) {
+                noExperiments.remove();
+            }
+        });
+    }
+}
+
+export function addDragListeners() {
+    let experimentSummaries = document.getElementsByClassName("experiment-summary");
+
+    for (let summary of experimentSummaries) {
+        summary.addEventListener("dragstart", (evt) => {
+            evt.dataTransfer.setData("text/plain", `${evt.target.dataset.name} (${evt.target.dataset.accession})`);
+            evt.dataTransfer.setData(
+                "text/html",
+                experimentListItemText(evt.target.dataset.name, evt.target.dataset.accession)
+            );
+        });
+    }
+}

--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -1,5 +1,6 @@
 import {e, g, rc} from "../dom.js";
 import {getJson} from "../files.js";
+import {addDragListeners, addSelectListeners} from "./drag_drop.js";
 
 export function facetFilterSetup() {
     let facetCheckboxes = g("categorical-facets").querySelectorAll("input[type=checkbox]");
@@ -15,27 +16,48 @@ export function facetFilterSetup() {
                 let experimentNodes = response_json["experiments"].map((expr) => {
                     return e(
                         "a",
-                        {href: `/search/experiment/${expr.accession_id}`, class: "content-container-link"},
-                        e("div", {class: "content-container"}, [
-                            e("div", {class: "name"}, expr.name),
-                            e("div", {class: "description"}, expr.description),
-                            e("div", {class: "flex justify-between"}, [
-                                e(
-                                    "div",
-                                    {class: "cell-lines"},
-                                    `Cell Lines: ${expr.biosamples.map((b) => b.cell_line).join(", ")}`
-                                ),
-                                e("div", {class: "accession-id"}, expr.accession_id),
-                            ]),
-                        ])
+                        {
+                            href: `/search/experiment/${expr.accession_id}`,
+                            class: "content-container-link experiment-summary",
+                            "data-accession": expr.accession_id,
+                            "data-name": expr.name,
+                        },
+                        e(
+                            "div",
+                            {
+                                class: "content-container",
+                            },
+                            [
+                                e("div", {class: "flex justify-between"}, [
+                                    e("div", {class: "name"}, expr.name),
+                                    e(
+                                        "div",
+                                        {
+                                            class: "select-experiment font-bold text-2xl",
+                                            title: "Select Experiment",
+                                            "data-accession": expr.accession_id,
+                                            "data-name": expr.name,
+                                        },
+                                        "＋"
+                                    ),
+                                ]),
+                                e("div", {class: "description"}, expr.description),
+                                e("div", {class: "flex justify-between"}, [
+                                    e(
+                                        "div",
+                                        {class: "cell-lines"},
+                                        `Cell Lines: ${expr.biosamples.map((b) => b.cell_line).join(", ")}`
+                                    ),
+                                    e("div", {class: "accession-id"}, expr.accession_id),
+                                ]),
+                            ]
+                        )
                     );
                 });
                 rc(experimentListNode, experimentNodes);
 
-                let experimentIdList = g("experiment-id-list");
-                experimentIdList.textContent = JSON.stringify(
-                    response_json["experiments"].map((expr) => expr.accession_id)
-                );
+                addDragListeners();
+                addSelectListeners();
             });
         });
     });

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -107,24 +107,35 @@
                     {% endfor %}
                 </div>
             </div>
+            <div class="content-container" id="selected-experiments">
+                <div class="text-xl font-bold text-slate-500">Selected Experiments</div>
+                <div class="title-separator"></div>
+                <div class="italic" id="no-selected-experiments">Drag experiments here to select</div>
+                <div id="selected-experiment-list"></div>
+            </div>
             {% if logged_in %}
             <div class="content-container">
+                <div class="text-xl font-bold text-slate-500">Download Data from Selected Experiments</div>
+                <div class="title-separator"></div>
                 <form name="dataDownloadForm">
                     <div>
-                        <label class="font-bold" for="dataDlFile">Download Data from Selected Experiments</label>
+                        <label class="font-bold" for="dataDlFile">Select a .bed File with Regions of Interest</label>
                         <input id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
                     </div>
                 </form>
-                <div id="dataDownloadLink" class="mt-5 mb-5"></div>
+                <div id="dataDownloadLink" class="mt-5 mb-5">Please select at least one experiment.</div>
             </div>
             {% endif %}
         </div>
 
         <div id="experiment-list" class="basis-3/4">
             {% for experiment in experiments %}
-            <a href="{% url 'search:experiment' experiment.accession_id %}" class="content-container-link">
+            <a href="{% url 'search:experiment' experiment.accession_id %}" class="content-container-link experiment-summary" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">
                 <div class="content-container">
-                    <div class="name">{{ experiment.name }}</div>
+                    <div class="flex justify-between">
+                        <div class="name">{{ experiment.name }}</div>
+                        <div class="select-experiment font-bold text-2xl" title="Select Experiment" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">＋</div>
+                    </div>
                     <div class="description">{{ experiment.description }}</div>
                     <div class="flex justify-between">
                         <div class="cell-lines">Cell Lines: {{ experiment.cell_lines }}</div>
@@ -142,11 +153,13 @@
 {% block inline_javascript %}
 <script type="module">
     import { facetFilterSetup } from "{% static 'search/js/experiment_list/facet_filter.js' %}";
+    import { addDragListeners, addDropListeners, addSelectListeners } from "{% static 'search/js/experiment_list/drag_drop.js' %}";
     facetFilterSetup();
+    addDropListeners();
+    addDragListeners();
+    addSelectListeners();
 </script>
 {% if logged_in %}
-{{ experiment_ids|json_script:"experiment-id-list" }}
-
 <script type="module">
     import { downloadDataSetup } from "{% static 'search/js/experiment_list/download_data.js' %}";
     downloadDataSetup("{{ csrf_token }}");


### PR DESCRIPTION
Instead of experiments on the experiment list page being implicitly selected just by existing a user must explicitly select them.

Users can do this two ways: drag the experiment on to the selection area or click the "plus" on the experiment.

Experiments can be removed from the selection area by clicking the "X"

Users cannot download data unless at least one experiment is selected.

<img width="1536" alt="Screenshot 2023-10-12 at 4 08 39 PM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/82d634db-06ff-4456-b495-73cf423c17b6">
<img width="1536" alt="Screenshot 2023-10-12 at 4 08 33 PM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/5239fece-4c82-4a9e-bce7-048155ba2f07">
