### PR TITLE
Improves browser perf when downloading source features

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -224,6 +224,18 @@ def feature() -> DNAFeature:
 
 
 @pytest.fixture
+def effect_dir_feature() -> DNAFeature:
+    return DNAFeatureFactory(
+        ref_genome="GRCh38",
+        effect_directions=[
+            EffectObservationDirectionType.ENRICHED.value,
+            EffectObservationDirectionType.ENRICHED.value,
+            EffectObservationDirectionType.NON_SIGNIFICANT.value,
+        ],
+    )
+
+
+@pytest.fixture
 def search_feature() -> DNAFeature:
     return DNAFeatureFactory(feature_type=DNAFeatureType.GENE, ref_genome="GRCh38")
 

--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -261,7 +261,7 @@ def nearby_feature_mix() -> tuple[DNAFeature, DNAFeature, DNAFeature]:
 
 def _reg_effect(public=True, archived=False) -> RegulatoryEffectObservation:
     direction_facet = FacetFactory(description="", name=RegulatoryEffectObservation.Facet.DIRECTION.value)
-    direction = FacetValueFactory(facet=direction_facet, value=EffectObservationDirectionType.ENRICHED)
+    direction = FacetValueFactory(facet=direction_facet, value=EffectObservationDirectionType.ENRICHED.value)
     effect = RegEffectFactory(
         sources=(DNAFeatureFactory(), DNAFeatureFactory()),
         facet_values=(direction,),
@@ -523,15 +523,12 @@ def genoverse_dhs_features():
         feature_type=DNAFeatureType.GENE,
     )
 
-    _ = RegEffectFactory(sources=(f1,), targets=(g1,))
-    _ = RegEffectFactory(sources=(f2,))
-    _ = RegEffectFactory(sources=(f3,))
+    direction_facet = FacetFactory(description="", name=RegulatoryEffectObservation.Facet.DIRECTION.value)
+    direction = FacetValueFactory(facet=direction_facet, value=EffectObservationDirectionType.ENRICHED.value)
 
-    g1 = DNAFeatureFactory(
-        ref_genome=ref_genome,
-        chrom_name=chrom,
-        feature_type=DNAFeatureType.GENE,
-    )
+    _ = RegEffectFactory(sources=(f1,), targets=(g1,), facet_values=(direction,))
+    _ = RegEffectFactory(sources=(f2,), facet_values=(direction,))
+    _ = RegEffectFactory(sources=(f3,), facet_values=(direction,))
 
     return {
         "chrom": chrom,

--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -536,11 +536,12 @@ def genoverse_dhs_features():
     )
 
     direction_facet = FacetFactory(description="", name=RegulatoryEffectObservation.Facet.DIRECTION.value)
-    direction = FacetValueFactory(facet=direction_facet, value=EffectObservationDirectionType.ENRICHED.value)
+    enriched = FacetValueFactory(facet=direction_facet, value=EffectObservationDirectionType.ENRICHED.value)
+    non_sig = FacetValueFactory(facet=direction_facet, value=EffectObservationDirectionType.NON_SIGNIFICANT.value)
 
