### PR TITLE
Use common state names across search results js

### DIFF
--- a/cegs_portal/search/static/search/js/search_results/consts.js
+++ b/cegs_portal/search/static/search/js/search_results/consts.js
@@ -1,0 +1,3 @@
+export const STATE_REGION = "region";
+export const STATE_FACETS = "facets";
+export const STATE_DHS_EFFECT = "dhs-effect-data";

--- a/cegs_portal/search/static/search/js/search_results/downloads.js
+++ b/cegs_portal/search/static/search/js/search_results/downloads.js
@@ -1,4 +1,5 @@
 import {g, rc, t} from "../dom.js";
+import {STATE_REGION} from "./consts.js";
 
 function getDownload(url, filename) {
     rc(g("dataDownloadLink"), t("Getting your data..."));
@@ -58,7 +59,7 @@ export function downloadRegionsSetup(state, assembly) {
                 .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
                 .map((i) => i.id);
 
-            let location = state.g("location");
+            let location = state.g(STATE_REGION);
             getDownloadRegions(checkedFacets, location.chr, location.start, location.end, assembly);
         },
         false

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -250,6 +250,7 @@
         import { getJson } from "{% static 'search/js/files.js' %}";
         import { State } from "{% static 'search/js/state.js' %}";
         import { downloadRegionsSetup } from "{% static 'search/js/search_results/downloads.js' %}";
+        import { STATE_DHS_EFFECT, STATE_FACETS, STATE_REGION } from "{% static 'search/js/search_results/consts.js' %}";
 
         let searchURL = function(facets) {
             let enabledFacets = facets.map(id => `facet=${id}`)
@@ -257,9 +258,6 @@
             return `{% url 'search:results' %}?query={{ query }}${enabledFacets !== '' ? '&' + enabledFacets : ''}`;
         }
 
-        const STATE_REGION = "region";
-        const STATE_FACETS = "facets"
-        const STATE_DHS_EFFECT = "dhs-effect-data"
         let state = new State({
             [STATE_REGION]: {
                 chr: "{{ region.chromo }}",


### PR DESCRIPTION
This should keep us from using the incorrect state names