### PR TITLE
Format effect sizes differently

### DIFF
--- a/cegs_portal/search/templates/search/v1/partials/_feature_sig_reg_effects.html
+++ b/cegs_portal/search/templates/search/v1/partials/_feature_sig_reg_effects.html
@@ -24,9 +24,9 @@
                 <div>Target Genes: {% for gene in regeffect.targets.all %}<a href="{% url 'search:dna_features' 'accession' gene.accession_id %}">{{ gene.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</div>
                 {% endif %}
             </td>
-            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.effect_size|format_float }}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.significance|format_float }}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.raw_p_value|format_float }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.effect_size|format_effect_size }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.significance|format_pval }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.accession_id %}">{{ regeffect.raw_p_value|format_pval }}</a></td>
             <td><a href="{% url 'search:experiment' regeffect.experiment_accession_id %}">{{ regeffect.experiment.name }}</a></td>
         </tr>
         {% endfor %}

--- a/cegs_portal/search/templates/search/v1/partials/_non_targeting_reo.html
+++ b/cegs_portal/search/templates/search/v1/partials/_non_targeting_reo.html
@@ -41,9 +41,9 @@
             <td>
                 <span>{{ first_source.chrom_name }}: {{ first_source.location.lower|intcomma }} - {{ first_source.location.upper|add:"-1"|intcomma }}</span>
             </td>
-            <td>{{ reo.effect_size|format_float }}</td>
+            <td>{{ reo.effect_size|format_effect_size }}</td>
             <td>{{ reo.direction }}</td>
-            <td>{{ reo.significance|format_float }}</td>
+            <td>{{ reo.significance|format_pval }}</td>
             <td>{{ first_source.closest_gene_distance|intcomma }}</td>
             <td>
                 <div class="w-[100px]">

