### PR TITLE
Adds basic "multi-experiment analysis page"

### DIFF
--- a/cegs_portal/search/static/search/js/experiment_list/drag_drop.js
+++ b/cegs_portal/search/static/search/js/experiment_list/drag_drop.js
@@ -39,6 +39,11 @@ function addRemoveListener(node, accession) {
             g("selected-experiment-list").before(noExperiments);
 
             rc(g("dataDownloadLink"), t("Please select at least one experiment."));
+
+            let experiments_link = g("experiments-link");
+            if (experiments_link) {
+                rc(experiments_link, t("Please select at least one experiment."));
+            }
         }
     });
 }
@@ -53,13 +58,39 @@ function addToExperimentList(experimentItemText) {
     let newAccession = experimentItem.dataset.accession;
     let experimentListItems = document.getElementsByClassName("experiment-list-item");
     let accessionIds = Array.from(experimentListItems, (item) => item.dataset.accession);
-    if (accessionIds.includes(newAccession)) return;
+    if (accessionIds.includes(newAccession)) {
+        return;
+    } else {
+        accessionIds.push(newAccession);
+    }
 
     let close = closeButton();
     addRemoveListener(close, newAccession);
     experimentItem.before(close);
     a(selectedExperimentList, e("div", {id: `${newAccession}-list-item`}, [close, experimentItem]));
     cc(g("dataDownloadLink"));
+
+    let noExperiments = g("no-selected-experiments");
+    if (noExperiments) {
+        noExperiments.remove();
+    }
+
+    let experiments_link = g("experiments-link");
+    if (experiments_link) {
+        rc(
+            experiments_link,
+            e(
+                "a",
+                {
+                    href: `experiments?${accessionIds.map((id) => `exp=${id}`).join("&")}`,
+                    class: "expr-list-link",
+                },
+                `Analyze ${accessionIds.length} Selected ${
+                    accessionIds.length > 1 ? "Experiments together" : "Experiment"
+                }`
+            )
+        );
+    }
 }
 
 export function addDropListeners() {
@@ -70,11 +101,6 @@ export function addDropListeners() {
     });
     selectedExperiments.addEventListener("drop", (evt) => {
         evt.preventDefault();
-        let noExperiments = g("no-selected-experiments");
-        if (noExperiments) {
-            noExperiments.remove();
-        }
-
         addToExperimentList(evt.dataTransfer.getData("text/html"));
     });
 }
@@ -90,11 +116,6 @@ export function addSelectListeners() {
         summary.addEventListener("click", (evt) => {
             evt.preventDefault();
             addToExperimentList(experimentListItemText(evt.target.dataset.name, evt.target.dataset.accession));
-
-            let noExperiments = g("no-selected-experiments");
-            if (noExperiments) {
-                noExperiments.remove();
-            }
         });
     }
 }

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
+
 {% load static i18n %}
+{% load waffle_tags %}
+
 {% block css %}
 {{ block.super }}
 <style>
@@ -39,6 +42,16 @@
     .name {
         color: #3490dc;
         font-weight: bold;
+    }
+
+    .expr-list-link {
+        color: #3490dc;
+        font-style: normal;
+    }
+
+    .expr-list-link:visited {
+        color: #3490dc;
+        font-style: normal;
     }
 
     .cell-lines {
@@ -113,6 +126,13 @@
                 <div class="italic" id="no-selected-experiments">Drag experiments here to select</div>
                 <div id="selected-experiment-list"></div>
             </div>
+            {% switch "multi_expr_page" %}
+            <div class="content-container" id="view-experiments">
+                <div class="text-xl font-bold text-slate-500">Analyze Multiple Experiments</div>
+                <div class="title-separator"></div>
+                <div class="italic" id="experiments-link">Please select at least one experiment.</div>
+            </div>
+            {% endswitch %}
             {% if logged_in %}
             <div class="content-container">
                 <div class="text-xl font-bold text-slate-500">Download Data from Selected Experiments</div>
@@ -123,7 +143,7 @@
                         <input id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
                     </div>
                 </form>
-                <div id="dataDownloadLink" class="mt-5 mb-5">Please select at least one experiment.</div>
+                <div id="dataDownloadLink" class="italic mt-5 mb-5">Please select at least one experiment.</div>
             </div>
             {% endif %}
         </div>

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load static i18n %}
+
+{% block title %}Experiments{% endblock %}
+
+{% block content %}
+<div>
+    <div class="content-container">
+        <ul>
+            {% for expr in experiments %}
+            <li>{{ expr.name }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/cegs_portal/search/urls.py
+++ b/cegs_portal/search/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
         name="dna_feature_loc",
     ),
     path("experiment", views.v1.ExperimentListView.as_view(), name="experiments"),
