### PR TITLE
Show combined coverage data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ exp_cov:
 	./scripts/data_generation/gen_experiment_coverage_viz.sh
 
 collectstatic:
-	python manage.py collectstatic -i "*.ecd" -i "*.pd"  # ignore binary files in the static_data directory
+	python manage.py collectstatic -i "*.ecd" -i "*.pd"  -i "*.fd" # ignore binary files in the static_data directory

--- a/cegs_portal/search/json_templates/v1/combined_experiments.py
+++ b/cegs_portal/search/json_templates/v1/combined_experiments.py
@@ -1,0 +1,2 @@
+def combined_experiments(combined_experiments_obj, _options):
+    return combined_experiments_obj

--- a/cegs_portal/search/models/tests/experiment_factory.py
+++ b/cegs_portal/search/models/tests/experiment_factory.py
@@ -95,6 +95,14 @@ class ExperimentFactory(DjangoModelFactory):
             for sample in extracted:
                 self.biosamples.add(sample)  # pylint: disable=no-member
 
+    @post_generation
+    def default_analysis(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        self.default_analysis = self.analyses.first()
+
 
 class ExperimentDataFileInfoFactory(DjangoModelFactory):
     class Meta:

--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -2,36 +2,43 @@ import {a, cc, e, g, rc, t} from "../dom.js";
 import {State} from "../state.js";
 import {getRegions} from "../bed.js";
 import {getJson, postJson} from "../files.js";
-import {Legend} from "./obsLegend.js";
 import {GenomeRenderer} from "./chromosomeSvg.js";
 import {getDownloadRegions, getDownloadAll} from "./downloads.js";
 import {debounce} from "../utils.js";
-
-const STATE_ZOOMED = "state-zoomed";
-const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
-const STATE_SCALE = "state-scale";
-const STATE_SCALE_X = "state-scale-x";
-const STATE_SCALE_Y = "state-scale-y";
-const STATE_VIEWBOX = "state-viewbox";
-const STATE_FACETS = "state-facets";
-const STATE_CATEGORICAL_FACET_VALUES = "state-categorical-facets";
-const STATE_NUMERIC_FACET_VALUES = "state-numeric-facets";
-const STATE_COUNT_FILTER_VALUES = "state-count-filter";
-const STATE_COVERAGE_DATA = "state-coverage-data";
-const STATE_ALL_FILTERED = "state-all-filtered";
-const STATE_NUMERIC_FILTER_INTERVALS = "state-numeric-filter-intervals";
-const STATE_COUNT_FILTER_INTERVALS = "state-count-filter-intervals";
-const STATE_HIGHLIGHT_REGIONS = "state-highlight-regions";
-const STATE_SELECTED_EXPERIMENTS = "state-selected-experiments";
-const STATE_ITEM_COUNTS = "state-item-counts";
-const STATE_SOURCE_TYPE = "state-source-type";
-const STATE_ANALYSIS = "state-analysis";
-const STATE_COVERAGE_TYPE = "state-coverage-type";
-const STATE_LEGEND_INTERVALS = "state-legend-intervals";
-
-const COVERAGE_TYPE_COUNT = "coverage-type-count";
-const COVERAGE_TYPE_SIG = "coverage-type-sig";
-const COVERAGE_TYPE_EFFECT = "coverage-type-effect";
+import {render} from "./render.js";
+import {getHighlightRegions} from "./highlightRegions.js";
+import {mergeFilteredData} from "./coverageData.js";
+import {coverageValue, effectInterval, levelCountInterval, sigInterval} from "./covTypeUtils.js";
+import {
+    STATE_ZOOMED,
+    STATE_ZOOM_CHROMO_INDEX,
+    STATE_SCALE,
+    STATE_SCALE_X,
+    STATE_SCALE_Y,
+    STATE_VIEWBOX,
+    STATE_FACETS,
+    STATE_CATEGORICAL_FACET_VALUES,
+    STATE_NUMERIC_FACET_VALUES,
+    STATE_COUNT_FILTER_VALUES,
+    STATE_COVERAGE_DATA,
+    STATE_ALL_FILTERED,
+    STATE_NUMERIC_FILTER_INTERVALS,
+    STATE_COUNT_FILTER_INTERVALS,
+    STATE_HIGHLIGHT_REGIONS,
+    STATE_SELECTED_EXPERIMENTS,
+    STATE_ITEM_COUNTS,
+    STATE_SOURCE_TYPE,
+    STATE_COVERAGE_TYPE,
+    STATE_LEGEND_INTERVALS,
+} from "./consts.js";
+import {
+    numericFilterControls,
+    countFilterControls,
+    getFilterBody,
+    setFacetControls,
+    setCountControls,
+    setLegendIntervals,
+} from "./ui.js";
 
 class GenomeError extends Error {
     constructor(message, options) {
@@ -167,441 +174,6 @@ function build_state(manifests, genomeRenderer, accessionIDs, sourceType) {
     return state;
 }
 
-function render(state, genomeRenderer) {
-    const viewBox = state.g(STATE_VIEWBOX);
-    const scale = state.g(STATE_SCALE);
-    const scaleX = state.g(STATE_SCALE_X);
-    const scaleY = state.g(STATE_SCALE_Y);
-    const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
-    let currentLevel = state.g(STATE_ALL_FILTERED);
-    let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
-    let itemCounts = state.g(STATE_ITEM_COUNTS);
-    let legendIntervals = state.g(STATE_LEGEND_INTERVALS);
-
-    let sourceColors = sourceRenderColors(state);
-    let targetColors = targetRenderColors(state);
-
-    rc(
-        g("chrom-data"),
-        genomeRenderer.render(
-            currentLevel,
-            focusIndex,
-            sourceColors,
-            targetColors,
-            sourceRenderDataTransform(state),
-            targetRenderDataTransform(state),
-            tooltipDataSelectors,
-            sourceTooltipDataLabel(state),
-            targetTooltipDataLabel,
-            viewBox,
-            scale,
-            scaleX,
-            scaleY,
-            highlightRegions
-        )
-    );
-    rc(
-        g("chrom-data-legend"),
-        Legend(d3.scaleSequential(legendIntervals.source, sourceColors.color), {
-            title: sourceLegendTitle(state),
-        })
-    );
-    a(
-        g("chrom-data-legend"),
-        Legend(d3.scaleSequential(legendIntervals.target, targetColors.color), {
-            title: targetLegendTitle(state),
-        })
-    );
-    rc(g("reo-count"), t(`Observations: ${itemCounts[0].toLocaleString()}`));
-    rc(g("source-count"), t(`${state.g(STATE_SOURCE_TYPE)}s: ${itemCounts[1].toLocaleString()}`));
-    rc(g("target-count"), t(`Genes: ${itemCounts[2].toLocaleString()}`));
-}
-
-function categoricalFilterControls(facets, default_facets) {
-    return facets
-        .filter((f) => f.facet_type == "FacetType.CATEGORICAL")
-        .map((facet) => {
-            return e("fieldset", {name: "facetfield", class: "my-4"}, [
-                e("legend", {class: "font-bold"}, facet.name),
-                e(
-                    "div",
-                    {class: "flex flex-row flex-wrap gap-1"},
-                    Object.entries(facet.values).map((entry) => {
-                        return e("div", {class: "ml-1"}, [
-                            default_facets.includes(parseInt(entry[0]))
-                                ? e("input", {type: "checkbox", id: entry[0], name: facet.name, checked: "true"}, [])
-                                : e("input", {type: "checkbox", id: entry[0], name: facet.name}, []),
-                            e("label", {for: entry[0]}, entry[1]),
-                        ]);
-                    })
-                ),
-            ]);
-        });
-}
-
-function numericFilterControls(state, facets) {
-    const numericFacets = facets.filter((f) => f.facet_type == "FacetType.NUMERIC");
-    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
-    let filterNodes = [];
-    let intervals = state.g(STATE_NUMERIC_FILTER_INTERVALS);
-
-    for (let i = 0; i < numericFacets.length; i++) {
-        let facet = numericFacets[i];
-        let sliderNode = sliderNodes[i];
-
-        let range;
-        let sliderLabel;
-
-        if (facet.name === "Effect Size") {
-            range = intervals.effect;
-            sliderLabel = facet.name;
-        } else if (facet.name === "Significance") {
-            range = [intervals.sig[0], intervals.sig[1]];
-            sliderLabel = "Significance (-log10)";
-        } else {
-            continue;
-        }
-
-        noUiSlider.create(sliderNode, {
-            start: [range[0], range[1]],
-            format: {
-                to: (n) => n.toPrecision(3),
-                from: (s) => Number.parseFloat(s),
-            },
-            connect: true,
-            range: {
-                min: range[0],
-                max: range[1],
-            },
-            pips: {
-                mode: "range",
-                density: 5,
-                format: {
-                    to: (n) => n.toPrecision(3),
-                    from: (s) => Number.parseFloat(s),
-                },
-            },
-        });
-
-        sliderNode.noUiSlider.on("start", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
-        });
-
-        sliderNode.noUiSlider.on("end", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
-        });
-
-        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", sliderLabel), sliderNode]));
-    }
-
-    sliderNodes.forEach((sliderNode) => {
-        sliderNode.noUiSlider.on("slide", function (values, handle) {
-            state.u(
-                STATE_NUMERIC_FACET_VALUES,
-                sliderNodes.map((n) => n.noUiSlider.get(true))
-            );
-        });
-    });
-
-    return filterNodes;
-}
-
-function countFilterControls(state) {
-    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
-    let filterNodes = [];
-    let intervals = state.g(STATE_COUNT_FILTER_INTERVALS);
-
-    for (let i = 0; i < 2; i++) {
-        let sliderNode = sliderNodes[i];
-
-        let range;
-        let name;
-
-        if (i == 0) {
-            range = intervals.source;
-            name = `Number of ${state.g(STATE_SOURCE_TYPE)}s`;
-        } else if (i == 1) {
-            range = intervals.target;
-            name = "Number of Genes Assayed";
-        } else {
-            continue;
-        }
-
-        noUiSlider.create(sliderNode, {
-            start: [range[0], range[1]],
-            step: 1,
-            connect: true,
-            range: {
-                min: range[0],
-                max: range[1],
-            },
-            pips: {
-                mode: "range",
-                density: 5,
-            },
-        });
-
-        sliderNode.noUiSlider.on("start", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
-        });
-
-        sliderNode.noUiSlider.on("end", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
-        });
-
-        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", name), sliderNode]));
-    }
-
-    sliderNodes.forEach((sliderNode) => {
-        sliderNode.noUiSlider.on("slide", function (values, handle) {
-            state.u(
-                STATE_COUNT_FILTER_VALUES,
-                sliderNodes.map((n) => n.noUiSlider.get(true))
-            );
-        });
-    });
-
-    return filterNodes;
-}
-
-function getFilterBody(state, genome, chroms, filter_values) {
-    let filters = {
-        filters: filter_values,
-        chromosomes: genome.map((c) => c.chrom),
-    };
-    if (state.g(STATE_ZOOMED)) {
-        let zoomChromoIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
-        filters.zoom = chroms[zoomChromoIndex].chrom;
-    }
-
-    return filters;
-}
-
-function mergeFilteredData(current_data, response_data) {
-    let resp_obj = response_data.reduce((obj, chrom) => {
-        obj[chrom.chrom] = chrom;
-        return obj;
-    }, {});
-
-    return current_data.map((chrom) => {
-        return chrom.chrom in resp_obj ? resp_obj[chrom.chrom] : chrom;
-    });
-}
-
-function experimentsQuery(state) {
-    let selectedExperiments = state.g(STATE_SELECTED_EXPERIMENTS);
-    return selectedExperiments.map((e) => `exp=${e[0]}`).join("&");
-}
-
-function valueInterval(selector) {
-    return (chroms, interval, chromoIndex) => {
-        if (chromoIndex) {
-            chroms = [chroms[chromoIndex]];
-        }
-        let max = Number.NEGATIVE_INFINITY;
-        let min = Number.POSITIVE_INFINITY;
-        for (const chrom of chroms) {
-            const values = chrom[interval].map(selector);
-            max = Math.max(max, Math.max(...values));
-            min = Math.min(min, Math.min(...values));
-        }
-
-        if (max == Number.NEGATIVE_INFINITY || min == Number.POSITIVE_INFINITY) {
-            return [0, 0];
-        }
-
-        return [min, max];
-    };
-}
-
-const levelCountInterval = valueInterval((d) => d.count);
-const sigInterval = valueInterval((d) => d.max_log10_sig);
-const effectInterval = valueInterval((d) => d.max_abs_effect);
-
-function coverageTypeFunctions(count, sig, effect) {
-    return (state) => {
-        const coverage_type = state.g(STATE_COVERAGE_TYPE);
-        if (coverage_type == COVERAGE_TYPE_COUNT) {
-            return count;
-        } else if (coverage_type == COVERAGE_TYPE_SIG) {
-            return sig;
-        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
-            return effect;
-        }
-    };
-}
-
-function coverageTypeDeferredFunctions(count, sig, effect) {
-    return (state) => {
-        const coverage_type = state.g(STATE_COVERAGE_TYPE);
-        if (coverage_type == COVERAGE_TYPE_COUNT) {
-            return count(state);
-        } else if (coverage_type == COVERAGE_TYPE_SIG) {
-            return sig(state);
-        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
-            return effect(state);
-        }
-    };
-}
-
-let getLegendIntervalFunc = coverageTypeFunctions(levelCountInterval, sigInterval, effectInterval);
-
-let tooltipDataSelectors = [
-    (d) => d.count,
-    (d) => {
-        if (d.max_log10_sig >= 0.001) {
-            return d.max_log10_sig.toFixed(3); // e.g., 12.34567890 -> 12.345
-        } else {
-            return d.max_log10_sig.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
-        }
-    },
-    (d) => {
-        if (Math.abs(d.max_abs_effect) >= 0.001) {
-            return d.max_abs_effect.toFixed(3); // e.g., 12.34567890 -> 12.345
-        } else {
-            return d.max_abs_effect.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
-        }
-    },
-];
-
-function sourceTooltipDataLabel(state) {
-    return [`${state.g(STATE_SOURCE_TYPE)} Count`, "Largest Significance", "Greatest Effect Size"];
-}
-let targetTooltipDataLabel = ["Gene Count", "Largest Significance", "Greatest Effect Size"];
-
-let sourceLegendTitle = coverageTypeDeferredFunctions(
-    (state) => `Number of ${state.g(STATE_SOURCE_TYPE)}s`,
-    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Significance`,
-    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Size`
-);
-
-let targetLegendTitle = coverageTypeFunctions(
-    "Number of Genes Assayed",
-    "Significance of Effect on Assayed Genes",
-    "Size of Effect on Assayed Genes"
-);
-
-let sourceRenderDataTransform = coverageTypeDeferredFunctions(
-    (state) => {
-        return (d) => {
-            let sourceCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).source;
-            let sourceCountRange = sourceCountInterval[1] - sourceCountInterval[0];
-            return (d.count - sourceCountInterval[0]) / sourceCountRange;
-        };
-    },
-    (state) => (d) => {
-        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
-        let significanceRange = significanceInterval[1] - significanceInterval[0];
-        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
-    },
-    (state) => (d) => {
-        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
-        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
-        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
-    }
-);
-
-let targetRenderDataTransform = coverageTypeDeferredFunctions(
-    (state) => {
-        return (d) => {
-            let targetCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).target;
-            let targetCountRange = targetCountInterval[1] - targetCountInterval[0];
-            return (d.count - targetCountInterval[0]) / targetCountRange;
-        };
-    },
-    (state) => (d) => {
-        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
-        let significanceRange = significanceInterval[1] - significanceInterval[0];
-        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
-    },
-    (state) => (d) => {
-        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
-        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
-        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
-    }
-);
-
-let sourceRenderColors = coverageTypeFunctions(
-    {
-        color: d3.interpolateCool,
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(-260, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
-    }
-);
-
-let targetRenderColors = coverageTypeFunctions(
-    {
-        color: d3.interpolateWarm,
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(-100, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
-    }
-);
-
-function setFacetControls(state, categoricalFacetControls, defaultFacets, facets) {
-    cc(categoricalFacetControls);
-    categoricalFilterControls(facets, defaultFacets).forEach((element) => {
-        a(categoricalFacetControls, element);
-    });
-    let facetCheckboxes = categoricalFacetControls.querySelectorAll("input[type=checkbox]");
-    facetCheckboxes.forEach((checkbox) => {
-        checkbox.addEventListener("change", (_) => {
-            let checkedFacets = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
-                .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
-                .map((i) => Number(i.id));
-            state.u(STATE_CATEGORICAL_FACET_VALUES, checkedFacets);
-        });
-    });
-
-    let effectSizeFilterInterval = facets.filter((f) => f.name === "Effect Size")[0].range;
-    let sigFilterInterval = facets.filter((f) => f.name === "Significance")[0].range64;
-    state.u(STATE_NUMERIC_FILTER_INTERVALS, {effect: effectSizeFilterInterval, sig: sigFilterInterval});
-}
-
-function setCountControls(state, coverageData) {
-    let sourceCountInterval = levelCountInterval(coverageData, "source_intervals");
-    let targetCountInterval = levelCountInterval(coverageData, "target_intervals");
-    state.u(STATE_COUNT_FILTER_INTERVALS, {source: sourceCountInterval, target: targetCountInterval});
-    state.u(STATE_COUNT_FILTER_VALUES, [sourceCountInterval, targetCountInterval]);
-}
-
-function setLegendIntervals(state, coverageData) {
-    let legendInterval = getLegendIntervalFunc(state);
-    let sourceLegendInterval = legendInterval(coverageData, "source_intervals");
-    let targetLegendInterval = legendInterval(coverageData, "target_intervals");
-    state.u(STATE_LEGEND_INTERVALS, {source: sourceLegendInterval, target: targetLegendInterval});
-}
-
-function getHighlightRegions(regionUploadInput, regionReader) {
-    if (regionUploadInput.files.length != 1) {
-        return;
-    }
-    regionReader.readAsText(regionUploadInput.files[0]);
-}
-
-function coverageValue(selectedCoverageType) {
-    if (selectedCoverageType == "count") {
-        return COVERAGE_TYPE_COUNT;
-    } else if (selectedCoverageType == "sig") {
-        return COVERAGE_TYPE_SIG;
-    } else if (selectedCoverageType == "effect") {
-        return COVERAGE_TYPE_EFFECT;
-    }
-}
-
 async function getCombinedCoverageData(staticRoot, accessionIDs) {
     let manifests;
     let genome;
@@ -636,6 +208,11 @@ async function getCombinedCoverageData(staticRoot, accessionIDs) {
     return [genome, manifests];
 }
 
+function experimentsQuery(state) {
+    let selectedExperiments = state.g(STATE_SELECTED_EXPERIMENTS);
+    return selectedExperiments.map((e) => `exp=${e[0]}`).join("&");
+}
+
 export async function combined_viz(staticRoot, csrfToken, loggedIn) {
     let experiment_info = JSON.parse(g("experiment_viz").innerText);
     let accessionIDs = experiment_info.map((exp) => [exp.accession_id, exp.analysis_accession_id]);
@@ -652,11 +229,9 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
 
     const genomeRenderer = new GenomeRenderer(genome);
 
-    let sourceType = experiment_info.length == 1 ? experiment_info[0].source : "Tested Elements";
+    let sourceType = experiment_info.length == 1 ? experiment_info[0].source : "Tested Element";
 
     let state = build_state(manifests, genomeRenderer, accessionIDs, sourceType);
-
-    // Get data
 
     render(state, genomeRenderer);
 
@@ -699,12 +274,12 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         state.u(STATE_SCALE_X, zoomed ? 30 : 1);
         state.u(STATE_SCALE_Y, zoomed ? 15 : 1);
 
-        let body = getFilterBody(state, genome, manifest.chromosomes, [
+        let body = getFilterBody(state, genome, manifests[0].chromosomes, [
             state.g(STATE_CATEGORICAL_FACET_VALUES),
             state.g(STATE_NUMERIC_FACET_VALUES),
         ]);
 
-        postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+        postJson(`/search/combined_experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
             (response_json) => {
                 state.u(
                     STATE_COVERAGE_DATA,
@@ -718,44 +293,47 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         render(state, genomeRenderer);
     });
 
+    function get_all_data() {
+        let body = getFilterBody(state, genome, manifests[0].chromosomes, [state.g(STATE_CATEGORICAL_FACET_VALUES)]);
+
+        postJson(`/search/combined_experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+            (response_json) => {
+                state.u(
+                    STATE_COVERAGE_DATA,
+                    mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes)
+                );
+                state.u(STATE_NUMERIC_FILTER_INTERVALS, response_json.numeric_intervals);
+                state.u(
+                    STATE_NUMERIC_FACET_VALUES,
+                    [response_json.numeric_intervals.effect, response_json.numeric_intervals.sig],
+                    false
+                );
+                state.u(STATE_ITEM_COUNTS, [
+                    response_json.reo_count,
+                    response_json.source_count,
+                    response_json.target_count,
+                ]);
+            }
+        );
+    }
+
+    get_all_data();
+
     state.ac(
         STATE_CATEGORICAL_FACET_VALUES,
-        debounce((s, key) => {
-            // Send facet data to server to get filtered data and updated numeric facets
-            let body = getFilterBody(state, genome, manifest.chromosomes, [state.g(STATE_CATEGORICAL_FACET_VALUES)]);
-
-            postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
-                (response_json) => {
-                    state.u(
-                        STATE_COVERAGE_DATA,
-                        mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes)
-                    );
-                    state.u(STATE_NUMERIC_FILTER_INTERVALS, response_json.numeric_intervals);
-                    state.u(
-                        STATE_NUMERIC_FACET_VALUES,
-                        [response_json.numeric_intervals.effect, response_json.numeric_intervals.sig],
-                        false
-                    );
-                    state.u(STATE_ITEM_COUNTS, [
-                        response_json.reo_count,
-                        response_json.source_count,
-                        response_json.target_count,
-                    ]);
-                }
-            );
-        }, 300)
+        debounce((s, key) => get_all_data(), 300)
     );
 
     state.ac(
         STATE_NUMERIC_FACET_VALUES,
         debounce((s, key) => {
             // Send facet data to server to get filtered data and updated numeric facets
-            let body = getFilterBody(state, genome, manifest.chromosomes, [
+            let body = getFilterBody(state, genome, manifests[0].chromosomes, [
                 state.g(STATE_CATEGORICAL_FACET_VALUES),
                 state.g(STATE_NUMERIC_FACET_VALUES),
             ]);
 
-            postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+            postJson(`/search/combined_experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
                 (response_json) => {
                     state.u(
                         STATE_COVERAGE_DATA,

--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -1,0 +1,812 @@
+import {a, cc, e, g, rc, t} from "../dom.js";
+import {State} from "../state.js";
+import {getRegions} from "../bed.js";
+import {getJson, postJson} from "../files.js";
+import {Legend} from "./obsLegend.js";
+import {GenomeRenderer} from "./chromosomeSvg.js";
+import {getDownloadRegions, getDownloadAll} from "./downloads.js";
+import {debounce} from "../utils.js";
+
+const STATE_ZOOMED = "state-zoomed";
+const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
+const STATE_SCALE = "state-scale";
+const STATE_SCALE_X = "state-scale-x";
+const STATE_SCALE_Y = "state-scale-y";
+const STATE_VIEWBOX = "state-viewbox";
+const STATE_FACETS = "state-facets";
+const STATE_CATEGORICAL_FACET_VALUES = "state-categorical-facets";
+const STATE_NUMERIC_FACET_VALUES = "state-numeric-facets";
+const STATE_COUNT_FILTER_VALUES = "state-count-filter";
+const STATE_COVERAGE_DATA = "state-coverage-data";
+const STATE_ALL_FILTERED = "state-all-filtered";
+const STATE_NUMERIC_FILTER_INTERVALS = "state-numeric-filter-intervals";
+const STATE_COUNT_FILTER_INTERVALS = "state-count-filter-intervals";
+const STATE_HIGHLIGHT_REGIONS = "state-highlight-regions";
+const STATE_SELECTED_EXPERIMENTS = "state-selected-experiments";
+const STATE_ITEM_COUNTS = "state-item-counts";
+const STATE_SOURCE_TYPE = "state-source-type";
+const STATE_ANALYSIS = "state-analysis";
+const STATE_COVERAGE_TYPE = "state-coverage-type";
+const STATE_LEGEND_INTERVALS = "state-legend-intervals";
+
+const COVERAGE_TYPE_COUNT = "coverage-type-count";
+const COVERAGE_TYPE_SIG = "coverage-type-sig";
+const COVERAGE_TYPE_EFFECT = "coverage-type-effect";
+
+class GenomeError extends Error {
+    constructor(message, options) {
+        super(message, options);
+    }
+}
+
+function build_state(manifest, genomeRenderer, accessionIDs, sourceType) {
+    let coverageData = manifest.chromosomes;
+    let facets = manifest.facets; // merge
+    let default_facets = manifest.hasOwnProperty("default_facets") ? manifest.default_facets : []; // merge
+    let reoCount = manifest.reo_count;
+    let sourceCount = manifest.source_count;
+    let targetCount = manifest.target_count;
+    let sourceCountInterval = levelCountInterval(coverageData, "source_intervals");
+    let targetCountInterval = levelCountInterval(coverageData, "target_intervals");
+    let effectSizeFilterInterval = facets.filter((f) => f.name === "Effect Size")[0].range;
+    let sigFilterInterval = facets.filter((f) => f.name === "Significance")[0].range64;
+    let coverageSelectorValue = g("covSelect").value;
+    let legendIntervalFunc = sigInterval;
+
+    if (coverageSelectorValue == "count") {
+        legendIntervalFunc = levelCountInterval;
+    } else if (coverageSelectorValue == "sig") {
+        legendIntervalFunc = sigInterval;
+    } else if (coverageSelectorValue == "effect") {
+        legendIntervalFunc = effectInterval;
+    }
+
+    let state = new State({
+        [STATE_ZOOMED]: false,
+        [STATE_ZOOM_CHROMO_INDEX]: undefined,
+        [STATE_SCALE]: 1,
+        [STATE_SCALE_X]: 1,
+        [STATE_SCALE_Y]: 1,
+        [STATE_VIEWBOX]: [0, 0, genomeRenderer.renderContext.viewWidth, genomeRenderer.renderContext.viewHeight],
+        [STATE_FACETS]: facets,
+        [STATE_CATEGORICAL_FACET_VALUES]: default_facets,
+        [STATE_COVERAGE_DATA]: coverageData,
+        [STATE_ALL_FILTERED]: coverageData,
+        [STATE_NUMERIC_FILTER_INTERVALS]: {effect: effectSizeFilterInterval, sig: sigFilterInterval},
+        [STATE_NUMERIC_FACET_VALUES]: [effectSizeFilterInterval, sigFilterInterval],
+        [STATE_COUNT_FILTER_INTERVALS]: {source: sourceCountInterval, target: targetCountInterval},
+        [STATE_COUNT_FILTER_VALUES]: [sourceCountInterval, targetCountInterval],
+        [STATE_HIGHLIGHT_REGIONS]: {},
+        [STATE_SELECTED_EXPERIMENTS]: accessionIDs,
+        [STATE_ITEM_COUNTS]: [reoCount, sourceCount, targetCount],
+        [STATE_SOURCE_TYPE]: sourceType,
+        [STATE_COVERAGE_TYPE]: coverageValue(coverageSelectorValue),
+        [STATE_LEGEND_INTERVALS]: {
+            source: legendIntervalFunc(coverageData, "source_intervals"),
+            target: legendIntervalFunc(coverageData, "target_intervals"),
+        },
+    });
+
+    return state;
+}
+
+function render(state, genomeRenderer) {
+    const viewBox = state.g(STATE_VIEWBOX);
+    const scale = state.g(STATE_SCALE);
+    const scaleX = state.g(STATE_SCALE_X);
+    const scaleY = state.g(STATE_SCALE_Y);
+    const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
+    let currentLevel = state.g(STATE_ALL_FILTERED);
+    let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
+    let itemCounts = state.g(STATE_ITEM_COUNTS);
+    let legendIntervals = state.g(STATE_LEGEND_INTERVALS);
+
+    let sourceColors = sourceRenderColors(state);
+    let targetColors = targetRenderColors(state);
+
+    rc(
+        g("chrom-data"),
+        genomeRenderer.render(
+            currentLevel,
+            focusIndex,
+            sourceColors,
+            targetColors,
+            sourceRenderDataTransform(state),
+            targetRenderDataTransform(state),
+            tooltipDataSelectors,
+            sourceTooltipDataLabel(state),
+            targetTooltipDataLabel,
+            viewBox,
+            scale,
+            scaleX,
+            scaleY,
+            highlightRegions
+        )
+    );
+    rc(
+        g("chrom-data-legend"),
+        Legend(d3.scaleSequential(legendIntervals.source, sourceColors.color), {
+            title: sourceLegendTitle(state),
+        })
+    );
+    a(
+        g("chrom-data-legend"),
+        Legend(d3.scaleSequential(legendIntervals.target, targetColors.color), {
+            title: targetLegendTitle(state),
+        })
+    );
+    rc(g("reo-count"), t(`Observations: ${itemCounts[0].toLocaleString()}`));
+    rc(g("source-count"), t(`${state.g(STATE_SOURCE_TYPE)}s: ${itemCounts[1].toLocaleString()}`));
+    rc(g("target-count"), t(`Genes: ${itemCounts[2].toLocaleString()}`));
+}
+
+function categoricalFilterControls(facets, default_facets) {
+    return facets
+        .filter((f) => f.facet_type == "FacetType.CATEGORICAL")
+        .map((facet) => {
+            return e("fieldset", {name: "facetfield", class: "my-4"}, [
+                e("legend", {class: "font-bold"}, facet.name),
+                e(
+                    "div",
+                    {class: "flex flex-row flex-wrap gap-1"},
+                    Object.entries(facet.values).map((entry) => {
+                        return e("div", {class: "ml-1"}, [
+                            default_facets.includes(parseInt(entry[0]))
+                                ? e("input", {type: "checkbox", id: entry[0], name: facet.name, checked: "true"}, [])
+                                : e("input", {type: "checkbox", id: entry[0], name: facet.name}, []),
+                            e("label", {for: entry[0]}, entry[1]),
+                        ]);
+                    })
+                ),
+            ]);
+        });
+}
+
+function numericFilterControls(state, facets) {
+    const numericFacets = facets.filter((f) => f.facet_type == "FacetType.NUMERIC");
+    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
+    let filterNodes = [];
+    let intervals = state.g(STATE_NUMERIC_FILTER_INTERVALS);
+
+    for (let i = 0; i < numericFacets.length; i++) {
+        let facet = numericFacets[i];
+        let sliderNode = sliderNodes[i];
+
+        let range;
+        let sliderLabel;
+
+        if (facet.name === "Effect Size") {
+            range = intervals.effect;
+            sliderLabel = facet.name;
+        } else if (facet.name === "Significance") {
+            range = [intervals.sig[0], intervals.sig[1]];
+            sliderLabel = "Significance (-log10)";
+        } else {
+            continue;
+        }
+
+        noUiSlider.create(sliderNode, {
+            start: [range[0], range[1]],
+            format: {
+                to: (n) => n.toPrecision(3),
+                from: (s) => Number.parseFloat(s),
+            },
+            connect: true,
+            range: {
+                min: range[0],
+                max: range[1],
+            },
+            pips: {
+                mode: "range",
+                density: 5,
+                format: {
+                    to: (n) => n.toPrecision(3),
+                    from: (s) => Number.parseFloat(s),
+                },
+            },
+        });
+
+        sliderNode.noUiSlider.on("start", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
+        });
+
+        sliderNode.noUiSlider.on("end", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
+        });
+
+        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", sliderLabel), sliderNode]));
+    }
+
+    sliderNodes.forEach((sliderNode) => {
+        sliderNode.noUiSlider.on("slide", function (values, handle) {
+            state.u(
+                STATE_NUMERIC_FACET_VALUES,
+                sliderNodes.map((n) => n.noUiSlider.get(true))
+            );
+        });
+    });
+
+    return filterNodes;
+}
+
+function countFilterControls(state) {
+    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
+    let filterNodes = [];
+    let intervals = state.g(STATE_COUNT_FILTER_INTERVALS);
+
+    for (let i = 0; i < 2; i++) {
+        let sliderNode = sliderNodes[i];
+
+        let range;
+        let name;
+
+        if (i == 0) {
+            range = intervals.source;
+            name = `Number of ${state.g(STATE_SOURCE_TYPE)}s`;
+        } else if (i == 1) {
+            range = intervals.target;
+            name = "Number of Genes Assayed";
+        } else {
+            continue;
+        }
+
+        noUiSlider.create(sliderNode, {
+            start: [range[0], range[1]],
+            step: 1,
+            connect: true,
+            range: {
+                min: range[0],
+                max: range[1],
+            },
+            pips: {
+                mode: "range",
+                density: 5,
+            },
+        });
+
+        sliderNode.noUiSlider.on("start", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
+        });
+
+        sliderNode.noUiSlider.on("end", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
+        });
+
+        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", name), sliderNode]));
+    }
+
+    sliderNodes.forEach((sliderNode) => {
+        sliderNode.noUiSlider.on("slide", function (values, handle) {
+            state.u(
+                STATE_COUNT_FILTER_VALUES,
+                sliderNodes.map((n) => n.noUiSlider.get(true))
+            );
+        });
+    });
+
+    return filterNodes;
+}
+
+function getFilterBody(state, genome, chroms, filter_values) {
+    let filters = {
+        filters: filter_values,
+        chromosomes: genome.map((c) => c.chrom),
+    };
+    if (state.g(STATE_ZOOMED)) {
+        let zoomChromoIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
+        filters.zoom = chroms[zoomChromoIndex].chrom;
+    }
+
+    return filters;
+}
+
+function mergeFilteredData(current_data, response_data) {
+    let resp_obj = response_data.reduce((obj, chrom) => {
+        obj[chrom.chrom] = chrom;
+        return obj;
+    }, {});
+
+    return current_data.map((chrom) => {
+        return chrom.chrom in resp_obj ? resp_obj[chrom.chrom] : chrom;
+    });
+}
+
+function experimentsQuery(state) {
+    let selectedExperiments = state.g(STATE_SELECTED_EXPERIMENTS);
+    return selectedExperiments.map((e) => `exp=${e[0]}`).join("&");
+}
+
+function valueInterval(selector) {
+    return (chroms, interval, chromoIndex) => {
+        if (chromoIndex) {
+            chroms = [chroms[chromoIndex]];
+        }
+        let max = Number.NEGATIVE_INFINITY;
+        let min = Number.POSITIVE_INFINITY;
+        for (const chrom of chroms) {
+            const values = chrom[interval].map(selector);
+            max = Math.max(max, Math.max(...values));
+            min = Math.min(min, Math.min(...values));
+        }
+
+        if (max == Number.NEGATIVE_INFINITY || min == Number.POSITIVE_INFINITY) {
+            return [0, 0];
+        }
+
+        return [min, max];
+    };
+}
+
+const levelCountInterval = valueInterval((d) => d.count);
+const sigInterval = valueInterval((d) => d.max_log10_sig);
+const effectInterval = valueInterval((d) => d.max_abs_effect);
+
+function coverageTypeFunctions(count, sig, effect) {
+    return (state) => {
+        const coverage_type = state.g(STATE_COVERAGE_TYPE);
+        if (coverage_type == COVERAGE_TYPE_COUNT) {
+            return count;
+        } else if (coverage_type == COVERAGE_TYPE_SIG) {
+            return sig;
+        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
+            return effect;
+        }
+    };
+}
+
+function coverageTypeDeferredFunctions(count, sig, effect) {
+    return (state) => {
+        const coverage_type = state.g(STATE_COVERAGE_TYPE);
+        if (coverage_type == COVERAGE_TYPE_COUNT) {
+            return count(state);
+        } else if (coverage_type == COVERAGE_TYPE_SIG) {
+            return sig(state);
+        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
+            return effect(state);
+        }
+    };
+}
+
+let getLegendIntervalFunc = coverageTypeFunctions(levelCountInterval, sigInterval, effectInterval);
+
+let tooltipDataSelectors = [
+    (d) => d.count,
+    (d) => {
+        if (d.max_log10_sig >= 0.001) {
+            return d.max_log10_sig.toFixed(3); // e.g., 12.34567890 -> 12.345
+        } else {
+            return d.max_log10_sig.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
+        }
+    },
+    (d) => {
+        if (Math.abs(d.max_abs_effect) >= 0.001) {
+            return d.max_abs_effect.toFixed(3); // e.g., 12.34567890 -> 12.345
+        } else {
+            return d.max_abs_effect.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
+        }
+    },
+];
+
+function sourceTooltipDataLabel(state) {
+    return [`${state.g(STATE_SOURCE_TYPE)} Count`, "Largest Significance", "Greatest Effect Size"];
+}
+let targetTooltipDataLabel = ["Gene Count", "Largest Significance", "Greatest Effect Size"];
+
+let sourceLegendTitle = coverageTypeDeferredFunctions(
+    (state) => `Number of ${state.g(STATE_SOURCE_TYPE)}s`,
+    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Significance`,
+    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Size`
+);
+
+let targetLegendTitle = coverageTypeFunctions(
+    "Number of Genes Assayed",
+    "Significance of Effect on Assayed Genes",
+    "Size of Effect on Assayed Genes"
+);
+
+let sourceRenderDataTransform = coverageTypeDeferredFunctions(
+    (state) => {
+        return (d) => {
+            let sourceCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).source;
+            let sourceCountRange = sourceCountInterval[1] - sourceCountInterval[0];
+            return (d.count - sourceCountInterval[0]) / sourceCountRange;
+        };
+    },
+    (state) => (d) => {
+        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
+        let significanceRange = significanceInterval[1] - significanceInterval[0];
+        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
+    },
+    (state) => (d) => {
+        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
+        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
+        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
+    }
+);
+
+let targetRenderDataTransform = coverageTypeDeferredFunctions(
+    (state) => {
+        return (d) => {
+            let targetCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).target;
+            let targetCountRange = targetCountInterval[1] - targetCountInterval[0];
+            return (d.count - targetCountInterval[0]) / targetCountRange;
+        };
+    },
+    (state) => (d) => {
+        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
+        let significanceRange = significanceInterval[1] - significanceInterval[0];
+        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
+    },
+    (state) => (d) => {
+        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
+        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
+        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
+    }
+);
+
+let sourceRenderColors = coverageTypeFunctions(
+    {
+        color: d3.interpolateCool,
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(-260, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
+    }
+);
+
+let targetRenderColors = coverageTypeFunctions(
+    {
+        color: d3.interpolateWarm,
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(-100, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
+    }
+);
+
+function setFacetControls(state, categoricalFacetControls, defaultFacets, facets) {
+    cc(categoricalFacetControls);
+    categoricalFilterControls(facets, defaultFacets).forEach((element) => {
+        a(categoricalFacetControls, element);
+    });
+    let facetCheckboxes = categoricalFacetControls.querySelectorAll("input[type=checkbox]");
+    facetCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", (_) => {
+            let checkedFacets = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
+                .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
+                .map((i) => Number(i.id));
+            state.u(STATE_CATEGORICAL_FACET_VALUES, checkedFacets);
+        });
+    });
+
+    let effectSizeFilterInterval = facets.filter((f) => f.name === "Effect Size")[0].range;
+    let sigFilterInterval = facets.filter((f) => f.name === "Significance")[0].range64;
+    state.u(STATE_NUMERIC_FILTER_INTERVALS, {effect: effectSizeFilterInterval, sig: sigFilterInterval});
+}
+
+function setCountControls(state, coverageData) {
+    let sourceCountInterval = levelCountInterval(coverageData, "source_intervals");
+    let targetCountInterval = levelCountInterval(coverageData, "target_intervals");
+    state.u(STATE_COUNT_FILTER_INTERVALS, {source: sourceCountInterval, target: targetCountInterval});
+    state.u(STATE_COUNT_FILTER_VALUES, [sourceCountInterval, targetCountInterval]);
+}
+
+function setLegendIntervals(state, coverageData) {
+    let legendInterval = getLegendIntervalFunc(state);
+    let sourceLegendInterval = legendInterval(coverageData, "source_intervals");
+    let targetLegendInterval = legendInterval(coverageData, "target_intervals");
+    state.u(STATE_LEGEND_INTERVALS, {source: sourceLegendInterval, target: targetLegendInterval});
+}
+
+function getHighlightRegions(regionUploadInput, regionReader) {
+    if (regionUploadInput.files.length != 1) {
+        return;
+    }
+    regionReader.readAsText(regionUploadInput.files[0]);
+}
+
+function coverageValue(selectedCoverageType) {
+    if (selectedCoverageType == "count") {
+        return COVERAGE_TYPE_COUNT;
+    } else if (selectedCoverageType == "sig") {
+        return COVERAGE_TYPE_SIG;
+    } else if (selectedCoverageType == "effect") {
+        return COVERAGE_TYPE_EFFECT;
+    }
+}
+
+async function getCombinedCoverageData(staticRoot, accessionIDs) {
+    let manifests;
+    let genome;
+    try {
+        manifests = await Promise.all(
+            accessionIDs.map((accessionIDPair) =>
+                getJson(
+                    `${staticRoot}search/experiments/${accessionIDPair[0]}/${accessionIDPair[1]}/coverage_manifest.json`
+                )
+            )
+        );
+
+        let genomeNames = manifests.map((m) => m.genome.name);
+        if (genomeNames.some((g) => g != genomeNames[0])) {
+            throw new GenomeError("Experiment analyses based on different genomes and are incompatible.");
+        }
+
+        genome = await getJson(
+            `${staticRoot}search/experiments/${accessionIDs[0][0]}/${accessionIDs[0][1]}/${manifests[0].genome.file}`
+        );
+    } catch (error) {
+        let consoleError;
+        if (error instanceof Error) {
+            consoleError = "Files necessary to load coverage not found.";
+        } else if (error instanceof GenomeError) {
+            consoleError = error.message;
+        }
+
+        throw new Error(consoleError);
+    }
+
+    return [genome, manifests];
+}
+
+export async function combined_viz(staticRoot, csrfToken, loggedIn) {
+    let experiment_info = JSON.parse(g("experiment_viz").innerText);
+    let accessionIDs = experiment_info.map((exp) => [exp.accession_id, exp.analysis_accession_id]);
+    let genome, manifests;
+    try {
+        [genome, manifests] = await getCombinedCoverageData(staticRoot, accessionIDs);
+    } catch (error) {
+        console.log(error);
+        return;
+    }
+    let genomeName = manifests[0].genome.name;
+
+    rc(g("chrom-data-header"), t("Experiment Coverage"));
+
+    const genomeRenderer = new GenomeRenderer(genome);
+
+    let state = build_state(manifests, genomeRenderer, accessionIDs, sourceType);
+
+    // Get data
+
+    render(state, genomeRenderer);
+
+    genomeRenderer.onBucketClick = (i, chromName, start, end, renderer) => {
+        let zoomed = state.g(STATE_ZOOMED);
+        if (zoomed) {
+            window.open(`/search/results/?query=chr${chromName}:${start}-${end}+${genomeName}`, "_blank");
+        } else {
+            state.u(STATE_VIEWBOX, [
+                renderer.renderContext.xInset +
+                    renderer.renderContext.toPx(start) * 30 -
+                    renderer.renderContext.viewHeight / 6,
+                renderer.renderContext.yInset +
+                    (renderer.chromDimensions.chromHeight + renderer.chromDimensions.chromSpacing) * i * 15 -
+                    renderer.renderContext.viewHeight / 6,
+                renderer.renderContext.viewWidth,
+                renderer.renderContext.viewHeight,
+            ]);
+            state.u(STATE_ZOOM_CHROMO_INDEX, i);
+            state.u(STATE_ZOOMED, !zoomed);
+        }
+    };
+
+    genomeRenderer.onBackgroundClick = (rect, renderer) => {
+        let zoomed = state.g(STATE_ZOOMED);
+        if (zoomed) {
+            state.u(STATE_VIEWBOX, [0, 0, renderer.renderContext.viewWidth, renderer.renderContext.viewHeight]);
+            state.u(STATE_ZOOM_CHROMO_INDEX, undefined);
+            state.u(STATE_ZOOMED, !zoomed);
+        }
+    };
+
+    countFilterControls(state).forEach((element) => {
+        a(g("chrom-data-counts"), element);
+    });
+
+    state.ac(STATE_ZOOMED, (s, key) => {
+        const zoomed = s[key];
+        state.u(STATE_SCALE, zoomed ? 15 : 1);
+        state.u(STATE_SCALE_X, zoomed ? 30 : 1);
+        state.u(STATE_SCALE_Y, zoomed ? 15 : 1);
+
+        let body = getFilterBody(state, genome, manifest.chromosomes, [
+            state.g(STATE_CATEGORICAL_FACET_VALUES),
+            state.g(STATE_NUMERIC_FACET_VALUES),
+        ]);
+
+        postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+            (response_json) => {
+                state.u(
+                    STATE_COVERAGE_DATA,
+                    mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes)
+                );
+            }
+        );
+    });
+
+    state.ac(STATE_ALL_FILTERED, (s, key) => {
+        render(state, genomeRenderer);
+    });
+
+    state.ac(
+        STATE_CATEGORICAL_FACET_VALUES,
+        debounce((s, key) => {
+            // Send facet data to server to get filtered data and updated numeric facets
+            let body = getFilterBody(state, genome, manifest.chromosomes, [state.g(STATE_CATEGORICAL_FACET_VALUES)]);
+
+            postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+                (response_json) => {
+                    state.u(
+                        STATE_COVERAGE_DATA,
+                        mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes)
+                    );
+                    state.u(STATE_NUMERIC_FILTER_INTERVALS, response_json.numeric_intervals);
+                    state.u(
+                        STATE_NUMERIC_FACET_VALUES,
+                        [response_json.numeric_intervals.effect, response_json.numeric_intervals.sig],
+                        false
+                    );
+                    state.u(STATE_ITEM_COUNTS, [
+                        response_json.reo_count,
+                        response_json.source_count,
+                        response_json.target_count,
+                    ]);
+                }
+            );
+        }, 300)
+    );
+
+    state.ac(
+        STATE_NUMERIC_FACET_VALUES,
+        debounce((s, key) => {
+            // Send facet data to server to get filtered data and updated numeric facets
+            let body = getFilterBody(state, genome, manifest.chromosomes, [
+                state.g(STATE_CATEGORICAL_FACET_VALUES),
+                state.g(STATE_NUMERIC_FACET_VALUES),
+            ]);
+
+            postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+                (response_json) => {
+                    state.u(
+                        STATE_COVERAGE_DATA,
+                        mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes)
+                    );
+                    state.u(STATE_ITEM_COUNTS, [
+                        response_json.reo_count,
+                        response_json.source_count,
+                        response_json.target_count,
+                    ]);
+                }
+            );
+        }, 300)
+    );
+
+    state.ac(STATE_NUMERIC_FILTER_INTERVALS, (s, key) => {
+        cc(g("chrom-data-numeric-facets"));
+        numericFilterControls(state, state.g(STATE_FACETS)).forEach((element) =>
+            a(g("chrom-data-numeric-facets"), element)
+        );
+    });
+
+    state.ac(STATE_COUNT_FILTER_INTERVALS, (s, key) => {
+        cc(g("chrom-data-counts"));
+        countFilterControls(state).forEach((element) => a(g("chrom-data-counts"), element));
+    });
+
+    let countFacetWorker;
+    if (window.Worker) {
+        countFacetWorker = new Worker("/static/search/js/exp_viz/countFacetFilterWorker.js");
+        countFacetWorker.onmessage = (cf) => {
+            state.u(STATE_ALL_FILTERED, cf.data);
+        };
+    }
+
+    state.ac(
+        STATE_COUNT_FILTER_VALUES,
+        debounce((s, key) => {
+            if (countFacetWorker) {
+                countFacetWorker.postMessage({
+                    data: state.g(STATE_COVERAGE_DATA),
+                    countFilters: state.g(STATE_COUNT_FILTER_VALUES),
+                });
+            }
+        }, 60)
+    );
+
+    state.ac(STATE_HIGHLIGHT_REGIONS, (s, key) => {
+        render(state, genomeRenderer);
+    });
+
+    let categoricalFacetControls = g("chrom-data-categorical-facets");
+
+    state.ac(STATE_FACETS, (s, key) => {
+        setFacetControls(state, categoricalFacetControls, [], s[key]);
+    });
+
+    setFacetControls(state, categoricalFacetControls, state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_FACETS));
+
+    state.ac(STATE_COVERAGE_DATA, (s, key) => {
+        setCountControls(state, s[key]);
+        setLegendIntervals(state, s[key]);
+    });
+
+    //
+    // Highlight regions
+    //
+    let regionReader = new FileReader();
+    regionReader.addEventListener(
+        "load",
+        () => {
+            state.u(STATE_HIGHLIGHT_REGIONS, getRegions(regionReader.result));
+            let highlightResetButton = e("input", {type: "button", value: "Reset Highlights"}, []);
+            highlightResetButton.addEventListener("click", () => {
+                state.u(STATE_HIGHLIGHT_REGIONS, {});
+                cc(g("regionUploadInputReset"));
+            });
+            rc(g("regionUploadInputReset"), highlightResetButton);
+        },
+        false
+    );
+    let regionUploadInput = g("regionUploadInput");
+
+    regionUploadInput.addEventListener("change", () => getHighlightRegions(regionUploadInput, regionReader), false);
+
+    //
+    // Data downloads
+    //
+    if (loggedIn) {
+        let dataDownloadInput = g("dataDownloadInput");
+        dataDownloadInput.addEventListener(
+            "change",
+            () =>
+                getDownloadRegions(
+                    [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
+                    dataDownloadInput,
+                    exprAccessionID,
+                    csrfToken
+                ),
+            false
+        );
+
+        let dataDownloadAll = g("dataDownloadAll");
+        dataDownloadAll.addEventListener(
+            "click",
+            () =>
+                getDownloadAll(
+                    [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
+                    exprAccessionID,
+                    csrfToken
+                ),
+            false
+        );
+    }
+
+    //
+    // Coverage Type Selector
+    //
+    let coverageSelector = g("covSelect");
+    coverageSelector.addEventListener(
+        "change",
+        () => {
+            let selectedCoverageType = coverageSelector.value;
+            state.u(STATE_COVERAGE_TYPE, coverageValue(selectedCoverageType));
+        },
+        false
+    );
+
+    state.ac(STATE_COVERAGE_TYPE, (s, key) => {
+        setLegendIntervals(state, state.g(STATE_COVERAGE_DATA));
+        render(state, genomeRenderer);
+    });
+}

--- a/cegs_portal/search/static/search/js/exp_viz/consts.js
+++ b/cegs_portal/search/static/search/js/exp_viz/consts.js
@@ -1,0 +1,26 @@
+export const STATE_ZOOMED = "state-zoomed";
+export const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
+export const STATE_SCALE = "state-scale";
+export const STATE_SCALE_X = "state-scale-x";
+export const STATE_SCALE_Y = "state-scale-y";
+export const STATE_VIEWBOX = "state-viewbox";
+export const STATE_FACETS = "state-facets";
+export const STATE_CATEGORICAL_FACET_VALUES = "state-categorical-facets";
+export const STATE_NUMERIC_FACET_VALUES = "state-numeric-facets";
+export const STATE_COUNT_FILTER_VALUES = "state-count-filter";
+export const STATE_COVERAGE_DATA = "state-coverage-data";
+export const STATE_ALL_FILTERED = "state-all-filtered";
+export const STATE_NUMERIC_FILTER_INTERVALS = "state-numeric-filter-intervals";
+export const STATE_COUNT_FILTER_INTERVALS = "state-count-filter-intervals";
+export const STATE_HIGHLIGHT_REGIONS = "state-highlight-regions";
+export const STATE_SELECTED_EXPERIMENTS = "state-selected-experiments";
+export const STATE_SELECTED_EXPERIMENT = "state-selected-experiment";
+export const STATE_ITEM_COUNTS = "state-item-counts";
+export const STATE_SOURCE_TYPE = "state-source-type";
+export const STATE_ANALYSIS = "state-analysis";
+export const STATE_COVERAGE_TYPE = "state-coverage-type";
+export const STATE_LEGEND_INTERVALS = "state-legend-intervals";
+
+export const COVERAGE_TYPE_COUNT = "coverage-type-count";
+export const COVERAGE_TYPE_SIG = "coverage-type-sig";
+export const COVERAGE_TYPE_EFFECT = "coverage-type-effect";

--- a/cegs_portal/search/static/search/js/exp_viz/covTypeUtils.js
+++ b/cegs_portal/search/static/search/js/exp_viz/covTypeUtils.js
@@ -1,0 +1,66 @@
+import {STATE_COVERAGE_TYPE, COVERAGE_TYPE_COUNT, COVERAGE_TYPE_EFFECT, COVERAGE_TYPE_SIG} from "./consts.js";
+
+export function coverageTypeFunctions(count, sig, effect) {
+    return (state) => {
+        const coverage_type = state.g(STATE_COVERAGE_TYPE);
+        if (coverage_type == COVERAGE_TYPE_COUNT) {
+            return count;
+        } else if (coverage_type == COVERAGE_TYPE_SIG) {
+            return sig;
+        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
+            return effect;
+        }
+    };
+}
+
+export function coverageTypeDeferredFunctions(count, sig, effect) {
+    return (state) => {
+        const coverage_type = state.g(STATE_COVERAGE_TYPE);
+        if (coverage_type == COVERAGE_TYPE_COUNT) {
+            return count(state);
+        } else if (coverage_type == COVERAGE_TYPE_SIG) {
+            return sig(state);
+        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
+            return effect(state);
+        }
+    };
+}
+
+export function coverageValue(selectedCoverageType) {
+    if (selectedCoverageType == "count") {
+        return COVERAGE_TYPE_COUNT;
+    } else if (selectedCoverageType == "sig") {
+        return COVERAGE_TYPE_SIG;
+    } else if (selectedCoverageType == "effect") {
+        return COVERAGE_TYPE_EFFECT;
+    }
+}
+
+function valueInterval(selector) {
+    return (chroms, interval, chromoIndex) => {
+        if (chromoIndex) {
+            chroms = [chroms[chromoIndex]];
+        }
+        let max = Number.NEGATIVE_INFINITY;
+        let min = Number.POSITIVE_INFINITY;
+        for (const chrom of chroms) {
+            const values = chrom[interval].map(selector);
+            max = Math.max(max, Math.max(...values));
+            min = Math.min(min, Math.min(...values));
+        }
+
+        if (max == Number.NEGATIVE_INFINITY || min == Number.POSITIVE_INFINITY) {
+            return [0, 0];
+        }
+
+        return [min, max];
+    };
+}
+
+export const levelCountInterval = valueInterval((d) => d.count);
+export const sigInterval = valueInterval((d) => d.max_log10_sig);
+export const effectInterval = valueInterval((d) => d.max_abs_effect);
+
+let getLegendIntervalFunc = coverageTypeFunctions(levelCountInterval, sigInterval, effectInterval);
+
+export {getLegendIntervalFunc};

--- a/cegs_portal/search/static/search/js/exp_viz/coverageData.js
+++ b/cegs_portal/search/static/search/js/exp_viz/coverageData.js
@@ -1,0 +1,14 @@
+export function mergeFilteredData(current_data, response_data) {
+    if (current_data.length == 0) {
+        return response_data;
+    }
+
+    let resp_obj = response_data.reduce((obj, chrom) => {
+        obj[chrom.chrom] = chrom;
+        return obj;
+    }, {});
+
+    return current_data.map((chrom) => {
+        return chrom.chrom in resp_obj ? resp_obj[chrom.chrom] : chrom;
+    });
+}

--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -2,36 +2,44 @@ import {a, cc, e, g, rc, t} from "../dom.js";
 import {State} from "../state.js";
 import {getRegions} from "../bed.js";
 import {getJson, postJson} from "../files.js";
-import {Legend} from "./obsLegend.js";
 import {GenomeRenderer} from "./chromosomeSvg.js";
 import {getDownloadRegions, getDownloadAll} from "./downloads.js";
 import {debounce} from "../utils.js";
-
-const STATE_ZOOMED = "state-zoomed";
-const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
-const STATE_SCALE = "state-scale";
-const STATE_SCALE_X = "state-scale-x";
-const STATE_SCALE_Y = "state-scale-y";
-const STATE_VIEWBOX = "state-viewbox";
-const STATE_FACETS = "state-facets";
-const STATE_CATEGORICAL_FACET_VALUES = "state-categorical-facets";
-const STATE_NUMERIC_FACET_VALUES = "state-numeric-facets";
-const STATE_COUNT_FILTER_VALUES = "state-count-filter";
-const STATE_COVERAGE_DATA = "state-coverage-data";
-const STATE_ALL_FILTERED = "state-all-filtered";
-const STATE_NUMERIC_FILTER_INTERVALS = "state-numeric-filter-intervals";
-const STATE_COUNT_FILTER_INTERVALS = "state-count-filter-intervals";
-const STATE_HIGHLIGHT_REGIONS = "state-highlight-regions";
-const STATE_SELECTED_EXPERIMENTS = "state-selected-experiments";
-const STATE_ITEM_COUNTS = "state-item-counts";
-const STATE_SOURCE_TYPE = "state-source-type";
-const STATE_ANALYSIS = "state-analysis";
-const STATE_COVERAGE_TYPE = "state-coverage-type";
-const STATE_LEGEND_INTERVALS = "state-legend-intervals";
-
-const COVERAGE_TYPE_COUNT = "coverage-type-count";
-const COVERAGE_TYPE_SIG = "coverage-type-sig";
-const COVERAGE_TYPE_EFFECT = "coverage-type-effect";
+import {render} from "./render.js";
+import {getHighlightRegions} from "./highlightRegions.js";
+import {mergeFilteredData} from "./coverageData.js";
+import {coverageValue, effectInterval, levelCountInterval, sigInterval} from "./covTypeUtils.js";
+import {
+    STATE_ZOOMED,
+    STATE_ZOOM_CHROMO_INDEX,
+    STATE_SCALE,
+    STATE_SCALE_X,
+    STATE_SCALE_Y,
+    STATE_VIEWBOX,
+    STATE_FACETS,
+    STATE_CATEGORICAL_FACET_VALUES,
+    STATE_NUMERIC_FACET_VALUES,
+    STATE_COUNT_FILTER_VALUES,
+    STATE_COVERAGE_DATA,
+    STATE_ALL_FILTERED,
+    STATE_NUMERIC_FILTER_INTERVALS,
+    STATE_COUNT_FILTER_INTERVALS,
+    STATE_HIGHLIGHT_REGIONS,
+    STATE_SELECTED_EXPERIMENT,
+    STATE_ITEM_COUNTS,
+    STATE_SOURCE_TYPE,
+    STATE_ANALYSIS,
+    STATE_COVERAGE_TYPE,
+    STATE_LEGEND_INTERVALS,
+} from "./consts.js";
+import {
+    numericFilterControls,
+    countFilterControls,
+    getFilterBody,
+    setFacetControls,
+    setCountControls,
+    setLegendIntervals,
+} from "./ui.js";
 
 function build_state(manifest, genomeRenderer, exprAccessionID, analysisAccessionID, sourceType) {
     let coverageData = manifest.chromosomes;
@@ -71,7 +79,7 @@ function build_state(manifest, genomeRenderer, exprAccessionID, analysisAccessio
         [STATE_COUNT_FILTER_INTERVALS]: {source: sourceCountInterval, target: targetCountInterval},
         [STATE_COUNT_FILTER_VALUES]: [sourceCountInterval, targetCountInterval],
         [STATE_HIGHLIGHT_REGIONS]: {},
-        [STATE_SELECTED_EXPERIMENTS]: [exprAccessionID],
+        [STATE_SELECTED_EXPERIMENT]: exprAccessionID,
         [STATE_ITEM_COUNTS]: [reoCount, sourceCount, targetCount],
         [STATE_SOURCE_TYPE]: sourceType,
         [STATE_ANALYSIS]: analysisAccessionID,
@@ -111,439 +119,8 @@ async function getCoverageData(staticRoot, exprAccessionID, analysisAccessionID)
     return [genome, manifest];
 }
 
-function render(state, genomeRenderer) {
-    const viewBox = state.g(STATE_VIEWBOX);
-    const scale = state.g(STATE_SCALE);
-    const scaleX = state.g(STATE_SCALE_X);
-    const scaleY = state.g(STATE_SCALE_Y);
-    const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
-    let currentLevel = state.g(STATE_ALL_FILTERED);
-    let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
-    let itemCounts = state.g(STATE_ITEM_COUNTS);
-    let legendIntervals = state.g(STATE_LEGEND_INTERVALS);
-
-    let sourceColors = sourceRenderColors(state);
-    let targetColors = targetRenderColors(state);
-
-    rc(
-        g("chrom-data"),
-        genomeRenderer.render(
-            currentLevel,
-            focusIndex,
-            sourceColors,
-            targetColors,
-            sourceRenderDataTransform(state),
-            targetRenderDataTransform(state),
-            tooltipDataSelectors,
-            sourceTooltipDataLabel(state),
-            targetTooltipDataLabel,
-            viewBox,
-            scale,
-            scaleX,
-            scaleY,
-            highlightRegions
-        )
-    );
-    rc(
-        g("chrom-data-legend"),
-        Legend(d3.scaleSequential(legendIntervals.source, sourceColors.color), {
-            title: sourceLegendTitle(state),
-        })
-    );
-    a(
-        g("chrom-data-legend"),
-        Legend(d3.scaleSequential(legendIntervals.target, targetColors.color), {
-            title: targetLegendTitle(state),
-        })
-    );
-    rc(g("reo-count"), t(`Observations: ${itemCounts[0].toLocaleString()}`));
-    rc(g("source-count"), t(`${state.g(STATE_SOURCE_TYPE)}s: ${itemCounts[1].toLocaleString()}`));
-    rc(g("target-count"), t(`Genes: ${itemCounts[2].toLocaleString()}`));
-}
-
-function categoricalFilterControls(facets, default_facets) {
-    return facets
-        .filter((f) => f.facet_type == "FacetType.CATEGORICAL")
-        .map((facet) => {
-            return e("fieldset", {name: "facetfield", class: "my-4"}, [
-                e("legend", {class: "font-bold"}, facet.name),
-                e(
-                    "div",
-                    {class: "flex flex-row flex-wrap gap-1"},
-                    Object.entries(facet.values).map((entry) => {
-                        return e("div", {class: "ml-1"}, [
-                            default_facets.includes(parseInt(entry[0]))
-                                ? e("input", {type: "checkbox", id: entry[0], name: facet.name, checked: "true"}, [])
-                                : e("input", {type: "checkbox", id: entry[0], name: facet.name}, []),
-                            e("label", {for: entry[0]}, entry[1]),
-                        ]);
-                    })
-                ),
-            ]);
-        });
-}
-
-function numericFilterControls(state, facets) {
-    const numericFacets = facets.filter((f) => f.facet_type == "FacetType.NUMERIC");
-    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
-    let filterNodes = [];
-    let intervals = state.g(STATE_NUMERIC_FILTER_INTERVALS);
-
-    for (let i = 0; i < numericFacets.length; i++) {
-        let facet = numericFacets[i];
-        let sliderNode = sliderNodes[i];
-
-        let range;
-        let sliderLabel;
-
-        if (facet.name === "Effect Size") {
-            range = intervals.effect;
-            sliderLabel = facet.name;
-        } else if (facet.name === "Significance") {
-            range = [intervals.sig[0], intervals.sig[1]];
-            sliderLabel = "Significance (-log10)";
-        } else {
-            continue;
-        }
-
-        noUiSlider.create(sliderNode, {
-            start: [range[0], range[1]],
-            format: {
-                to: (n) => n.toPrecision(3),
-                from: (s) => Number.parseFloat(s),
-            },
-            connect: true,
-            range: {
-                min: range[0],
-                max: range[1],
-            },
-            pips: {
-                mode: "range",
-                density: 5,
-                format: {
-                    to: (n) => n.toPrecision(3),
-                    from: (s) => Number.parseFloat(s),
-                },
-            },
-        });
-
-        sliderNode.noUiSlider.on("start", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
-        });
-
-        sliderNode.noUiSlider.on("end", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
-        });
-
-        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", sliderLabel), sliderNode]));
-    }
-
-    sliderNodes.forEach((sliderNode) => {
-        sliderNode.noUiSlider.on("slide", function (values, handle) {
-            state.u(
-                STATE_NUMERIC_FACET_VALUES,
-                sliderNodes.map((n) => n.noUiSlider.get(true))
-            );
-        });
-    });
-
-    return filterNodes;
-}
-
-function countFilterControls(state) {
-    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
-    let filterNodes = [];
-    let intervals = state.g(STATE_COUNT_FILTER_INTERVALS);
-
-    for (let i = 0; i < 2; i++) {
-        let sliderNode = sliderNodes[i];
-
-        let range;
-        let name;
-
-        if (i == 0) {
-            range = intervals.source;
-            name = `Number of ${state.g(STATE_SOURCE_TYPE)}s`;
-        } else if (i == 1) {
-            range = intervals.target;
-            name = "Number of Genes Assayed";
-        } else {
-            continue;
-        }
-
-        noUiSlider.create(sliderNode, {
-            start: [range[0], range[1]],
-            step: 1,
-            connect: true,
-            range: {
-                min: range[0],
-                max: range[1],
-            },
-            pips: {
-                mode: "range",
-                density: 5,
-            },
-        });
-
-        sliderNode.noUiSlider.on("start", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
-        });
-
-        sliderNode.noUiSlider.on("end", function (values, handle) {
-            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
-        });
-
-        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", name), sliderNode]));
-    }
-
-    sliderNodes.forEach((sliderNode) => {
-        sliderNode.noUiSlider.on("slide", function (values, handle) {
-            state.u(
-                STATE_COUNT_FILTER_VALUES,
-                sliderNodes.map((n) => n.noUiSlider.get(true))
-            );
-        });
-    });
-
-    return filterNodes;
-}
-
-function getFilterBody(state, genome, chroms, filter_values) {
-    let filters = {
-        filters: filter_values,
-        chromosomes: genome.map((c) => c.chrom),
-    };
-    if (state.g(STATE_ZOOMED)) {
-        let zoomChromoIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
-        filters.zoom = chroms[zoomChromoIndex].chrom;
-    }
-
-    return filters;
-}
-
-function mergeFilteredData(current_data, response_data) {
-    let resp_obj = response_data.reduce((obj, chrom) => {
-        obj[chrom.chrom] = chrom;
-        return obj;
-    }, {});
-
-    return current_data.map((chrom) => {
-        return chrom.chrom in resp_obj ? resp_obj[chrom.chrom] : chrom;
-    });
-}
-
-function experimentsQuery(state) {
-    let selectedExperiments = state.g(STATE_SELECTED_EXPERIMENTS);
-    return selectedExperiments.map((e) => `exp=${e}`).join("&");
-}
-
-function valueInterval(selector) {
-    return (chroms, interval, chromoIndex) => {
-        if (chromoIndex) {
-            chroms = [chroms[chromoIndex]];
-        }
-        let max = Number.NEGATIVE_INFINITY;
-        let min = Number.POSITIVE_INFINITY;
-        for (const chrom of chroms) {
-            const values = chrom[interval].map(selector);
-            max = Math.max(max, Math.max(...values));
-            min = Math.min(min, Math.min(...values));
-        }
-
-        if (max == Number.NEGATIVE_INFINITY || min == Number.POSITIVE_INFINITY) {
-            return [0, 0];
-        }
-
-        return [min, max];
-    };
-}
-
-const levelCountInterval = valueInterval((d) => d.count);
-const sigInterval = valueInterval((d) => d.max_log10_sig);
-const effectInterval = valueInterval((d) => d.max_abs_effect);
-
-function coverageTypeFunctions(count, sig, effect) {
-    return (state) => {
-        const coverage_type = state.g(STATE_COVERAGE_TYPE);
-        if (coverage_type == COVERAGE_TYPE_COUNT) {
-            return count;
-        } else if (coverage_type == COVERAGE_TYPE_SIG) {
-            return sig;
-        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
-            return effect;
-        }
-    };
-}
-
-function coverageTypeDeferredFunctions(count, sig, effect) {
-    return (state) => {
-        const coverage_type = state.g(STATE_COVERAGE_TYPE);
-        if (coverage_type == COVERAGE_TYPE_COUNT) {
-            return count(state);
-        } else if (coverage_type == COVERAGE_TYPE_SIG) {
-            return sig(state);
-        } else if (coverage_type == COVERAGE_TYPE_EFFECT) {
-            return effect(state);
-        }
-    };
-}
-
-let getLegendIntervalFunc = coverageTypeFunctions(levelCountInterval, sigInterval, effectInterval);
-
-let tooltipDataSelectors = [
-    (d) => d.count,
-    (d) => {
-        if (d.max_log10_sig >= 0.001) {
-            return d.max_log10_sig.toFixed(3); // e.g., 12.34567890 -> 12.345
-        } else {
-            return d.max_log10_sig.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
-        }
-    },
-    (d) => {
-        if (Math.abs(d.max_abs_effect) >= 0.001) {
-            return d.max_abs_effect.toFixed(3); // e.g., 12.34567890 -> 12.345
-        } else {
-            return d.max_abs_effect.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
-        }
-    },
-];
-
-function sourceTooltipDataLabel(state) {
-    return [`${state.g(STATE_SOURCE_TYPE)} Count`, "Largest Significance", "Greatest Effect Size"];
-}
-let targetTooltipDataLabel = ["Gene Count", "Largest Significance", "Greatest Effect Size"];
-
-let sourceLegendTitle = coverageTypeDeferredFunctions(
-    (state) => `Number of ${state.g(STATE_SOURCE_TYPE)}s`,
-    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Significance`,
-    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Size`
-);
-
-let targetLegendTitle = coverageTypeFunctions(
-    "Number of Genes Assayed",
-    "Significance of Effect on Assayed Genes",
-    "Size of Effect on Assayed Genes"
-);
-
-let sourceRenderDataTransform = coverageTypeDeferredFunctions(
-    (state) => {
-        return (d) => {
-            let sourceCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).source;
-            let sourceCountRange = sourceCountInterval[1] - sourceCountInterval[0];
-            return (d.count - sourceCountInterval[0]) / sourceCountRange;
-        };
-    },
-    (state) => (d) => {
-        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
-        let significanceRange = significanceInterval[1] - significanceInterval[0];
-        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
-    },
-    (state) => (d) => {
-        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
-        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
-        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
-    }
-);
-
-let targetRenderDataTransform = coverageTypeDeferredFunctions(
-    (state) => {
-        return (d) => {
-            let targetCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).target;
-            let targetCountRange = targetCountInterval[1] - targetCountInterval[0];
-            return (d.count - targetCountInterval[0]) / targetCountRange;
-        };
-    },
-    (state) => (d) => {
-        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
-        let significanceRange = significanceInterval[1] - significanceInterval[0];
-        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
-    },
-    (state) => (d) => {
-        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
-        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
-        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
-    }
-);
-
-let sourceRenderColors = coverageTypeFunctions(
-    {
-        color: d3.interpolateCool,
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(-260, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
-    }
-);
-
-let targetRenderColors = coverageTypeFunctions(
-    {
-        color: d3.interpolateWarm,
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(-100, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
-    }
-);
-
-function setFacetControls(state, categoricalFacetControls, defaultFacets, facets) {
-    cc(categoricalFacetControls);
-    categoricalFilterControls(facets, defaultFacets).forEach((element) => {
-        a(categoricalFacetControls, element);
-    });
-    let facetCheckboxes = categoricalFacetControls.querySelectorAll("input[type=checkbox]");
-    facetCheckboxes.forEach((checkbox) => {
-        checkbox.addEventListener("change", (_) => {
-            let checkedFacets = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
-                .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
-                .map((i) => Number(i.id));
-            state.u(STATE_CATEGORICAL_FACET_VALUES, checkedFacets);
-        });
-    });
-
-    let effectSizeFilterInterval = facets.filter((f) => f.name === "Effect Size")[0].range;
-    let sigFilterInterval = facets.filter((f) => f.name === "Significance")[0].range64;
-    state.u(STATE_NUMERIC_FILTER_INTERVALS, {effect: effectSizeFilterInterval, sig: sigFilterInterval});
-}
-
-function setCountControls(state, coverageData) {
-    let sourceCountInterval = levelCountInterval(coverageData, "source_intervals");
-    let targetCountInterval = levelCountInterval(coverageData, "target_intervals");
-    state.u(STATE_COUNT_FILTER_INTERVALS, {source: sourceCountInterval, target: targetCountInterval});
-    state.u(STATE_COUNT_FILTER_VALUES, [sourceCountInterval, targetCountInterval]);
-}
-
-function setLegendIntervals(state, coverageData) {
-    let legendInterval = getLegendIntervalFunc(state);
-    let sourceLegendInterval = legendInterval(coverageData, "source_intervals");
-    let targetLegendInterval = legendInterval(coverageData, "target_intervals");
-    state.u(STATE_LEGEND_INTERVALS, {source: sourceLegendInterval, target: targetLegendInterval});
-}
-
-function getHighlightRegions(regionUploadInput, regionReader) {
-    if (regionUploadInput.files.length != 1) {
-        return;
-    }
-    regionReader.readAsText(regionUploadInput.files[0]);
-}
-
-function coverageValue(selectedCoverageType) {
-    if (selectedCoverageType == "count") {
-        return COVERAGE_TYPE_COUNT;
-    } else if (selectedCoverageType == "sig") {
-        return COVERAGE_TYPE_SIG;
-    } else if (selectedCoverageType == "effect") {
-        return COVERAGE_TYPE_EFFECT;
-    }
+function experimentQuery(state) {
+    return `exp=${state.g(STATE_SELECTED_EXPERIMENT)}`;
 }
 
 export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, csrfToken, sourceType, loggedIn) {
@@ -608,7 +185,7 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
             state.g(STATE_NUMERIC_FACET_VALUES),
         ]);
 
-        postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+        postJson(`/search/experiment_coverage?${experimentQuery(state)}`, JSON.stringify(body)).then(
             (response_json) => {
                 state.u(
                     STATE_COVERAGE_DATA,
@@ -628,7 +205,7 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
             // Send facet data to server to get filtered data and updated numeric facets
             let body = getFilterBody(state, genome, manifest.chromosomes, [state.g(STATE_CATEGORICAL_FACET_VALUES)]);
 
-            postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+            postJson(`/search/experiment_coverage?${experimentQuery(state)}`, JSON.stringify(body)).then(
                 (response_json) => {
                     state.u(
                         STATE_COVERAGE_DATA,
@@ -659,7 +236,7 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
                 state.g(STATE_NUMERIC_FACET_VALUES),
             ]);
 
-            postJson(`/search/experiment_coverage?${experimentsQuery(state)}`, JSON.stringify(body)).then(
+            postJson(`/search/experiment_coverage?${experimentQuery(state)}`, JSON.stringify(body)).then(
                 (response_json) => {
                     state.u(
                         STATE_COVERAGE_DATA,

--- a/cegs_portal/search/static/search/js/exp_viz/highlightRegions.js
+++ b/cegs_portal/search/static/search/js/exp_viz/highlightRegions.js
@@ -1,0 +1,6 @@
+export function getHighlightRegions(regionUploadInput, regionReader) {
+    if (regionUploadInput.files.length != 1) {
+        return;
+    }
+    regionReader.readAsText(regionUploadInput.files[0]);
+}

--- a/cegs_portal/search/static/search/js/exp_viz/render.js
+++ b/cegs_portal/search/static/search/js/exp_viz/render.js
@@ -1,0 +1,173 @@
+import {a, g, rc, t} from "../dom.js";
+import {Legend} from "./obsLegend.js";
+import {coverageTypeDeferredFunctions, coverageTypeFunctions} from "./covTypeUtils.js";
+import {
+    STATE_ZOOM_CHROMO_INDEX,
+    STATE_SCALE,
+    STATE_SCALE_X,
+    STATE_SCALE_Y,
+    STATE_VIEWBOX,
+    STATE_ALL_FILTERED,
+    STATE_NUMERIC_FILTER_INTERVALS,
+    STATE_COUNT_FILTER_INTERVALS,
+    STATE_HIGHLIGHT_REGIONS,
+    STATE_ITEM_COUNTS,
+    STATE_SOURCE_TYPE,
+    STATE_LEGEND_INTERVALS,
+} from "./consts.js";
+
+let sourceRenderColors = coverageTypeFunctions(
+    {
+        color: d3.interpolateCool,
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(-260, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
+    }
+);
+
+let targetRenderColors = coverageTypeFunctions(
+    {
+        color: d3.interpolateWarm,
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(-100, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
+    },
+    {
+        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
+    }
+);
+
+let sourceRenderDataTransform = coverageTypeDeferredFunctions(
+    (state) => {
+        return (d) => {
+            let sourceCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).source;
+            let sourceCountRange = sourceCountInterval[1] - sourceCountInterval[0];
+            return (d.count - sourceCountInterval[0]) / sourceCountRange;
+        };
+    },
+    (state) => (d) => {
+        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
+        let significanceRange = significanceInterval[1] - significanceInterval[0];
+        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
+    },
+    (state) => (d) => {
+        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
+        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
+        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
+    }
+);
+
+let targetRenderDataTransform = coverageTypeDeferredFunctions(
+    (state) => {
+        return (d) => {
+            let targetCountInterval = state.g(STATE_COUNT_FILTER_INTERVALS).target;
+            let targetCountRange = targetCountInterval[1] - targetCountInterval[0];
+            return (d.count - targetCountInterval[0]) / targetCountRange;
+        };
+    },
+    (state) => (d) => {
+        let significanceInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).sig;
+        let significanceRange = significanceInterval[1] - significanceInterval[0];
+        return (d.max_log10_sig - significanceInterval[0]) / significanceRange;
+    },
+    (state) => (d) => {
+        let effectSizeInterval = state.g(STATE_NUMERIC_FILTER_INTERVALS).effect;
+        let effectSizeRange = effectSizeInterval[1] - effectSizeInterval[0];
+        return (d.max_abs_effect - effectSizeInterval[0]) / effectSizeRange;
+    }
+);
+
+function sourceTooltipDataLabel(state) {
+    return [`${state.g(STATE_SOURCE_TYPE)} Count`, "Largest Significance", "Greatest Effect Size"];
+}
+
+let targetTooltipDataLabel = ["Gene Count", "Largest Significance", "Greatest Effect Size"];
+
+let sourceLegendTitle = coverageTypeDeferredFunctions(
+    (state) => `Number of ${state.g(STATE_SOURCE_TYPE)}s`,
+    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Significance`,
+    (state) => `${state.g(STATE_SOURCE_TYPE)} Effect Size`
+);
+
+let targetLegendTitle = coverageTypeFunctions(
+    "Number of Genes Assayed",
+    "Significance of Effect on Assayed Genes",
+    "Size of Effect on Assayed Genes"
+);
+
+let tooltipDataSelectors = [
+    (d) => d.count,
+    (d) => {
+        if (d.max_log10_sig >= 0.001) {
+            return d.max_log10_sig.toFixed(3); // e.g., 12.34567890 -> 12.345
+        } else {
+            return d.max_log10_sig.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
+        }
+    },
+    (d) => {
+        if (Math.abs(d.max_abs_effect) >= 0.001) {
+            return d.max_abs_effect.toFixed(3); // e.g., 12.34567890 -> 12.345
+        } else {
+            return d.max_abs_effect.toExponential(2); // e.g., 0.0000000000345345345 -> 3.45e-11
+        }
+    },
+];
+
+export function render(state, genomeRenderer) {
+    const viewBox = state.g(STATE_VIEWBOX);
+    const scale = state.g(STATE_SCALE);
+    const scaleX = state.g(STATE_SCALE_X);
+    const scaleY = state.g(STATE_SCALE_Y);
+    const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
+    let currentLevel = state.g(STATE_ALL_FILTERED);
+    let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
+    let itemCounts = state.g(STATE_ITEM_COUNTS);
+    let legendIntervals = state.g(STATE_LEGEND_INTERVALS);
+
+    let sourceColors = sourceRenderColors(state);
+    let targetColors = targetRenderColors(state);
+
+    rc(
+        g("chrom-data"),
+        genomeRenderer.render(
+            currentLevel,
+            focusIndex,
+            sourceColors,
+            targetColors,
+            sourceRenderDataTransform(state),
+            targetRenderDataTransform(state),
+            tooltipDataSelectors,
+            sourceTooltipDataLabel(state),
+            targetTooltipDataLabel,
+            viewBox,
+            scale,
+            scaleX,
+            scaleY,
+            highlightRegions
+        )
+    );
+    rc(
+        g("chrom-data-legend"),
+        Legend(d3.scaleSequential(legendIntervals.source, sourceColors.color), {
+            title: sourceLegendTitle(state),
+        })
+    );
+    a(
+        g("chrom-data-legend"),
+        Legend(d3.scaleSequential(legendIntervals.target, targetColors.color), {
+            title: targetLegendTitle(state),
+        })
+    );
+    rc(g("reo-count"), t(`Observations: ${itemCounts[0].toLocaleString()}`));
+    rc(g("source-count"), t(`${state.g(STATE_SOURCE_TYPE)}s: ${itemCounts[1].toLocaleString()}`));
+    rc(g("target-count"), t(`Genes: ${itemCounts[2].toLocaleString()}`));
+}

--- a/cegs_portal/search/static/search/js/exp_viz/ui.js
+++ b/cegs_portal/search/static/search/js/exp_viz/ui.js
@@ -1,0 +1,207 @@
+import {a, cc, e} from "../dom.js";
+import {getLegendIntervalFunc, levelCountInterval} from "./covTypeUtils.js";
+import {
+    STATE_CATEGORICAL_FACET_VALUES,
+    STATE_COUNT_FILTER_INTERVALS,
+    STATE_COUNT_FILTER_VALUES,
+    STATE_LEGEND_INTERVALS,
+    STATE_NUMERIC_FILTER_INTERVALS,
+    STATE_NUMERIC_FACET_VALUES,
+    STATE_SOURCE_TYPE,
+    STATE_ZOOM_CHROMO_INDEX,
+    STATE_ZOOMED,
+} from "./consts.js";
+
+export function categoricalFilterControls(facets, default_facets) {
+    return facets
+        .filter((f) => f.facet_type == "FacetType.CATEGORICAL")
+        .map((facet) => {
+            return e("fieldset", {name: "facetfield", class: "my-4"}, [
+                e("legend", {class: "font-bold"}, facet.name),
+                e(
+                    "div",
+                    {class: "flex flex-row flex-wrap gap-1"},
+                    Object.entries(facet.values).map((entry) => {
+                        return e("div", {class: "ml-1"}, [
+                            default_facets.includes(parseInt(entry[0]))
+                                ? e("input", {type: "checkbox", id: entry[0], name: facet.name, checked: "true"}, [])
+                                : e("input", {type: "checkbox", id: entry[0], name: facet.name}, []),
+                            e("label", {for: entry[0]}, entry[1]),
+                        ]);
+                    })
+                ),
+            ]);
+        });
+}
+
+export function numericFilterControls(state, facets) {
+    const numericFacets = facets.filter((f) => f.facet_type == "FacetType.NUMERIC");
+    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
+    let filterNodes = [];
+    let intervals = state.g(STATE_NUMERIC_FILTER_INTERVALS);
+
+    for (let i = 0; i < numericFacets.length; i++) {
+        let facet = numericFacets[i];
+        let sliderNode = sliderNodes[i];
+
+        let range;
+        let sliderLabel;
+
+        if (facet.name === "Effect Size") {
+            range = intervals.effect;
+            sliderLabel = facet.name;
+        } else if (facet.name === "Significance") {
+            range = [intervals.sig[0], intervals.sig[1]];
+            sliderLabel = "Significance (-log10)";
+        } else {
+            continue;
+        }
+
+        noUiSlider.create(sliderNode, {
+            start: [range[0], range[1]],
+            format: {
+                to: (n) => n.toPrecision(3),
+                from: (s) => Number.parseFloat(s),
+            },
+            connect: true,
+            range: {
+                min: range[0],
+                max: range[1],
+            },
+            pips: {
+                mode: "range",
+                density: 5,
+                format: {
+                    to: (n) => n.toPrecision(3),
+                    from: (s) => Number.parseFloat(s),
+                },
+            },
+        });
+
+        sliderNode.noUiSlider.on("start", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
+        });
+
+        sliderNode.noUiSlider.on("end", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
+        });
+
+        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", sliderLabel), sliderNode]));
+    }
+
+    sliderNodes.forEach((sliderNode) => {
+        sliderNode.noUiSlider.on("slide", function (values, handle) {
+            state.u(
+                STATE_NUMERIC_FACET_VALUES,
+                sliderNodes.map((n) => n.noUiSlider.get(true))
+            );
+        });
+    });
+
+    return filterNodes;
+}
+
+export function countFilterControls(state) {
+    let sliderNodes = [e("div", {name: "facetslider"}, []), e("div", {name: "facetslider"}, [])];
+    let filterNodes = [];
+    let intervals = state.g(STATE_COUNT_FILTER_INTERVALS);
+
+    for (let i = 0; i < 2; i++) {
+        let sliderNode = sliderNodes[i];
+
+        let range;
+        let name;
+
+        if (i == 0) {
+            range = intervals.source;
+            name = `Number of ${state.g(STATE_SOURCE_TYPE)}s`;
+        } else if (i == 1) {
+            range = intervals.target;
+            name = "Number of Genes Assayed";
+        } else {
+            continue;
+        }
+
+        noUiSlider.create(sliderNode, {
+            start: [range[0], range[1]],
+            step: 1,
+            connect: true,
+            range: {
+                min: range[0],
+                max: range[1],
+            },
+            pips: {
+                mode: "range",
+                density: 5,
+            },
+        });
+
+        sliderNode.noUiSlider.on("start", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [true, true]});
+        });
+
+        sliderNode.noUiSlider.on("end", function (values, handle) {
+            sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
+        });
+
+        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", name), sliderNode]));
+    }
+
+    sliderNodes.forEach((sliderNode) => {
+        sliderNode.noUiSlider.on("slide", function (values, handle) {
+            state.u(
+                STATE_COUNT_FILTER_VALUES,
+                sliderNodes.map((n) => n.noUiSlider.get(true))
+            );
+        });
+    });
+
+    return filterNodes;
+}
+
+export function getFilterBody(state, genome, chroms, filter_values) {
+    let filters = {
+        filters: filter_values,
+        chromosomes: genome.map((c) => c.chrom),
+    };
+    if (state.g(STATE_ZOOMED)) {
+        let zoomChromoIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
+        filters.zoom = chroms[zoomChromoIndex].chrom;
+    }
+
+    return filters;
+}
+
+export function setFacetControls(state, categoricalFacetControls, defaultFacets, facets) {
+    cc(categoricalFacetControls);
+    categoricalFilterControls(facets, defaultFacets).forEach((element) => {
+        a(categoricalFacetControls, element);
+    });
+    let facetCheckboxes = categoricalFacetControls.querySelectorAll("input[type=checkbox]");
+    facetCheckboxes.forEach((checkbox) => {
+        checkbox.addEventListener("change", (_) => {
+            let checkedFacets = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
+                .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
+                .map((i) => Number(i.id));
+            state.u(STATE_CATEGORICAL_FACET_VALUES, checkedFacets);
+        });
+    });
+
+    let effectSizeFilterInterval = facets.filter((f) => f.name === "Effect Size")[0].range;
+    let sigFilterInterval = facets.filter((f) => f.name === "Significance")[0].range64;
+    state.u(STATE_NUMERIC_FILTER_INTERVALS, {effect: effectSizeFilterInterval, sig: sigFilterInterval});
+}
+
+export function setCountControls(state, coverageData) {
+    let sourceCountInterval = levelCountInterval(coverageData, "source_intervals");
+    let targetCountInterval = levelCountInterval(coverageData, "target_intervals");
+    state.u(STATE_COUNT_FILTER_INTERVALS, {source: sourceCountInterval, target: targetCountInterval});
+    state.u(STATE_COUNT_FILTER_VALUES, [sourceCountInterval, targetCountInterval]);
+}
+
+export function setLegendIntervals(state, coverageData) {
+    let legendInterval = getLegendIntervalFunc(state);
+    let sourceLegendInterval = legendInterval(coverageData, "source_intervals");
+    let targetLegendInterval = legendInterval(coverageData, "target_intervals");
+    state.u(STATE_LEGEND_INTERVALS, {source: sourceLegendInterval, target: targetLegendInterval});
+}

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -1,4 +1,9 @@
-{% extends "base.html" %} {% load static i18n %} {% block css %} {{ block.super }}
+{% extends "base.html" %}
+
+{% load static i18n %}
+
+{% block css %}
+{{ block.super }}
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.25/css/jquery.dataTables.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
 <link href="{% static 'css/nouislider.min.css' %}" rel="stylesheet" />

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -123,7 +123,7 @@
                         <select name="views" id="covSelect">
                             <option value="sig">Largest Significance</option>
                             <option value="effect">Greatest Effect Size</option>
-                            <option value="count">{{ experiment.get_source_type_display }}/Gene Count</option>
+                            <option value="count">Gene Count</option>
                         </select>
                     </div>
                 </div>

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -3,13 +3,8 @@
 
 {% block css %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.25/css/jquery.dataTables.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
 <link href="{% static 'css/nouislider.min.css' %}" rel="stylesheet" />
-<script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-<script src="https://cdn.jsdelivr.net/npm/vega-lite@4"></script>
-<script src="https://cdn.jsdelivr.net/npm/vega-lite-api@4"></script>
-<script src="https://cdn.jsdelivr.net/npm/vega-tooltip"></script>
 <!-- This CSS modifies the range slider look -->
 <style>
     .noUi-horizontal {
@@ -52,7 +47,6 @@
 <script type="text/javascript" src="{% static 'search/js/exp_viz/vizUtils.js' %}"></script>
 <script type="text/javascript" src="https://d3js.org/d3.v7.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.js"></script>
 {% endblock %}
 
 {% block title %}Experiments{% endblock %}

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -1,6 +1,60 @@
 {% extends "base.html" %}
 {% load static i18n %}
 
+{% block css %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.25/css/jquery.dataTables.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+<link href="{% static 'css/nouislider.min.css' %}" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-lite@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-lite-api@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-tooltip"></script>
+<!-- This CSS modifies the range slider look -->
+<style>
+    .noUi-horizontal {
+        height: 10px;
+    }
+
+    .noUi-horizontal .noUi-handle {
+        width: 20px;
+        height: 20px;
+    }
+
+    .noUi-handle {
+        border-radius: 10px;
+    }
+
+    .noUi-handle:before,
+    .noUi-handle:after {
+        display: none;
+    }
+
+    .noUi-connect {
+        background: rgba(1, 33, 105, 1);
+    }
+
+    .noUi-pips-horizontal {
+        transform: translate(6px);
+    }
+
+    select {
+        font-size: 0.9rem;
+        padding: 5px 5px;
+    }
+
+</style>
+{% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script type="text/javascript" src="{% static 'js/nouislider.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'search/js/exp_viz/vizUtils.js' %}"></script>
+<script type="text/javascript" src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.js"></script>
+{% endblock %}
+
 {% block title %}Experiments{% endblock %}
 
 {% block content %}
@@ -13,4 +67,83 @@
         </ul>
     </div>
 </div>
+<div class="min-w-full">
+    <div
+        id="coverage"
+    >
+        <div class="flex flex-row gap-x-10">
+            <div id="chrom-data-filters" class="basis-1/4">
+                <!-- content section container for facet side bar -->
+                <div class="facet-content-section container">
+                    <div class="text-slate-500">
+                        <span id="chrom-data-header" class="text-xl font-bold"></span
+                        ><span class="bi bi-layers-half" style="margin-left: 0.5em"></span>
+                    </div>
+                    <div class="title-separator"></div>
+                    <div id="chrom-data-categorical-facets"></div>
+                    <div id="chrom-data-numeric-facets"></div>
+                    <div id="chrom-data-counts"></div>
+                </div>
+
+                <div class="facet-content-section container">
+                    <form name="regionUploadForm">
+                        <div>
+                            <label class="font-bold" for="regionFile">Highlight Regions</label>
+                            <input id="regionUploadInput" type="file" accept=".bed" name="regionFile" />
+                        </div>
+                    </form>
+                    <div id="regionUploadInputReset"></div>
+                </div>
+
+                {% if logged_in %}
+                <div class="facet-content-section container">
+                    <form name="dataDownloadForm">
+                        <div>
+                            <label class="font-bold" for="dataDlAll">Download All Selected Data*</label>
+                            <div><input id="dataDownloadAll" type="button" name="dataDlAll" value="Request Data" /></div>
+                        </div>
+                        <div class="mt-5">
+                            <label class="font-bold" for="dataDlFile">Download Some Selected Data*</label>
+                            <input id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
+                        </div>
+                    </form>
+                    <div id="dataDownloadLink" class="mt-5 mb-5"></div>
+                    <div>
+                    * Data downloads take facet filtering, except for "Number of {{ experiment.get_source_type_display }}s" and "Number of Genes Assayed", into account.
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+
+            <div class="basis-3/4 container">
+                <!-- content section container for ChromCov -->
+                <div class="flex flex-row gap-x-4 items-center">
+                    <div id="chrom-data-legend"></div>
+                    <div class="flex flex-col">
+                        <div id="reo-count"></div>
+                        <div id="source-count"></div>
+                        <div id="target-count"></div>
+                    </div>
+                    <div>
+                        <label for="covSelect">Choose a Coverage View:</label>
+                        <select name="views" id="covSelect">
+                            <option value="sig">Largest Significance</option>
+                            <option value="effect">Greatest Effect Size</option>
+                            <option value="count">{{ experiment.get_source_type_display }}/Gene Count</option>
+                        </select>
+                    </div>
+                </div>
+                <div id="chrom-data"></div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block inline_javascript %}
+{{ experiment_viz|json_script:"experiment_viz" }}
+<script type="module">
+    import {combined_viz} from "{% static 'search/js/exp_viz/combo_viz.js' %}";
+    combined_viz("{% get_static_prefix %}", "{{ csrf_token }}", "{{ logged_in }}" == "True");
+</script>
 {% endblock %}

--- a/cegs_portal/search/urls.py
+++ b/cegs_portal/search/urls.py
@@ -28,9 +28,9 @@ urlpatterns = [
         name="experiment_coverage",
     ),
     path(
-        "combined_experiments",
+        "combined_experiment_coverage",
         csrf_exempt(views.v1.CombinedExperimentView.as_view()),
-        name="combined_experiments",
+        name="combined_experiment_coverage",
     ),
     re_path(
         r"regeffect/source/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8})$",
@@ -67,7 +67,7 @@ urlpatterns = [
         csrf_exempt(views.v1.ExperimentCoverageView.as_view()),
     ),
     path(
-        "v1/combined_experiments",
+        "v1/combined_experiment_coverage",
         csrf_exempt(views.v1.CombinedExperimentView.as_view()),
     ),
     re_path(r"v1/regeffect/source/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8})$", views.v1.SourceEffectsView.as_view()),

--- a/cegs_portal/search/urls.py
+++ b/cegs_portal/search/urls.py
@@ -27,6 +27,11 @@ urlpatterns = [
         csrf_exempt(views.v1.ExperimentCoverageView.as_view()),
         name="experiment_coverage",
     ),
+    path(
+        "combined_experiments",
+        csrf_exempt(views.v1.CombinedExperimentView.as_view()),
+        name="combined_experiments",
+    ),
     re_path(
         r"regeffect/source/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8})$",
         views.v1.SourceEffectsView.as_view(),
@@ -60,7 +65,10 @@ urlpatterns = [
     path(
         "v1/experiment_coverage",
         csrf_exempt(views.v1.ExperimentCoverageView.as_view()),
-        name="experiment_coverage",
+    ),
+    path(
+        "v1/combined_experiments",
+        csrf_exempt(views.v1.CombinedExperimentView.as_view()),
     ),
     re_path(r"v1/regeffect/source/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8})$", views.v1.SourceEffectsView.as_view()),
     re_path(r"v1/regeffect/target/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8})$", views.v1.TargetEffectsView.as_view()),

--- a/cegs_portal/search/view_models/v1/experiment_coverage.py
+++ b/cegs_portal/search/view_models/v1/experiment_coverage.py
@@ -3,6 +3,14 @@ from cegs_portal.search.models import Experiment
 
 class ExperimentCoverageSearch:
     @classmethod
+    def default_analysis(cls, expr_id: str) -> tuple[str, str]:
+        return (
+            Experiment.objects.filter(accession_id=expr_id)
+            .select_related("default_analysis")
+            .values_list("accession_id", "default_analysis__accession_id")
+        )[0]
+
+    @classmethod
     def default_analyses(cls, expr_ids: list[str]) -> list[tuple[str, str]]:
         return list(
             Experiment.objects.filter(accession_id__in=expr_ids)

--- a/cegs_portal/search/views/v1/__init__.py
+++ b/cegs_portal/search/views/v1/__init__.py
@@ -1,6 +1,6 @@
 from .dna_features import DNAFeatureId, DNAFeatureLoc
 from .experiment import ExperimentListView, ExperimentsView, ExperimentView
-from .experiment_coverage import ExperimentCoverageView
+from .experiment_coverage import CombinedExperimentView, ExperimentCoverageView
 from .non_targeting_reos import NonTargetRegEffectsView
 from .reg_effects import RegEffectView, SourceEffectsView, TargetEffectsView
 from .search import (

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -129,6 +129,14 @@ class ExperimentsView(UserPassesTestMixin, MultiResponseFormatView):
             {
                 "logged_in": not request.user.is_anonymous,
                 "experiments": data,
+                "experiment_viz": [
+                    {
+                        "accession_id": exp.accession_id,
+                        "source": exp.get_source_type_display(),
+                        "analysis_accession_id": exp.default_analysis.accession_id,
+                    }
+                    for exp in data.all()
+                ],
             },
         )
 

--- a/cegs_portal/search/views/v1/experiment_coverage.py
+++ b/cegs_portal/search/views/v1/experiment_coverage.py
@@ -13,6 +13,9 @@ from exp_viz import (
     merge_filtered_data,
 )
 
+from cegs_portal.search.json_templates.v1.combined_experiments import (
+    combined_experiments,
+)
 from cegs_portal.search.json_templates.v1.experiment_coverage import experiment_coverage
 from cegs_portal.search.models.validators import validate_accession_id
 from cegs_portal.search.view_models.v1 import ExperimentCoverageSearch
@@ -78,6 +81,93 @@ def get_analyses(exp_acc_ids: list[str]) -> list[tuple[str, str]]:
 
 class ExperimentCoverageView(MultiResponseFormatView):
     json_renderer = experiment_coverage
+
+    def request_options(self, request):
+        """
+        GET queries used:
+            exp (multiple)
+                * Experiment Accession ID
+        POST body:
+            filters:
+                * object - the filter values
+            chromosomes:
+                * array - names of chromosomes that will be merged
+            zoom:
+                * str - the chromosome that's zoomed in on
+        """
+        options = super().request_options(request)
+        options["exp_acc_ids"] = request.GET.getlist("exp", [])
+
+        if len(options["exp_acc_ids"]) == 0:
+            raise Http400("Must query at least 1 experiment")
+
+        try:
+            body = json.loads(request.body)
+        except Exception as e:
+            raise Http400(f"Invalid request body:\n{request.body}") from e
+
+        try:
+            options["filters"] = body["filters"]
+        except Exception as e:
+            raise Http400(f'Invalid request body, no "filters" object:\n{request.body}') from e
+
+        try:
+            options["chromosomes"] = body["chromosomes"]
+        except Exception as e:
+            raise Http400(f'Invalid request body, no "chromosomes" object:\n{request.body}') from e
+
+        if (zoom_chr := body.get("zoom", None)) is not None and zoom_chr not in CHROM_NAMES:
+            raise Http400(f"Invalid chromosome in zoom: {zoom_chr}")
+        options["zoom_chr"] = zoom_chr
+
+        return options
+
+    def post(self, request, options, data):
+        raise Http400(
+            (
+                f'This is a JSON-only API. Please request using "Accept: {JSON_MIME}" header or '
+                f'pass "{JSON_MIME}" as the "accept" GET parameter.'
+            )
+        )
+
+    def post_json(self, _request, options, data, *args, **kwargs):
+        return HttpResponse(data.to_json(), content_type=JSON_MIME)
+
+    def post_data(self, options):
+        accession_ids = get_analyses(options["exp_acc_ids"])
+
+        filters = options["filters"]
+
+        data_filter = Filter()
+        data_filter.categorical_facets = set(filters[0])
+
+        if len(filters) > 1:
+            effect_size_interval, sig_interval = filters[1]
+            data_filter_intervals = FilterIntervals()
+            data_filter_intervals.effect = (effect_size_interval[0], effect_size_interval[1])
+            data_filter_intervals.sig = (sig_interval[0], sig_interval[1])
+            data_filter.numeric_intervals = data_filter_intervals
+
+        with ThreadPoolExecutor() as executor:
+            load_to_acc_id = {
+                executor.submit(load_coverage, exp_acc_id, analysis_acc_id, options["zoom_chr"]): (
+                    exp_acc_id,
+                    analysis_acc_id,
+                )
+                for exp_acc_id, analysis_acc_id in accession_ids
+            }
+            loaded_data = wait(load_to_acc_id, return_when=ALL_COMPLETED)
+            filter_to_acc_id = {
+                executor.submit(filter_coverage_data_allow_threads, data_filter, load_future.result())
+                for load_future in loaded_data.done
+            }
+            filtered_data = wait(filter_to_acc_id, return_when=ALL_COMPLETED)
+
+        return merge_filtered_data([d.result() for d in filtered_data.done], options["chromosomes"])
+
+
+class CombinedExperimentView(MultiResponseFormatView):
+    json_renderer = combined_experiments
 
     def request_options(self, request):
         """

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recomme
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage
 COPY --chown=django:root --from=python-build-stage /usr/src/app/wheels  /wheels
-COPY --chown=django:root --from=maturin /exp_viz/target/wheels/exp_viz-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl /wheels
+COPY --chown=django:root --from=maturin /exp_viz/target/wheels/exp_viz-0.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl /wheels
 
 # use wheels to install python dependencies
 RUN python -m pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recomme
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage
 COPY --chown=django:root --from=python-build-stage /usr/src/app/wheels  /wheels
-COPY --chown=django:root --from=maturin /exp_viz/target/wheels/exp_viz-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl /wheels
+COPY --chown=django:root --from=maturin /exp_viz/target/wheels/exp_viz-0.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl /wheels
 
 # use wheels to install python dependencies
 RUN python -m pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \

--- a/extensions/exp_viz/Cargo.lock
+++ b/extensions/exp_viz/Cargo.lock
@@ -43,10 +43,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cov_viz_ds"
-version = "0.3.0"
-source = "git+https://github.com/ReddyLab/cov_viz_ds?rev=c97744887871be107d220ee713c122726f908849#c97744887871be107d220ee713c122726f908849"
+version = "0.4.0"
 dependencies = [
  "bincode",
+ "roaring",
  "rustc-hash",
  "serde",
 ]
@@ -92,8 +92,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "exp_viz"
-version = "0.2.0"
-source = "git+https://github.com/ReddyLab/exp_viz?rev=b791a25b055071384c9d1c93253ff17cff64f15f#b791a25b055071384c9d1c93253ff17cff64f15f"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "cov_viz_ds",
@@ -106,12 +105,13 @@ dependencies = [
 
 [[package]]
 name = "exp_viz_extension"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bincode",
  "cov_viz_ds",
  "exp_viz",
  "pyo3",
+ "roaring",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/extensions/exp_viz/Cargo.lock
+++ b/extensions/exp_viz/Cargo.lock
@@ -44,6 +44,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cov_viz_ds"
 version = "0.4.0"
+source = "git+https://github.com/ReddyLab/cov_viz_ds?rev=0c58442bbef49acecb7ab2b5d7e2c150adaa61b5#0c58442bbef49acecb7ab2b5d7e2c150adaa61b5"
 dependencies = [
  "bincode",
  "roaring",
@@ -93,6 +94,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "exp_viz"
 version = "0.3.0"
+source = "git+https://github.com/ReddyLab/exp_viz?rev=7abf4eca583a9474214a91fe3713c04411722f2e#7abf4eca583a9474214a91fe3713c04411722f2e"
 dependencies = [
  "bincode",
  "cov_viz_ds",

--- a/extensions/exp_viz/Cargo.toml
+++ b/extensions/exp_viz/Cargo.toml
@@ -10,10 +10,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.3"
-# cov_viz_ds = { git = "https://github.com/ReddyLab/cov_viz_ds", rev = "c97744887871be107d220ee713c122726f908849" }
-cov_viz_ds = { path = "../../../cov_viz_ds" } # For working with a local copy during development
-# exp_viz = { git = "https://github.com/ReddyLab/exp_viz", rev = "b791a25b055071384c9d1c93253ff17cff64f15f" }
-exp_viz = { path = "../../../exp_viz" }                        # For working with a local copy during development
+cov_viz_ds = { git = "https://github.com/ReddyLab/cov_viz_ds", rev = "0c58442bbef49acecb7ab2b5d7e2c150adaa61b5" }
+# cov_viz_ds = { path = "../../../cov_viz_ds" } # For working with a local copy during development
+exp_viz = { git = "https://github.com/ReddyLab/exp_viz", rev = "7abf4eca583a9474214a91fe3713c04411722f2e" }
+# exp_viz = { path = "../../../exp_viz" }                        # For working with a local copy during development
 pyo3 = { version = "0.17.1", features = ["extension-module"] }
 roaring = "0.10.2"
 rustc-hash = "1.1.0"

--- a/extensions/exp_viz/Cargo.toml
+++ b/extensions/exp_viz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp_viz_extension"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,11 +10,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.3"
-cov_viz_ds = { git = "https://github.com/ReddyLab/cov_viz_ds", rev = "c97744887871be107d220ee713c122726f908849" }
-# cov_viz_ds = { path = "../../../cov_viz_ds" } # For working with a local copy during development
-exp_viz = { git = "https://github.com/ReddyLab/exp_viz", rev = "b791a25b055071384c9d1c93253ff17cff64f15f" }
-# exp_viz = { path = "../../../exp_viz" }                        # For working with a local copy during development
+# cov_viz_ds = { git = "https://github.com/ReddyLab/cov_viz_ds", rev = "c97744887871be107d220ee713c122726f908849" }
+cov_viz_ds = { path = "../../../cov_viz_ds" } # For working with a local copy during development
+# exp_viz = { git = "https://github.com/ReddyLab/exp_viz", rev = "b791a25b055071384c9d1c93253ff17cff64f15f" }
+exp_viz = { path = "../../../exp_viz" }                        # For working with a local copy during development
 pyo3 = { version = "0.17.1", features = ["extension-module"] }
+roaring = "0.10.2"
 rustc-hash = "1.1.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.82"

--- a/extensions/exp_viz/src/filter.rs
+++ b/extensions/exp_viz/src/filter.rs
@@ -1,18 +1,18 @@
 use pyo3::prelude::*;
 
 use crate::filter_data_structures::*;
-use crate::intersect_data_structures::PyIncludedFeatures;
+use crate::intersect_data_structures::PyExperimentFeatureData;
+use cov_viz_ds::ExperimentFeatureData;
 use exp_viz::filter_coverage_data as fcd;
-use exp_viz::IncludedFeatures;
 
 #[pyfunction]
 pub fn filter_coverage_data(
     filters: &PyFilter,
     data: &PyCoverageData,
-    included_features: Option<&PyIncludedFeatures>,
+    included_features: Option<&PyExperimentFeatureData>,
 ) -> PyResult<PyFilteredData> {
     let filtered_data = if let Some(included_features) = included_features {
-        let i_f: IncludedFeatures = included_features.to_included_features();
+        let i_f: ExperimentFeatureData = included_features.to_feature_data();
         fcd(&filters.as_filter(), &data.wraps, Some(&i_f))
     } else {
         fcd(&filters.as_filter(), &data.wraps, None)
@@ -26,7 +26,7 @@ pub fn filter_coverage_data_allow_threads(
     py: Python<'_>,
     filters: &PyFilter,
     data: &PyCoverageData,
-    included_features: Option<&PyIncludedFeatures>,
+    included_features: Option<&PyExperimentFeatureData>,
 ) -> PyResult<PyFilteredData> {
     py.allow_threads(|| filter_coverage_data(filters, data, included_features))
 }

--- a/extensions/exp_viz/src/filter_data_structures.rs
+++ b/extensions/exp_viz/src/filter_data_structures.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// Wraps the coverage data type so it can be passed to Python
 #[pyclass(name = "CoverageData")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PyCoverageData {
     pub wraps: CoverageData,
 }

--- a/extensions/exp_viz/src/intersect_data_structures.rs
+++ b/extensions/exp_viz/src/intersect_data_structures.rs
@@ -1,0 +1,19 @@
+use pyo3::prelude::*;
+use roaring::RoaringTreemap;
+
+use exp_viz::IncludedFeatures;
+
+#[pyclass(name = "IncludedFeatures")]
+pub struct PyIncludedFeatures {
+    pub sources: RoaringTreemap,
+    pub targets: RoaringTreemap,
+}
+
+impl PyIncludedFeatures {
+    pub fn to_included_features(&self) -> IncludedFeatures {
+        IncludedFeatures {
+            sources: self.sources.clone(),
+            targets: self.targets.clone(),
+        }
+    }
+}

--- a/extensions/exp_viz/src/intersect_data_structures.rs
+++ b/extensions/exp_viz/src/intersect_data_structures.rs
@@ -1,17 +1,18 @@
 use pyo3::prelude::*;
 use roaring::RoaringTreemap;
 
-use exp_viz::IncludedFeatures;
+use cov_viz_ds::ExperimentFeatureData;
 
-#[pyclass(name = "IncludedFeatures")]
-pub struct PyIncludedFeatures {
+#[pyclass(name = "ExperimentFeatureData")]
+#[derive(Clone, Debug)]
+pub struct PyExperimentFeatureData {
     pub sources: RoaringTreemap,
     pub targets: RoaringTreemap,
 }
 
-impl PyIncludedFeatures {
-    pub fn to_included_features(&self) -> IncludedFeatures {
-        IncludedFeatures {
+impl PyExperimentFeatureData {
+    pub fn to_feature_data(&self) -> ExperimentFeatureData {
+        ExperimentFeatureData {
             sources: self.sources.clone(),
             targets: self.targets.clone(),
         }

--- a/extensions/exp_viz/src/intersects.rs
+++ b/extensions/exp_viz/src/intersects.rs
@@ -1,0 +1,15 @@
+use pyo3::prelude::*;
+
+use crate::filter_data_structures::*;
+use crate::intersect_data_structures::PyIncludedFeatures;
+use exp_viz::intersect_coverage_data_features as icdf;
+
+#[pyfunction]
+pub fn intersect_coverage_data_features(data: Vec<PyCoverageData>) -> PyResult<PyIncludedFeatures> {
+    let intersected_features = icdf(data.into_iter().map(|c| c.wraps).collect());
+    println!("{:?}", intersected_features);
+    Ok(PyIncludedFeatures {
+        sources: intersected_features.0,
+        targets: intersected_features.1,
+    })
+}

--- a/extensions/exp_viz/src/intersects.rs
+++ b/extensions/exp_viz/src/intersects.rs
@@ -1,15 +1,15 @@
 use pyo3::prelude::*;
 
-use crate::filter_data_structures::*;
-use crate::intersect_data_structures::PyIncludedFeatures;
+use crate::intersect_data_structures::PyExperimentFeatureData;
 use exp_viz::intersect_coverage_data_features as icdf;
 
 #[pyfunction]
-pub fn intersect_coverage_data_features(data: Vec<PyCoverageData>) -> PyResult<PyIncludedFeatures> {
-    let intersected_features = icdf(data.into_iter().map(|c| c.wraps).collect());
-    println!("{:?}", intersected_features);
-    Ok(PyIncludedFeatures {
-        sources: intersected_features.0,
-        targets: intersected_features.1,
+pub fn intersect_coverage_data_features(
+    data: Vec<PyExperimentFeatureData>,
+) -> PyResult<PyExperimentFeatureData> {
+    let intersected_features = icdf(data.into_iter().map(|c| c.to_feature_data()).collect());
+    Ok(PyExperimentFeatureData {
+        sources: intersected_features.sources,
+        targets: intersected_features.targets,
     })
 }

--- a/extensions/exp_viz/src/lib.rs
+++ b/extensions/exp_viz/src/lib.rs
@@ -9,9 +9,12 @@ use pyo3::prelude::*;
 
 use crate::filter::{filter_coverage_data, filter_coverage_data_allow_threads};
 use crate::filter_data_structures::{PyFilter, PyFilterIntervals, PyFilteredData};
-use crate::intersect_data_structures::PyIncludedFeatures;
+use crate::intersect_data_structures::PyExperimentFeatureData;
 use crate::intersects::intersect_coverage_data_features;
-use crate::load::{load_coverage_data, load_coverage_data_allow_threads};
+use crate::load::{
+    load_coverage_data, load_coverage_data_allow_threads, load_feature_data,
+    load_feature_data_allow_threads,
+};
 use crate::merge::merge_filtered_data;
 
 /// A Python module implemented in Rust.
@@ -19,6 +22,8 @@ use crate::merge::merge_filtered_data;
 fn exp_viz(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load_coverage_data, m)?)?;
     m.add_function(wrap_pyfunction!(load_coverage_data_allow_threads, m)?)?;
+    m.add_function(wrap_pyfunction!(load_feature_data, m)?)?;
+    m.add_function(wrap_pyfunction!(load_feature_data_allow_threads, m)?)?;
     m.add_function(wrap_pyfunction!(filter_coverage_data, m)?)?;
     m.add_function(wrap_pyfunction!(filter_coverage_data_allow_threads, m)?)?;
     m.add_function(wrap_pyfunction!(intersect_coverage_data_features, m)?)?;
@@ -26,6 +31,6 @@ fn exp_viz(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyFilter>()?;
     m.add_class::<PyFilterIntervals>()?;
     m.add_class::<PyFilteredData>()?;
-    m.add_class::<PyIncludedFeatures>()?;
+    m.add_class::<PyExperimentFeatureData>()?;
     Ok(())
 }

--- a/extensions/exp_viz/src/lib.rs
+++ b/extensions/exp_viz/src/lib.rs
@@ -1,5 +1,7 @@
 mod filter;
 mod filter_data_structures;
+mod intersect_data_structures;
+mod intersects;
 mod load;
 mod merge;
 
@@ -7,6 +9,8 @@ use pyo3::prelude::*;
 
 use crate::filter::{filter_coverage_data, filter_coverage_data_allow_threads};
 use crate::filter_data_structures::{PyFilter, PyFilterIntervals, PyFilteredData};
+use crate::intersect_data_structures::PyIncludedFeatures;
+use crate::intersects::intersect_coverage_data_features;
 use crate::load::{load_coverage_data, load_coverage_data_allow_threads};
 use crate::merge::merge_filtered_data;
 
@@ -17,9 +21,11 @@ fn exp_viz(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(load_coverage_data_allow_threads, m)?)?;
     m.add_function(wrap_pyfunction!(filter_coverage_data, m)?)?;
     m.add_function(wrap_pyfunction!(filter_coverage_data_allow_threads, m)?)?;
+    m.add_function(wrap_pyfunction!(intersect_coverage_data_features, m)?)?;
     m.add_function(wrap_pyfunction!(merge_filtered_data, m)?)?;
     m.add_class::<PyFilter>()?;
     m.add_class::<PyFilterIntervals>()?;
     m.add_class::<PyFilteredData>()?;
+    m.add_class::<PyIncludedFeatures>()?;
     Ok(())
 }

--- a/extensions/exp_viz/src/load.rs
+++ b/extensions/exp_viz/src/load.rs
@@ -2,9 +2,10 @@ use pyo3::exceptions::PyOSError;
 use pyo3::prelude::*;
 use std::path::PathBuf;
 
-use cov_viz_ds::CoverageData;
+use cov_viz_ds::{CoverageData, ExperimentFeatureData};
 
 use crate::filter_data_structures::PyCoverageData;
+use crate::PyExperimentFeatureData;
 
 /// Loads the coverage data from disk
 #[pyfunction]
@@ -23,4 +24,26 @@ pub fn load_coverage_data_allow_threads(
     location: PathBuf,
 ) -> PyResult<PyCoverageData> {
     py.allow_threads(|| load_coverage_data(location))
+}
+
+/// Loads the experiment feature data from disk
+#[pyfunction]
+pub fn load_feature_data(location: PathBuf) -> PyResult<PyExperimentFeatureData> {
+    let result = match ExperimentFeatureData::deserialize(&location) {
+        Ok(data) => Ok(PyExperimentFeatureData {
+            sources: data.sources,
+            targets: data.targets,
+        }),
+        Err(e) => Err(PyOSError::new_err(e.to_string())),
+    };
+
+    result
+}
+
+#[pyfunction]
+pub fn load_feature_data_allow_threads(
+    py: Python<'_>,
+    location: PathBuf,
+) -> PyResult<PyExperimentFeatureData> {
+    py.allow_threads(|| load_feature_data(location))
 }


### PR DESCRIPTION
Combines and displays experiment coverage in a way similar to a single experiment. This includes the same ability to filter on facets.

A new kind of file has to be generated that includes data on the features each experiment has, so be sure to re-run `./scripts/data_generation/gen_experiment_coverage_viz.sh` after this gets merged into main.

The new visualization is, under the covers, different than that of the single experiment page. There is a lot of overlap though, so a lot of code was factored out to be shared between the two.

![Screenshot 2023-11-09 at 11 19 13 AM](https://github.com/ReddyLab/cegs-portal/assets/719958/dd10212a-4c57-4067-8e96-472140db8ff5)