-    _ = RegEffectFactory(sources=(f1,), targets=(g1,), facet_values=(direction,))
-    _ = RegEffectFactory(sources=(f2,), facet_values=(direction,))
-    _ = RegEffectFactory(sources=(f3,), facet_values=(direction,))
+    _ = RegEffectFactory(sources=(f1,), targets=(g1,), facet_values=(enriched,))
+    _ = RegEffectFactory(sources=(f2,), facet_values=(enriched,))
+    _ = RegEffectFactory(sources=(f3,), facet_values=(non_sig,))
 
     return {
         "chrom": chrom,

--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -72,6 +72,12 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
         result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
         result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
 
+    if options is not None and "effect_directions" in options.get("feature_properties", []):
+        result["effect_directions"] = feature_obj.effect_directions
+
+    if options is not None and "effect_targets" in options.get("feature_properties", []):
+        result["effect_targets"] = feature_obj.effect_targets
+
     if options is not None and options.get("json_format", None) == "genoverse":
         genoversify(result)
 

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -50,11 +50,14 @@ def test_feature(feature: DNAFeature):
 
     assert "source_for" not in f_dict
     assert "target_of" not in f_dict
+    assert "effect_directions" not in f_dict
 
     f_dict = f_json(feature, {"feature_properties": ["regeffects"]})
-
     assert "source_for" in f_dict
     assert "target_of" in f_dict
+
+    f_dict = f_json(feature, {"feature_properties": ["effect_directions"]})
+    assert "effect_directions" in f_dict
 
     result["id"] = result["accession_id"]
     result["chr"] = feature.chrom_name.removeprefix("chr")

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -20,7 +20,7 @@ def test_features(features: Iterable[DNAFeature]):
     assert fs_json(features, {"json_format": "genoverse"}) == result
 
 
-def test_feature(feature: DNAFeature):
+def test_feature(feature: DNAFeature, effect_dir_feature: DNAFeature):
     result = {
         "accession_id": feature.accession_id,
         "ensembl_id": feature.ensembl_id,
@@ -56,7 +56,7 @@ def test_feature(feature: DNAFeature):
     assert "source_for" in f_dict
     assert "target_of" in f_dict
 
-    f_dict = f_json(feature, {"feature_properties": ["effect_directions"]})
+    f_dict = f_json(effect_dir_feature, {"feature_properties": ["effect_directions"]})
     assert "effect_directions" in f_dict
 
     result["id"] = result["accession_id"]

--- a/cegs_portal/search/models/tests/dna_feature_factory.py
+++ b/cegs_portal/search/models/tests/dna_feature_factory.py
@@ -41,10 +41,22 @@ class DNAFeatureFactory(DjangoModelFactory):
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
+        # in DNAFeatureSearch#loc_search the "effect_directions" property adds
+        # an "effect_directions" annotation to DNAFeature objects
+        if "effect_directions" in kwargs:
+            effect_dirs = kwargs["effect_directions"]
+            del kwargs["effect_directions"]
+        else:
+            effect_dirs = None
+
         obj = model_class(*args, **kwargs)
         if "accession_id" not in kwargs:
             obj.accession_id = cls._faker.unique.hexify(text="DCPGENE^^^^^^^^^^", upper=True)
             obj.save()
+
+        if effect_dirs is not None:
+            setattr(obj, "effect_directions", effect_dirs)
+
         return obj
 
     @factory.lazy_attribute

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -17,7 +17,7 @@ def test_genoverse_track_view_DHS(client: Client, genoverse_dhs_features):
     features = genoverse_dhs_features["features"]
 
     response = client.get(
-        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=regeffects"  # noqa: E501
+        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=effect_directions&property=effect_targets"  # noqa: E501
     )
 
     assert response.status_code == 200
@@ -27,11 +27,11 @@ def test_genoverse_track_view_DHS(client: Client, genoverse_dhs_features):
     assert len(json_content) == len(features)
 
     for feature in json_content:
-        assert feature.get("source_for", None) is not None
-        assert feature.get("target_of", None) is not None
-
-        for effect in feature["source_for"]:
-            assert effect.get("targets", None) is not None
+        assert feature.get("effect_directions", None) is not None
+        assert feature.get("effect_targets", None) is not None
+        if len(feature["effect_targets"]) > 0:
+            print(feature["effect_targets"])
+            assert False
 
 
 def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_features):
@@ -42,7 +42,7 @@ def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_feature
     features = genoverse_dhs_features["features"]
 
     response = client.get(
-        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=regeffects"  # noqa: E501
+        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=effect_directions&property=effect_targets"  # noqa: E501
     )
 
     assert response.status_code == 200
@@ -51,7 +51,7 @@ def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_feature
     assert isinstance(json_content, list)
     assert len(json_content) == len(features)
 
-    effectful_dhs = [f for f in json_content if len(f["source_for"]) > 0]
+    effectful_dhs = [f for f in json_content if len(f["effect_directions"]) > 0]
     for dhs in effectful_dhs:
         assert "chr" in dhs
         assert "start" in dhs

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -17,14 +17,21 @@ def test_genoverse_track_view_DHS(client: Client, genoverse_dhs_features):
     features = genoverse_dhs_features["features"]
 
     response = client.get(
-        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=effect_directions&property=effect_targets"  # noqa: E501
+        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=effect_directions&property=effect_targets&property=significant"  # noqa: E501
     )
 
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
     assert isinstance(json_content, list)
-    assert len(json_content) == len([f for f in features if len(f.source_for.all()) > 0])
+    assert len(json_content) == len(
+        [
+            f
+            for f in features
+            if len(f.source_for.all()) > 0
+            and all(all(s.value != "Non-significant" for s in r.facet_values.all()) for r in f.source_for.all())
+        ]
+    )
 
     for feature in json_content:
         assert feature.get("effect_directions", None) is not None
@@ -39,14 +46,21 @@ def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_feature
     features = genoverse_dhs_features["features"]
 
     response = client.get(
-        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=effect_directions&property=effect_targets"  # noqa: E501
+        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&property=effect_directions&property=effect_targets&property=significant"  # noqa: E501
     )
 
     assert response.status_code == 200
 
     json_content = json.loads(response.content)
     assert isinstance(json_content, list)
-    assert len(json_content) == len([f for f in features if len(f.source_for.all()) > 0])
+    assert len(json_content) == len(
+        [
+            f
+            for f in features
+            if len(f.source_for.all()) > 0
+            and all(all(s.value != "Non-significant" for s in r.facet_values.all()) for r in f.source_for.all())
+        ]
+    )
 
     effectful_dhs = [f for f in json_content if len(f["effect_directions"]) > 0]
     for dhs in effectful_dhs:

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -24,14 +24,11 @@ def test_genoverse_track_view_DHS(client: Client, genoverse_dhs_features):
 
     json_content = json.loads(response.content)
     assert isinstance(json_content, list)
-    assert len(json_content) == len(features)
+    assert len(json_content) == len([f for f in features if len(f.source_for.all()) > 0])
 
     for feature in json_content:
         assert feature.get("effect_directions", None) is not None
         assert feature.get("effect_targets", None) is not None
-        if len(feature["effect_targets"]) > 0:
-            print(feature["effect_targets"])
-            assert False
 
 
 def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_features):
