### PR TITLE
Fixed open tag error

### DIFF
--- a/cegs_portal/search/templates/search/v1/partials/_non_targeting_reo.html
+++ b/cegs_portal/search/templates/search/v1/partials/_non_targeting_reo.html
@@ -28,7 +28,7 @@
             <th class="chrom-light-band">Direction</th>
             <th class="chrom-light-band">Significance<br />(p-value)</th>
             <th class="chrom-light-band chrom-right-centromere">Distance from TSS (bp)</th>
-            <th class="chrom-light-band chrom-left-centromere"Tested Element Type</th>
+            <th class="chrom-light-band chrom-left-centromere">Tested Element Type</th>
             <th class="chrom-last-end-cap chrom-dark-band">Experiment</th>
         </tr>
         {% for reo in non_targeting_reos %}


### PR DESCRIPTION
Table header tag was open. The header name was not being displayed in proximal regulatory effects table.