### PR TITLE
pytest test_search solution

### DIFF
--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -579,6 +579,8 @@ def test_sigdata(reg_effects, login_client: SearchClient):
     )  # strip out spaces in blank lines
     expected_string = f"""
 <div class="text-xl font-bold">Most Significant Reg Effect Observations</div>
+
+
 <table class="data-table no-hover">
     <tr><th>Enahncer/Gene</th><th>Effect Size</th><th>Significance</th><th>Raw p-value</th><th>Experiment</th></tr>
 


### PR DESCRIPTION
Ran pytest after a few merges and received a few errors. the load custom helpers tag created 2 additional empty lines and they needed to be accounted for on the test_search.py test. The empty lines should resolve the error.