--- a/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects_table.html
+++ b/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects_table.html
@@ -12,9 +12,9 @@
                 <div>Target Genes: {% for gene in regeffect.target_info %}<a href="{% url 'search:dna_features' 'ensembl' gene.1 %}">{{ gene.0 }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</div>
                 {% endif %}
             </td>
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{{ regeffect.effect_size|format_float }}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{{ regeffect.sig|format_float }}</a></td>
-            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{{ regeffect.p_value|format_float }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{{ regeffect.effect_size|format_effect_size }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{{ regeffect.sig|format_pval }}</a></td>
+            <td><a href="{% url 'search:reg_effect' regeffect.reo_accession_id %}">{{ regeffect.p_value|format_pval }}</a></td>
             {% if forloop.first %}
             <td rowspan="{{ regeffects|length }}"><a href="{% url 'search:experiment' regeffect.expr_accession_id %}">{{ regeffect.expr_name }}</a></td>
             {% endif %}

--- a/cegs_portal/search/templates/search/v1/reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/reg_effect.html
@@ -67,9 +67,9 @@
             </tr>
             <tr>
                 <td class="italic">{{ regulatory_effect.direction }}</td>
-                <td>{{ regulatory_effect.effect_size|format_float }}</td>
-                <td>{{ regulatory_effect.significance|format_float }}</td>
-                <td>{{ regulatory_effect.raw_p_value|format_float }}</td>
+                <td>{{ regulatory_effect.effect_size|format_effect_size }}</td>
+                <td>{{ regulatory_effect.significance|format_pval }}</td>
+                <td>{{ regulatory_effect.raw_p_value|format_pval }}</td>
                 <td>{{ regulatory_effect.cell_lines|join:", " }}</td>
                 {% if regulatory_effect.tissue_types.exist %}
                 <td>{{ regulatory_effect.tissue_types|join:", " }}</td>

--- a/cegs_portal/search/templatetags/custom_helpers.py
+++ b/cegs_portal/search/templatetags/custom_helpers.py
@@ -9,7 +9,12 @@ def remove_underscores(value):
 
 
 @register.filter
-def format_float(value):
+def format_effect_size(value):
+    return f"{value:.3f}"
+
+
+@register.filter
+def format_pval(value):
     if abs(value) < 0.000001:
         return f"{value:.2e}"
     else:

--- a/cegs_portal/search/tsv_templates/v1/non_targeting_reos.py
+++ b/cegs_portal/search/tsv_templates/v1/non_targeting_reos.py
@@ -1,4 +1,4 @@
-from cegs_portal.search.templatetags.custom_helpers import format_float, if_strand
+from cegs_portal.search.templatetags.custom_helpers import if_strand
 
 
 def item_name(source, feature):
@@ -55,9 +55,9 @@ def non_targeting_regulatory_effects(data, options):
                 item_name(source, feature),
                 "0",
                 if_strand(feature.strand),
-                format_float(reo.effect_size),
+                reo.effect_size,
                 reo.direction,
-                format_float(reo.significance),
+                reo.significance,
                 source.closest_gene_distance,
                 source.get_feature_type_display(),
                 reo.experiment.name,

--- a/cegs_portal/search/tsv_templates/v1/reg_effects.py
+++ b/cegs_portal/search/tsv_templates/v1/reg_effects.py
@@ -1,5 +1,5 @@
 from cegs_portal.search.helpers.options import is_bed6
-from cegs_portal.search.templatetags.custom_helpers import format_float, if_strand
+from cegs_portal.search.templatetags.custom_helpers import if_strand
 
 
 def tested_element(source, target):
@@ -69,7 +69,7 @@ def reg_effects(reos, options):
                     if_strand(source.strand),
                     reo.effect_size,
                     reo.direction,
-                    format_float(reo.significance),
+                    reo.significance,
                     reo.experiment.name,
                     target.name if target else "N/A",
                 ]
@@ -117,7 +117,7 @@ def target_reg_effects(reos, options):
                     if_strand(source.strand),
                     reo.effect_size,
                     reo.direction,
-                    format_float(reo.significance),
+                    reo.significance,
                     reo.experiment.name,
                 ]
 

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -591,7 +591,7 @@ def test_sigdata(reg_effects, login_client: SearchClient):
                 <div>Tested Element Locations: <a href="/search/feature/accession/{sources[0].accession_id}">{f"{sources[0].chrom_name}:{sources[0].location.lower:,}-{sources[0].location.upper:,}"}</a>, <a href="/search/feature/accession/{sources[1].accession_id}">{f"{sources[1].chrom_name}:{sources[1].location.lower:,}-{sources[1].location.upper:,}"}</a>, <a href="/search/feature/accession/{sources[2].accession_id}">{f"{sources[2].chrom_name}:{sources[2].location.lower:,}-{sources[2].location.upper:,}"}</a></div>
 
             </td>
-            <td><a href="/search/regeffect/{effect_source.accession_id}">{effect_source.effect_size:.6f}</a></td>
+            <td><a href="/search/regeffect/{effect_source.accession_id}">{effect_source.effect_size:.3f}</a></td>
             <td><a href="/search/regeffect/{effect_source.accession_id}">{effect_source.significance:.6f}</a></td>
             <td><a href="/search/regeffect/{effect_source.accession_id}">{effect_source.raw_p_value:.6f}</a></td>
 
@@ -606,7 +606,7 @@ def test_sigdata(reg_effects, login_client: SearchClient):
                 <div>Target Genes: <a href="/search/feature/ensembl/{target.ensembl_id}">{target.name}</a></div>
 
             </td>
-            <td><a href="/search/regeffect/{effect_target.accession_id}">{effect_target.effect_size:.6f}</a></td>
+            <td><a href="/search/regeffect/{effect_target.accession_id}">{effect_target.effect_size:.3f}</a></td>
             <td><a href="/search/regeffect/{effect_target.accession_id}">{effect_target.significance:.6f}</a></td>
             <td><a href="/search/regeffect/{effect_target.accession_id}">{effect_target.raw_p_value:.6f}</a></td>
 


### PR DESCRIPTION
Alex suggested that effect sizes only need 3 digits after the decimal and anything smaller should be 0 (shown as 0.000 in this implementation)