### PR TITLE
Adjusts how associated cCREs are calculated

### DIFF
--- a/scripts/data_generation/ccre_bed.py
+++ b/scripts/data_generation/ccre_bed.py
@@ -1,0 +1,38 @@
+import argparse
+import sys
+from os import getenv
+
+import psycopg2
+from psycopg2 import sql
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Get all the cCREs for particular assembly")
+    parser.add_argument("-a", "--assembly", help="Genome assembly (GRCh37 or GRCh38)", required=True)
+    parser.add_argument(
+        "-o", "--output", help="Output file", type=argparse.FileType("w", encoding="ascii"), default=sys.stdout
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    database_connection = getenv("DATABASE_URL")
+    if database_connection is None:
+        exit("Please set a DATABASE_URL environment variable")
+    args = get_args()
+
+    if args.assembly not in ["GRCh37", "GRCh38"]:
+        exit("Please enter either GRCh37 or GRCh38 for the assembly")
+
+    with psycopg2.connect(database_connection) as connection:
+        with connection.cursor() as cursor:
+            cursor.copy_expert(
+                sql.SQL(
+                    """COPY (SELECT chrom_name, lower(location), upper(location)
+FROM public.search_dnafeature
+WHERE feature_type = 'DNAFeatureType.CCRE' and ref_genome = {}
+ORDER BY chrom_name, lower(location)) TO STDOUT WITH NULL AS ''"""
+                ).format(sql.Literal(args.assembly)),
+                args.output,
+            )

--- a/scripts/data_generation/ccre_overlaps.sh
+++ b/scripts/data_generation/ccre_overlaps.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # The file a .bed of DHS locations is generated from
 DATA_FILE=$1
 
-# The .bed of of cCREs
-CCRE_BED_FILE=$2
+ASSEMBLY=$2
+
 
 # The locations of the
 SOURCE_NAME_COL=$3
@@ -18,8 +18,11 @@ SOURCE_END_COL=$5
 # cCREs from $CCRE_BED_FILE
 OUTPUT_FILE=$6
 
+# The .bed of of cCREs
+CCRE_BED_FILE="ccre.bed"
+python scripts/data_generation/ccre_bed.py -a ${ASSEMBLY} -o ${CCRE_BED_FILE}
+
 PYTHONPATH=`pwd` python scripts/data_generation/source_loc_extractor.py -i ${DATA_FILE} -o out.bed --chr_name_col ${SOURCE_NAME_COL} --chr_start_col ${SOURCE_START_COL} --chr_end_col ${SOURCE_END_COL}
 sort -k1,1 -k2,2n out.bed | uniq > a.bed
-sort -k1,1 -k2,2n ${CCRE_BED_FILE} > b.bed
-bedtools intersect -wo -sorted -a a.bed -b b.bed > ${OUTPUT_FILE}
-rm out.bed a.bed b.bed
+bedtools intersect -wo -sorted -a a.bed -b ${CCRE_BED_FILE} > ${OUTPUT_FILE}
+rm out.bed a.bed ${CCRE_BED_FILE}

--- a/scripts/data_generation/gen_experiment_coverage_viz.sh
+++ b/scripts/data_generation/gen_experiment_coverage_viz.sh
@@ -12,7 +12,7 @@ gen_dir() {
 gen_data() {
     local ANALYSIS=$1
     local GENOME=$2
-    local OUTPUT_DIR=$3
+    local OUTPUT_DIR="${3}/${ANALYSIS}"
     local DEFAULT_FACETS=$4
 
     echo $ANALYSIS
@@ -61,17 +61,16 @@ gen_data() {
 
 default_facets=`python manage.py shell -c "from cegs_portal.search.models import FacetValue; print(' '.join(str(facet.id) for facet in FacetValue.objects.filter(value__in=['Depleted Only', 'Enriched Only', 'Mixed']).all()))"`
 
-gen_data DCPAN0000000000 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000001/DCPAN0000000000 "${default_facets}"
-gen_data DCPAN0000000002 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000002/DCPAN0000000002 "${default_facets}"
+gen_data DCPAN0000000000 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000002 "${default_facets}"
 
 # gen_data DCPEXPR0000000003 needs some changes to the cov_viz and related programs to work. Some
 # of the  REOs have null effect sizes because the "direction" of the effect is "both". Deferring
 # for now. It's also not clear how to surface that in the facet filter.
-# gen_data DCPAN0000000001 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000003/DCPAN0000000001 "${default_facets}"
+# gen_data DCPAN0000000001 GRCH37 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000003 "${default_facets}"
 
-gen_data DCPAN0000000003 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000004/DCPAN0000000003 "${default_facets}"
-gen_data DCPAN0000000004 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000005/DCPAN0000000004 "${default_facets}"
-gen_data DCPAN0000000005 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000006/DCPAN0000000005 "${default_facets}"
-gen_data DCPAN0000000006 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000007/DCPAN0000000006 "${default_facets}"
-gen_data DCPAN0000000007 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000008/DCPAN0000000007 "${default_facets}"
-gen_data DCPAN0000000008 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000009/DCPAN0000000008 "${default_facets}"
+gen_data DCPAN0000000002 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000004 "${default_facets}"
+gen_data DCPAN0000000003 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000005 "${default_facets}"
+gen_data DCPAN0000000004 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000006 "${default_facets}"
+gen_data DCPAN0000000005 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000007 "${default_facets}"
+gen_data DCPAN0000000006 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000008 "${default_facets}"
+gen_data DCPAN0000000007 GRCH38 ./cegs_portal/static_data/search/experiments/DCPEXPR0000000009 "${default_facets}"

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_data.sh
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_data.sh
@@ -12,7 +12,7 @@ echo "Loading DCPEXPR0000000002"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000002_klann_scCERES_K562_2021/supplementary_table_17_grna.de.markers.all.filtered.empirical_pvals.w_gene_info.csv \
-    ${DATA_DIR}/screen_ccres/GRCh37-cCREs.bed \
+    GRCh37 \
     dhs_chrom dhs_start dhs_end \
     ${CLOSEST_CCRE_FILE}
 

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_experiment.py
@@ -66,7 +66,7 @@ def load_dhss(
                 new_dhss[dhs_name] = CcreSource(
                     _id=feature_id,
                     chrom_name=chrom_name,
-                    location=NumericRange(dhs_start, dhs_end),
+                    test_location=NumericRange(dhs_start, dhs_end),
                     cell_line=cell_line,
                     closest_gene_id=closest_gene["id"],
                     closest_gene_distance=distance,

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_data.sh
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_data.sh
@@ -12,7 +12,7 @@ echo "Loading DCPEXPR0000000003"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000003_klann_wgCERES_K562_2021/supplementary_table_5_DHS_summary_results.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh37-cCREs.bed \
+    GRCh37 \
     chrom chromStart chromEnd \
     ${CLOSEST_CCRE_FILE}
 

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_experiment.py
@@ -64,7 +64,7 @@ def load_dhss(
                 new_dhss[dhs_name] = CcreSource(
                     _id=feature_id,
                     chrom_name=chrom_name,
-                    location=NumericRange(dhs_start, dhs_end),
+                    test_location=NumericRange(dhs_start, dhs_end),
                     cell_line=cell_line,
                     closest_gene_id=closest_gene["id"],
                     closest_gene_distance=distance,

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021.sh
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021.sh
@@ -12,7 +12,7 @@ echo "Loading DCPEXPR0000000004"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000004_bounds_scCERES_mhc_ipsc_2021/ipsc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh38-cCREs.bed \
+    GRCh38 \
     grna.chr grna.start grna.end \
     ${CLOSEST_CCRE_FILE}
 

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.py
@@ -47,8 +47,8 @@ def load_reg_effects(ceres_file, accession_ids, analysis, ref_genome, ref_genome
             grna_label = line["grna"]
             grna_info = grna_label.split("-")
 
-            # Skip non-targeting guides
-            if not grna_info[0].startswith("chr"):
+            # Skip non-targeting guides and guides with no assigned enhancer
+            if not grna_info[0].startswith("chr") or line["dhs.chr"] == "NA":
                 continue
 
             reo_id = reo_ids.next_id()

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
@@ -165,6 +165,7 @@ def load_grnas(
                 new_ccre_sources.append(
                     CcreSource(
                         _id=feature_id,
+                        _new_id=dhs_feature_id,
                         chrom_name=chrom_name,
                         test_location=NumericRange(grna_start, grna_end, "[)"),
                         new_location=dhs_location,

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
@@ -63,64 +63,47 @@ def load_grnas(
             grna_type = line["type"]
             grna_promoter_class = line["annotation_manual"]
 
+            grna_info = grna_id.split("-")
+
+            # Skip non-targeting guides and guides with no assigned enhancer
+            if not grna_info[0].startswith("chr") or line["dhs.chr"] == "NA":
+                continue
+
             dhs_chrom_name = line["dhs.chr"]
 
-            # skip DHSs associated with non-targeting guides
-            if dhs_chrom_name.startswith("chr"):
-                dhs_start = int(line["dhs.start"])
-                dhs_end = int(line["dhs.end"])
-                dhs_location = f"[{dhs_start},{dhs_end})"
+            dhs_start = int(line["dhs.start"])
+            dhs_end = int(line["dhs.end"])
+            dhs_location = f"[{dhs_start},{dhs_end})"
 
-                dhs_name = f"{dhs_chrom_name}:{dhs_location}"
+            dhs_name = f"{dhs_chrom_name}:{dhs_location}"
 
-                if dhs_name not in new_dhss:
-                    closest_gene, distance, gene_name = get_closest_gene(ref_genome, dhs_chrom_name, dhs_start, dhs_end)
-                    closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
-                    dhs_feature_id = feature_ids.next_id()
-                    dhs_accession_id = accession_ids.incr(AccessionType.DHS)
-                    dhss.write(
-                        feature_entry(
-                            id_=dhs_feature_id,
-                            accession_id=dhs_accession_id,
-                            cell_line=cell_line,
-                            chrom_name=dhs_chrom_name,
-                            location=dhs_location,
-                            closest_gene_id=closest_gene["id"],
-                            closest_gene_distance=distance,
-                            closest_gene_name=gene_name,
-                            closest_gene_ensembl_id=closest_gene_ensembl_id,
-                            ref_genome=ref_genome,
-                            feature_type=DNAFeatureType.DHS,
-                            source_file_id=region_source_id,
-                            experiment_accession_id=experiment_accession_id,
-                        )
+            if dhs_name not in new_dhss:
+                closest_gene, distance, gene_name = get_closest_gene(ref_genome, dhs_chrom_name, dhs_start, dhs_end)
+                closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
+                dhs_feature_id = feature_ids.next_id()
+                dhs_accession_id = accession_ids.incr(AccessionType.DHS)
+                dhss.write(
+                    feature_entry(
+                        id_=dhs_feature_id,
+                        accession_id=dhs_accession_id,
+                        cell_line=cell_line,
+                        chrom_name=dhs_chrom_name,
+                        location=dhs_location,
+                        closest_gene_id=closest_gene["id"],
+                        closest_gene_distance=distance,
+                        closest_gene_name=gene_name,
+                        closest_gene_ensembl_id=closest_gene_ensembl_id,
+                        ref_genome=ref_genome,
+                        feature_type=DNAFeatureType.DHS,
+                        source_file_id=region_source_id,
+                        experiment_accession_id=experiment_accession_id,
                     )
-                    new_ccre_sources.append(
-                        CcreSource(
-                            _id=dhs_feature_id,
-                            chrom_name=dhs_chrom_name,
-                            location=NumericRange(dhs_start, dhs_end, "[)"),
-                            cell_line=cell_line,
-                            closest_gene_id=closest_gene["id"],
-                            closest_gene_distance=distance,
-                            closest_gene_name=gene_name,
-                            closest_gene_ensembl_id=closest_gene_ensembl_id,
-                            source_file_id=region_source_id,
-                            ref_genome=ref_genome,
-                            experiment_accession_id=experiment_accession_id,
-                        )
-                    )
-                    new_dhss[dhs_name] = (dhs_feature_id, dhs_accession_id)
-                else:
-                    dhs_feature_id, dhs_accession_id = new_dhss[dhs_name]
+                )
+                new_dhss[dhs_name] = (dhs_feature_id, dhs_accession_id, NumericRange(dhs_start, dhs_end, "[)"))
+
+            dhs_feature_id, dhs_accession_id, dhs_location = new_dhss[dhs_name]
 
             if grna_id not in new_grnas:
-                grna_info = grna_id.split("-")
-
-                # Skip non-targeting guides
-                if not grna_info[0].startswith("chr"):
-                    continue
-
                 feature_id = feature_ids.next_id()
 
                 if len(grna_info) == 5:
@@ -177,6 +160,22 @@ def load_grnas(
                         source_file_id=region_source_id,
                         experiment_accession_id=experiment_accession_id,
                         misc={"grna": grna_id},
+                    )
+                )
+                new_ccre_sources.append(
+                    CcreSource(
+                        _id=feature_id,
+                        chrom_name=chrom_name,
+                        test_location=NumericRange(grna_start, grna_end, "[)"),
+                        new_location=dhs_location,
+                        cell_line=cell_line,
+                        closest_gene_id=closest_gene["id"],
+                        closest_gene_distance=distance,
+                        closest_gene_name=gene_name,
+                        closest_gene_ensembl_id=closest_gene_ensembl_id,
+                        source_file_id=region_source_id,
+                        ref_genome=ref_genome,
+                        experiment_accession_id=experiment_accession_id,
                     )
                 )
                 new_grnas[grna_id] = feature_id

--- a/scripts/data_loading/DCPEXPR0000000005_load_bounds_scCERES_mhc_2021.sh
+++ b/scripts/data_loading/DCPEXPR0000000005_load_bounds_scCERES_mhc_2021.sh
@@ -12,7 +12,7 @@ echo "Loading DCPEXPR0000000005"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000005_bounds_scCERES_mhc_k562_2021/k562.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh38-cCREs.bed \
+    GRCh38 \
     grna.chr grna.start grna.end \
     ${CLOSEST_CCRE_FILE}
 

--- a/scripts/data_loading/DCPEXPR0000000006_load_bounds_scCERES_mhc_2021.sh
+++ b/scripts/data_loading/DCPEXPR0000000006_load_bounds_scCERES_mhc_2021.sh
@@ -12,7 +12,7 @@ echo "Loading DCPEXPR0000000006"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000006_bounds_scCERES_mhc_npc_2021/npc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh38-cCREs.bed \
+    GRCh38 \
     grna.chr grna.start grna.end \
     ${CLOSEST_CCRE_FILE}
 

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022.sh
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022.sh
@@ -11,7 +11,7 @@ echo "Loading DCPEXPR0000000007"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh38-cCREs.bed \
+    GRCh38 \
     seqnames start end \
     ${CLOSEST_CCRE_FILE}
 

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment.py
@@ -63,7 +63,7 @@ def load_cars(
                 new_cars[car_name] = CcreSource(
                     _id=feature_id,
                     chrom_name=chrom_name,
-                    location=NumericRange(car_start, car_end),
+                    test_location=NumericRange(car_start, car_end),
                     cell_line=cell_line,
                     closest_gene_id=closest_gene["id"],
                     closest_gene_distance=distance,

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
@@ -157,6 +157,7 @@ def load_grnas(
                 new_ccre_sources.append(
                     CcreSource(
                         _id=feature_id,
+                        _new_id=dhs_feature_id,
                         chrom_name=chrom_name,
                         test_location=NumericRange(grna_start, grna_end, "[)"),
                         new_location=dhs_location,

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
@@ -110,24 +110,9 @@ def load_grnas(
                         experiment_accession_id=experiment_accession_id,
                     )
                 )
-                new_ccre_sources.append(
-                    CcreSource(
-                        _id=dhs_feature_id,
-                        chrom_name=dhs_chrom_name,
-                        location=NumericRange(dhs_start, dhs_end, "[)"),
-                        cell_line=cell_line,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        source_file_id=region_source_id,
-                        ref_genome=ref_genome,
-                        experiment_accession_id=experiment_accession_id,
-                    )
-                )
-                new_dhss[dhs_name] = (dhs_feature_id, dhs_accession_id)
-            else:
-                dhs_feature_id, dhs_accession_id = new_dhss[dhs_name]
+                new_dhss[dhs_name] = (dhs_feature_id, dhs_accession_id, NumericRange(dhs_start, dhs_end, "[)"))
+
+            dhs_feature_id, dhs_accession_id, dhs_location = new_dhss[dhs_name]
 
             grna_id = line["grna"]
             if grna_id not in new_grnas:
@@ -167,6 +152,22 @@ def load_grnas(
                         source_file_id=region_source_id,
                         experiment_accession_id=experiment_accession_id,
                         misc={"grna": grna_id},
+                    )
+                )
+                new_ccre_sources.append(
+                    CcreSource(
+                        _id=feature_id,
+                        chrom_name=chrom_name,
+                        test_location=NumericRange(grna_start, grna_end, "[)"),
+                        new_location=dhs_location,
+                        cell_line=cell_line,
+                        closest_gene_id=closest_gene["id"],
+                        closest_gene_distance=distance,
+                        closest_gene_name=gene_name,
+                        closest_gene_ensembl_id=closest_gene_ensembl_id,
+                        source_file_id=region_source_id,
+                        ref_genome=ref_genome,
+                        experiment_accession_id=experiment_accession_id,
                     )
                 )
 

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPRa_2022.sh
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPRa_2022.sh
@@ -13,9 +13,11 @@ echo "Loading DCPEXPR0000000008"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh38-cCREs.bed \
+    GRCh38 \
     chr start end \
     ${CLOSEST_CCRE_FILE}
 
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\", \"${DHS_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.run(\"${ANALYSIS_FILE}\", \"${FEATURES_FILE}\")"
+
+rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000009_load_mccutcheon_scCERES_cd8_CRISPRi_2022.sh
+++ b/scripts/data_loading/DCPEXPR0000000009_load_mccutcheon_scCERES_cd8_CRISPRi_2022.sh
@@ -13,9 +13,11 @@ echo "Loading DCPEXPR0000000009"
 # generate ccre overlaps
 ./scripts/data_generation/ccre_overlaps.sh \
     ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.tsv \
-    ${DATA_DIR}/screen_ccres/GRCh38-cCREs.bed \
+    GRCh38 \
     chr start end \
     ${CLOSEST_CCRE_FILE}
 
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\", \"${DHS_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.run(\"${ANALYSIS_FILE}\", \"${FEATURES_FILE}\")"
+
+rm ${CLOSEST_CCRE_FILE}

--- a/utils/ccres.py
+++ b/utils/ccres.py
@@ -28,6 +28,7 @@ class CcreSource:
     ref_genome: str
     experiment_accession_id: str
     ref_genome_patch: str = "0"
+    _new_id: Optional[int] = None
     new_location: Optional[NumericRange] = None
     feature_type: DNAFeatureType = DNAFeatureType.CCRE
     misc: dict = field(default_factory=lambda: {"pseudo": True})
@@ -110,10 +111,11 @@ def associate_ccres(closest_ccre_filename, sources: list[CcreSource], ref_genome
                 missing += 1
                 feature_id = feature_ids.next_id()
                 location = source.new_location if source.new_location is not None else source.test_location
+                source_id = source._new_id if source._new_id is not None else source._id
                 new_ccres.write(
                     f"{feature_id}\t{accession_ids.incr(AccessionType.CCRE)}\t{source.cell_line}\t{source.chrom_name}\t{source.closest_gene_id}\t{source.closest_gene_distance}\t{source.closest_gene_name}\t{source.closest_gene_ensembl_id}\t{location}\t{source.ref_genome}\t{source.ref_genome_patch}\t{json.dumps({'pseudo': True})}\t{DNAFeatureType.CCRE}\t{source.source_file_id}\t{source.experiment_accession_id}\tfalse\ttrue\n"
                 )
-                ccre_associations.write(f"{source._id}\t{feature_id}\n")
+                ccre_associations.write(f"{source_id}\t{feature_id}\n")
     save_ccres(new_ccres)
     save_associations(ccre_associations)
     print(f"Found: {found}")


### PR DESCRIPTION
This makes two changes to associating cCREs with tested elements.

1) Generates the list of cCREs anew for each data load. Before we used same list from SCREEN every time and so weren't finding associations with "artificial" cCREs generated from previous data loads.

2) Changes how gRNA-based experiment look up/create cCREs. The initial cCRE/Tested Element overlap list is generated using the gRNAs but when creating "artificial" cCREs we use the location of the DHS the gRNA is associated with instead of the gRNA location.