### PR TITLE
Upload compatible bed file format

### DIFF
--- a/cegs_portal/search/tsv_templates/v1/non_targeting_reos.py
+++ b/cegs_portal/search/tsv_templates/v1/non_targeting_reos.py
@@ -14,17 +14,6 @@ def item_name(source, feature):
 
 def bed6_output(reos, feature):
     tsv_data = []
-    tsv_data.append(
-        [
-            "chrom",
-            "chromStart",
-            "chromEnd",
-            "name",
-            "score",
-            "strand",
-        ]
-    )
-
     for reo in reos:
         for source in reo.sources.all():
             row = [


### PR DESCRIPTION
The UCSC genome browser does not recognize the headers in the file, only the data. Previously you would have to copy and paste the contents to work. Now that the headers are removed, the user can now upload the file.
![image](https://github.com/ReddyLab/cegs-portal/assets/19657615/db910daf-4f09-4604-8bec-6f02f97af7df)
![image](https://github.com/ReddyLab/cegs-portal/assets/19657615/5e282b64-ac49-4046-89d0-ce2dbe903308)
