### PR TITLE
Modify logging levels

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -114,11 +114,6 @@ LOGGING = {
     "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
     "formatters": {"verbose": {"format": "%(levelname)s %(asctime)s %(module)s " "%(process)d %(thread)d %(message)s"}},
     "handlers": {
-        "mail_admins": {
-            "level": "ERROR",
-            "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
-        },
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
@@ -128,13 +123,13 @@ LOGGING = {
     "root": {"level": "INFO", "handlers": ["console"]},
     "loggers": {
         "django.request": {
-            "handlers": ["mail_admins"],
-            "level": "ERROR",
+            "handlers": ["console"],
+            "level": "INFO",
             "propagate": True,
         },
         "django.security.DisallowedHost": {
             "level": "ERROR",
-            "handlers": ["console", "mail_admins"],
+            "handlers": ["console"],
             "propagate": True,
         },
     },

--- a/config/settings/qa.py
+++ b/config/settings/qa.py
@@ -133,11 +133,6 @@ LOGGING = {
     "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
     "formatters": {"verbose": {"format": "%(levelname)s %(asctime)s %(module)s " "%(process)d %(thread)d %(message)s"}},
     "handlers": {
-        "mail_admins": {
-            "level": "DEBUG",
-            "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
-        },
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
@@ -147,13 +142,13 @@ LOGGING = {
     "root": {"level": "INFO", "handlers": ["console"]},
     "loggers": {
         "django.request": {
-            "handlers": ["mail_admins"],
+            "handlers": ["console"],
             "level": "DEBUG",
             "propagate": True,
         },
         "django.security.DisallowedHost": {
             "level": "DEBUG",
-            "handlers": ["console", "mail_admins"],
+            "handlers": ["console"],
             "propagate": True,
         },
     },


### PR DESCRIPTION
We're going to try using Duke's splunk instance to monitor logs. For this to work we have to send logs to the container's stdout/stderr instead of logging to disk. we also have to make sure everything relevant gets logged.

Additionally, we don't need django to mail us. We'll set up alerts in splunk.

Django logging info:
https://docs.djangoproject.com/en/4.2/topics/logging/
https://docs.djangoproject.com/en/4.2/howto/logging/
https://docs.djangoproject.com/en/4.2/ref/logging/