### PR TITLE
Remove all use of "content-container" class

### DIFF
--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -18,14 +18,14 @@ export function facetFilterSetup() {
                         "a",
                         {
                             href: `/search/experiment/${expr.accession_id}`,
-                            class: "content-container-link experiment-summary",
+                            class: "exp-list-content-container-link experiment-summary",
                             "data-accession": expr.accession_id,
                             "data-name": expr.name,
                         },
                         e(
                             "div",
                             {
-                                class: "content-container",
+                                class: "container",
                             },
                             [
                                 e("div", {class: "flex justify-between"}, [

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div>
-    <div class="content-container">
+    <div class="container">
         <ul>
             {% for expr in experiments %}
             <li>{{ expr.name }}</li>

--- a/cegs_portal/search/templates/search/v1/partials/_feature_sig_reg_effects.html
+++ b/cegs_portal/search/templates/search/v1/partials/_feature_sig_reg_effects.html
@@ -2,7 +2,7 @@
 {% load custom_helpers %}
 <div id="modal">
 <div class="modal-underlay" onclick="closeModal()"></div>
-<div class="content-container modal-content" id="feature-sig-reg-effects">
+<div class="container modal-content" id="feature-sig-reg-effects">
     <div class="flex justify-between max-w-full">
         <div class="text-xl font-bold">Significant Reg Effect Observations</div>
         <div class="close-button" onclick="closeModal()">

--- a/cegs_portal/users/templates/users/downloads.html
+++ b/cegs_portal/users/templates/users/downloads.html
@@ -1,14 +1,12 @@
-{% extends "base.html" %} {% load static i18n %} {% block css %} {{ block.super }}
+{% extends "base.html" %}
+
+{% load static i18n %}
+
+{% block css %}
+{{ block.super }}
 <style>
     #nav-searchbar {
         display: none;
-    }
-
-    .content-container {
-        background: #ffffff;
-        padding: 20px 40px;
-        border-radius: 10px;
-        box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
     }
 
     h1 {
@@ -33,10 +31,14 @@
         margin-block-end: 1em;
     }
 </style>
-{% endblock %} {% block title %}Downloads{% endblock %} {% block content %}
+{% endblock %}
+
+{% block title %}Downloads{% endblock %}
+
+{% block content %}
 <div>
 <h1>Download list</h1>
-<div class="content-container">
+<div class="container">
     {% if in_prep|length > 0 %}
     <div class="file-list">
         <h2>In Preperation Files</h2>


### PR DESCRIPTION
The global "container" class should always be used instead.