### PR TITLE
Miscellaneous fixes

### DIFF
--- a/cegs_portal/search/models/dna_feature.py
+++ b/cegs_portal/search/models/dna_feature.py
@@ -55,7 +55,7 @@ class DNAFeature(Accessioned, Faceted, AccessControlled):
     closest_gene_name = models.CharField(max_length=50, null=True, blank=True)
     closest_gene_ensembl_id = models.CharField(max_length=50, null=True, blank=True)
 
-    associated_ccres = models.ManyToManyField("self", related_name="associated_sources", blank=True)
+    associated_ccres = models.ManyToManyField("self", blank=True)
 
     # These values will be returned as 0-index, half-closed. This should be converted to
     # 1-index, closed for display purposes. 1,c is the default for genomic coordinates

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -115,7 +115,7 @@
                     </form>
                     <div id="dataDownloadLink" class="mt-5 mb-5"></div>
                     <div>
-                    * Data downloads take facet filtering, except for "Number of {{ experiment.get_source_type_display }}s" and "Number of Genes Assayed", into account.
+                    * Data downloads take facet filtering, except for "Number of Tested Elements" and "Number of Genes Assayed", into account.
                     </div>
                 </div>
                 {% endif %}

--- a/scripts/data_generation/qc_plots/gen_qc_plots.sh
+++ b/scripts/data_generation/qc_plots/gen_qc_plots.sh
@@ -132,7 +132,7 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 # DCPEXPR0000000007
 echo DCPEXPR0000000007
 python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000007/vpdata.pd \
-    --input ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.txt \
+    --input ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.tsv \
     -x logFC \
     -y minusLog10PValue
 # python3 ./scripts/data_generation/qc_plots/histogram.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000007/c_per_g.pd \
@@ -143,7 +143,7 @@ python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_porta
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/npc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
-python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.txt \
+python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.tsv \
     --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000007/qqplot.pd \
     -p minusLog10PValue \
     -q 10_000
@@ -151,7 +151,7 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 # DCPEXPR0000000008
 echo DCPEXPR0000000008
 python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000008/vpdata.pd \
-    --input ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.txt \
+    --input ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.tsv \
     -x avg_log2FC \
     -y p_val \
     -g target_gene
@@ -163,7 +163,7 @@ python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_porta
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/npc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
-python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.txt \
+python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.tsv \
     --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000008/qqplot.pd \
     -p p_val \
     --log-p-value \
@@ -172,7 +172,7 @@ python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXP
 # DCPEXPR0000000009
 echo DCPEXPR0000000009
 python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000009/vpdata.pd \
-    --input ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.txt \
+    --input ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.tsv \
     -x avg_log2FC \
     -y p_val \
     -g target_gene
@@ -184,7 +184,7 @@ python3 ./scripts/data_generation/qc_plots/volcano_plot.py --output ./cegs_porta
 #     --header \
 #     --input ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/npc.run_negbinom.ngrnas_per_cell.txt \
 #     --bin-size 1
-python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.txt \
+python3 ./scripts/data_generation/qc_plots/qq_plot.py --input ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.tsv \
     --output ./cegs_portal/static_data/search/experiments/DCPEXPR0000000009/qqplot.pd \
     -p p_val \
     --log-p-value \


### PR DESCRIPTION
* Fix experiments template to say "Tested Elements". Since experiments are getting mixed we can't say a specific kind of element there.
* remove related name from associated_ccres many-to-many field. This isn't used and we get constant warnings about it
* change .txt files in gen_qc_plots to .tsv. This data is in tsv format, the file names should reflect that.