+    path("experiments", views.v1.ExperimentsView.as_view(), name="combined_experiments"),
     re_path(r"experiment/(?P<exp_id>DCPEXPR[A-F0-9]{8})$", views.v1.ExperimentView.as_view(), name="experiment"),
     path(
         "experiment_coverage",
@@ -54,6 +55,7 @@ urlpatterns = [
         views.v1.DNAFeatureLoc.as_view(),
     ),
     path("v1/experiment", views.v1.ExperimentListView.as_view()),
+    path("v1/experiments", views.v1.ExperimentListView.as_view()),
     re_path(r"v1/experiment/(?P<exp_id>DCPEXPR[A-F0-9]{8})$", views.v1.ExperimentView.as_view()),
     path(
         "v1/experiment_coverage",

--- a/cegs_portal/search/view_models/v1/experiment.py
+++ b/cegs_portal/search/view_models/v1/experiment.py
@@ -27,12 +27,26 @@ class ExperimentSearch:
         return cast(bool, experiment[0])
 
     @classmethod
-    def accession_search(cls, accession_id):
+    def experiment_statuses(cls, expr_ids: list[str]) -> bool:
+        experiments = Experiment.objects.filter(accession_id__in=expr_ids).values_list(
+            "accession_id", "public", "archived"
+        )
+
+        if len(experiments) == 0:
+            raise ObjectNotFoundError(f"Experiments {expr_ids} not found")
+
+        return experiments
+
+    @classmethod
+    def accession_search(cls, accession_id: str):
+        return cls.multi_accession_search([accession_id]).first()
+
+    @classmethod
+    def multi_accession_search(cls, accession_ids: list[str]):
         experiment = (
-            Experiment.objects.filter(accession_id=accession_id)
+            Experiment.objects.filter(accession_id__in=accession_ids)
             .select_related("default_analysis")
             .prefetch_related("data_files", "biosamples__cell_line", "biosamples__cell_line__tissue_type", "files")
-            .first()
         )
         return experiment
 

--- a/cegs_portal/search/views/custom_views.py
+++ b/cegs_portal/search/views/custom_views.py
@@ -48,7 +48,7 @@ class ExperimentAccessMixin(UserPassesTestMixin):
 
     def test_func(self):
         if self.is_archived():
-            self.raise_exception = True
+            self.raise_exception = True  # Don't redirect to login
             return False
 
         if self.is_public():

--- a/cegs_portal/search/views/v1/__init__.py
+++ b/cegs_portal/search/views/v1/__init__.py
@@ -1,5 +1,5 @@
 from .dna_features import DNAFeatureId, DNAFeatureLoc
-from .experiment import ExperimentListView, ExperimentView
+from .experiment import ExperimentListView, ExperimentsView, ExperimentView
 from .experiment_coverage import ExperimentCoverageView
 from .non_targeting_reos import NonTargetRegEffectsView
 from .reg_effects import RegEffectView, SourceEffectsView, TargetEffectsView

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -1,6 +1,8 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.http import Http404
 
 from cegs_portal.search.json_templates.v1.experiment import experiment, experiments
+from cegs_portal.search.models.validators import validate_accession_id
 from cegs_portal.search.view_models.errors import ObjectNotFoundError
 from cegs_portal.search.view_models.v1 import ExperimentSearch
 from cegs_portal.search.views.custom_views import (
@@ -67,6 +69,64 @@ class ExperimentView(ExperimentAccessMixin, TemplateJsonView):
         setattr(experi, "assemblies", experi_assemblies)
 
         return experi, other_experiments
+
+
+class ExperimentsView(UserPassesTestMixin, TemplateJsonView):
+    template = "search/v1/experiments.html"
+
+    def test_func(self):
+        experiment_ids = self.request.GET.getlist("exp", [])
+        for expr_id in experiment_ids:
+            validate_accession_id(expr_id)
+
+        try:
+            experiments = ExperimentSearch.experiment_statuses(experiment_ids)
+        except ObjectNotFoundError as e:
+            raise Http404(str(e))
+
+        if any(archived for _, _, archived in experiments):
+            self.raise_exception = True
+            return False
+
+        if all(public for _, public, _ in experiments):
+            return True
+
+        if self.request.user.is_anonymous:
+            return False
+
+        private_experiments = {accession_id for accession_id, public, _ in experiments if not public}
+
+        return (
+            self.request.user.is_superuser
+            or self.request.user.is_portal_admin
+            or private_experiments <= set(self.request.user.all_experiments())
+        )
+
+    def request_options(self, request):
+        """
+        GET queries used:
+            exp (multiple)
+                * Should be a valid experiment accession ID
+        """
+        options = super().request_options(request)
+        options["exp_ids"] = request.GET.getlist("exp", [])
+        for expr in options["exp_ids"]:
+            validate_accession_id(expr)
+
+        return options
+
+    def get(self, request, options, data):
+        return super().get(
+            request,
+            options,
+            {
+                "logged_in": not request.user.is_anonymous,
+                "experiments": data,
+            },
+        )
+
+    def get_data(self, options):
+        return ExperimentSearch.multi_accession_search(options["exp_ids"])
 
 
 class ExperimentListView(TemplateJsonView):

--- a/cegs_portal/search/views/v1/tests/test_experiments.py
+++ b/cegs_portal/search/views/v1/tests/test_experiments.py
@@ -1,0 +1,70 @@
+import pytest
+from django.test import Client
+
+from cegs_portal.conftest import SearchClient
+from cegs_portal.search.models import Experiment
+
+pytestmark = pytest.mark.django_db
+
+
+def test_experiments(client: Client):
+    response = client.get("/search/experiments")
+
+    # Maybe a 404 isn't quite the right
+    assert response.status_code == 400
+
+
+def test_experiment_list_with_anonymous_client(access_control_experiments, client: Client):
+    public, private, archived = access_control_experiments
+    response = client.get(f"/search/experiments?exp={public.accession_id}")
+    assert response.status_code == 200
+
+    response = client.get(f"/search/experiments?exp={private.accession_id}")
+    assert response.status_code == 302  # Redirect to login
+
+    response = client.get(f"/search/experiments?exp={archived.accession_id}")
+    assert response.status_code == 403
+
+
+def test_experiment_list_with_authenticated_client(access_control_experiments, login_client: SearchClient):
+    public, private, archived = access_control_experiments
+    response = login_client.get(f"/search/experiments?exp={public.accession_id}")
+    assert response.status_code == 200
+
+    response = login_client.get(f"/search/experiments?exp={private.accession_id}")
+    assert response.status_code == 403
+
+    response = login_client.get(f"/search/experiments?exp={archived.accession_id}")
+    assert response.status_code == 403
+
+
+def test_experiment_list_with_authenticated_authorized_client(
+    login_client: SearchClient, access_control_experiments: tuple[Experiment, Experiment, Experiment]
+):
+    public, private, archived = access_control_experiments
+
+    login_client.set_user_experiments([private.accession_id, archived.accession_id])
+    response = login_client.get(f"/search/experiments?exp={public.accession_id}&exp={private.accession_id}")
+    assert response.status_code == 200
+
+    login_client.set_user_experiments([private.accession_id, archived.accession_id])
+    response = login_client.get(
+        f"/search/experiments?exp={public.accession_id}&exp={private.accession_id}&exp={archived.accession_id}"
+    )
+    assert response.status_code == 403
+
+
+def test_experiment_list_with_authenticated_authorized_group_client(
+    group_login_client: Client, access_control_experiments: tuple[Experiment, Experiment, Experiment]
+):
+    public, private, archived = access_control_experiments
+
+    group_login_client.set_group_experiments([private.accession_id, archived.accession_id])
+    response = group_login_client.get(f"/search/experiments?exp={public.accession_id}&exp={private.accession_id}")
+    assert response.status_code == 200
+
+    group_login_client.set_user_experiments([private.accession_id, archived.accession_id])
+    response = group_login_client.get(
+        f"/search/experiments?exp={public.accession_id}&exp={private.accession_id}&exp={archived.accession_id}"
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
Currently this page does nothing but show some experiment names.

This adds a link to the experiment list page, behind a feature flag, to go to the new experiments page. The link only shows when there is at least one selected experiment.

The new experiment page includes validation and authentication so users can't see experiments they aren't meant to nor can they pass arbitrary strings to the database.

To enable the waffle feature flag from the terminal:

    python manager.py waffle_switch --create multi_expr_page on

To disable the flag:

    python manager.py waffle_switch multi_expr_page off

To delete the flag:

    python manager.py waffle_delete --switches multi_expr_page

![Screenshot 2023-10-18 at 9 16 11 AM](https://github.com/ReddyLab/cegs-portal/assets/719958/47c3b8ab-6a81-4c5d-b2e9-19a5b74df718)
<img width="1134" alt="Screenshot 2023-10-17 at 4 59 20 PM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/dd7f1500-ea50-4bc9-b66b-bad804a82ce9">
<img width="1134" alt="Screenshot 2023-10-17 at 4 59 03 PM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/14d7a67d-0caa-4763-8149-ccc27a9bb369">