@@ -49,7 +46,7 @@ def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_feature
 
     json_content = json.loads(response.content)
     assert isinstance(json_content, list)
-    assert len(json_content) == len(features)
+    assert len(json_content) == len([f for f in features if len(f.source_for.all()) > 0])
 
     effectful_dhs = [f for f in json_content if len(f["effect_directions"]) > 0]
     for dhs in effectful_dhs:

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from typing import Any, Optional, cast
 
-from django.db.models import Q, QuerySet
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Count, Q, QuerySet
 from psycopg2.extras import NumericRange
 
 from cegs_portal.search.models import (
@@ -200,7 +201,8 @@ class DNAFeatureSearch:
         search_type: str,
         facets: list[int] = cast(list[int], list),
     ) -> QuerySet[DNAFeature]:
-        query: dict[str, Any] = {"chrom_name": chromo}
+        filters: dict[str, Any] = {"chrom_name": chromo}
+        excludes = Q(experiment_accession=None)
 
         new_feature_types: list[DNAFeatureType] = []
         for ft in feature_types:
@@ -210,7 +212,7 @@ class DNAFeatureSearch:
                 new_feature_types.append(DNAFeatureType(ft))
 
         if len(new_feature_types) > 0:
-            query["feature_type__in"] = new_feature_types
+            filters["feature_type__in"] = new_feature_types
 
         field = "location"
         if search_type == LocSearchType.EXACT.value:
@@ -221,13 +223,15 @@ class DNAFeatureSearch:
             raise ViewModelError(f"Invalid search type: {search_type}")
 
         if assembly is not None:
-            query["ref_genome"] = assembly
+            filters["ref_genome"] = assembly
 
         field_lookup = join_fields(field, lookup)
-        query[field_lookup] = NumericRange(int(start), int(end), "[)")
+        filters[field_lookup] = NumericRange(int(start), int(end), "[)")
 
         prefetch_values = ["parent", "parent_accession"]
+
         if len(facets) > 0:
+            filters["facet_values__in"] = facets
             prefetch_values.extend(["facet_values", "facet_values__facet"])
 
         if "regeffects" in feature_properties:
@@ -249,12 +253,41 @@ class DNAFeatureSearch:
                 ]
             )
 
-        features = DNAFeature.objects.filter(**query).prefetch_related(*prefetch_values)
+        features = DNAFeature.objects
 
-        if len(facets) > 0:
-            features = features.filter(facet_values__in=facets)
+        if any(p in {"effect_directions", "effect_targets", "significant"} for p in feature_properties):
+            # skip any feature that not the sources for any REOs
+            features = features.annotate(reo_count=Count("source_for"))
+            filters["reo_count__gt"] = 0
 
-        return features.order_by("location")
+        if "effect_directions" in feature_properties:
+            features = features.annotate(
+                effect_directions=ArrayAgg(
+                    "source_for__facet_values__value",
+                    filter=Q(source_for__facet_values__facet__name="Direction"),
+                    default=[],
+                )
+            )
+            features = features.annotate(
+                sig_count=Count(
+                    "source_for__facet_values__value",
+                    filter=Q(source_for__facet_values__value__in=["Depleted Only", "Enriched Only", "Mixed"]),
+                )
+            )
+
+        if "effect_targets" in feature_properties:
+            features = features.annotate(effect_targets=ArrayAgg("source_for__targets__accession_id", default=[]))
+
+        if "significant" in feature_properties:
+            features = features.annotate(
+                sig_count=Count(
+                    "source_for__facet_values__value",
+                    filter=Q(source_for__facet_values__value__in=["Depleted Only", "Enriched Only", "Mixed"]),
+                )
+            )
+            filters["sig_count__gt"] = 0
+
+        return features.filter(**filters).exclude(excludes).prefetch_related(*prefetch_values).order_by("location")
 
     @classmethod
     def loc_search_public(cls, *args, **kwargs):

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -202,7 +202,6 @@ class DNAFeatureSearch:
         facets: list[int] = cast(list[int], list),
     ) -> QuerySet[DNAFeature]:
         filters: dict[str, Any] = {"chrom_name": chromo}
-        excludes = Q(experiment_accession=None)
 
         new_feature_types: list[DNAFeatureType] = []
         for ft in feature_types:
@@ -268,12 +267,6 @@ class DNAFeatureSearch:
                     default=[],
                 )
             )
-            features = features.annotate(
-                sig_count=Count(
-                    "source_for__facet_values__value",
-                    filter=Q(source_for__facet_values__value__in=["Depleted Only", "Enriched Only", "Mixed"]),
-                )
-            )
 
         if "effect_targets" in feature_properties:
             features = features.annotate(effect_targets=ArrayAgg("source_for__targets__accession_id", default=[]))
@@ -287,7 +280,7 @@ class DNAFeatureSearch:
             )
             filters["sig_count__gt"] = 0
 
-        return features.filter(**filters).exclude(excludes).prefetch_related(*prefetch_values).order_by("location")
+        return features.filter(**filters).prefetch_related(*prefetch_values).order_by("location")
 
     @classmethod
     def loc_search_public(cls, *args, **kwargs):


### PR DESCRIPTION
The query run when genoverse requests source features wasn't specific enough and returned too many results. Additionally the feature returned had too much information.

The first issue is being tackled by making more specific query properties. The second by not requesting the feature and all REOs and all targets. That information was used by the menu. Now that information is request for a specific feature on demand when the menu is opened for that feature.