### PR TITLE
Makes feature-related URL paths start with "search/feature"

### DIFF
--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -405,15 +405,15 @@ Genoverse.Track.DHS = Genoverse.Track.extend({
             "Closest Gene": `<a target="_blank" href="/search/feature/ensembl/${feature.closest_gene_ensembl_id}">${feature.closest_gene_name} (${feature.closest_gene_ensembl_id})</a>`,
         };
 
-        let effects = await fetch(`/search/regeffect/source/${feature.accession_id}?accept=application/json`).then(
-            (response) => {
-                if (!response.ok) {
-                    throw new Error(`${path} fetch failed: ${response.status} ${response.statusText}`);
-                }
-
-                return response.json();
+        let effects = await fetch(
+            `/search/feature/accession/${feature.accession_id}/source_for?accept=application/json`
+        ).then((response) => {
+            if (!response.ok) {
+                throw new Error(`${path} fetch failed: ${response.status} ${response.statusText}`);
             }
-        );
+
+            return response.json();
+        });
         let i = 1;
         for (let reo of effects.object_list.slice(0, 5)) {
             if (reo.targets.length > 0) {
@@ -430,7 +430,7 @@ Genoverse.Track.DHS = Genoverse.Track.extend({
         if (effects.object_list.length > 5) {
             menu[
                 `Full Effect List`
-            ] = `<a target="_blank" href="/search/regeffect/source/${feature.accession_id}">All Associated Effects</a>`;
+            ] = `<a target="_blank" href="/search/feature/accession/${feature.accession_id}/source_for">All Associated Effects</a>`;
         }
 
         return menu;

--- a/cegs_portal/search/urls.py
+++ b/cegs_portal/search/urls.py
@@ -10,6 +10,21 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("results/", views.v1.SearchView.as_view(), name="results"),
     re_path(
+        r"feature/accession/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})/source_for$",
+        views.v1.SourceEffectsView.as_view(),
+        name="source_effects",
+    ),
+    re_path(
+        r"feature/accession/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})/target_of$",
+        views.v1.TargetEffectsView.as_view(),
+        name="target_effects",
+    ),
+    re_path(
+        r"feature/accession/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})/nontargets$",
+        views.v1.NonTargetRegEffectsView.as_view(),
+        name="non_target_reo",
+    ),
+    re_path(
         r"feature/(?P<id_type>\w+)/(?P<feature_id>[A-Za-z0-9][A-Za-z0-9\.\-]+)$",
         views.v1.DNAFeatureId.as_view(),
         name="dna_features",
@@ -32,26 +47,23 @@ urlpatterns = [
         csrf_exempt(views.v1.CombinedExperimentView.as_view()),
         name="combined_experiment_coverage",
     ),
-    re_path(
-        r"regeffect/source/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})$",
-        views.v1.SourceEffectsView.as_view(),
-        name="source_effects",
-    ),
-    re_path(
-        r"regeffect/target/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})$",
-        views.v1.TargetEffectsView.as_view(),
-        name="target_effects",
-    ),
-    re_path(
-        r"regeffect/nontarget/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})$",
-        views.v1.NonTargetRegEffectsView.as_view(),
-        name="non_target_reo",
-    ),
     re_path(r"regeffect/(?P<re_id>DCPREO[A-F0-9]{8,10})$", views.v1.RegEffectView.as_view(), name="reg_effect"),
     path("feature_counts", views.v1.FeatureCountView.as_view(), name="feature_counts"),
     path("sigdata", view=views.v1.SignificantExperimentDataView.as_view(), name="sigdata"),
     path("feature_sigreo", view=views.v1.FeatureSignificantREOsView.as_view(), name="feature_sigreo"),
     path("v1/results/", views.v1.SearchView.as_view()),
+    re_path(
+        r"v1/feature/accession/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})/source_for$",
+        views.v1.SourceEffectsView.as_view(),
+    ),
+    re_path(
+        r"v1/feature/accession/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})/target_of$",
+        views.v1.TargetEffectsView.as_view(),
+    ),
+    re_path(
+        r"v1/feature/accession/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})/nontargets$",
+        views.v1.NonTargetRegEffectsView.as_view(),
+    ),
     re_path(
         r"v1/feature/(?P<id_type>\w+)/(?P<feature_id>[A-Za-z0-9][A-Za-z0-9\.\-]+)$", views.v1.DNAFeatureId.as_view()
     ),
@@ -69,12 +81,6 @@ urlpatterns = [
     path(
         "v1/combined_experiment_coverage",
         csrf_exempt(views.v1.CombinedExperimentView.as_view()),
-    ),
-    re_path(r"v1/regeffect/source/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})$", views.v1.SourceEffectsView.as_view()),
-    re_path(r"v1/regeffect/target/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})$", views.v1.TargetEffectsView.as_view()),
-    re_path(
-        r"v1/regeffect/nontarget/(?P<feature_id>DCP[A-Z]{1,4}[A-F0-9]{8,10})$",
-        views.v1.NonTargetRegEffectsView.as_view(),
     ),
     re_path(r"v1/regeffect/(?P<re_id>DCPREO[A-F0-9]{8,10})$", views.v1.RegEffectView.as_view()),
     path("v1/feature_counts", views.v1.FeatureCountView.as_view()),

--- a/cegs_portal/search/views/v1/tests/test_non_targeting_reos.py
+++ b/cegs_portal/search/views/v1/tests/test_non_targeting_reos.py
@@ -13,7 +13,9 @@ pytestmark = pytest.mark.django_db
 def test_sig_only_proximal_reg_effects_list_json(client: Client, proximal_non_targeting_reg_effects):
     source = proximal_non_targeting_reg_effects["source"]
     effects = sorted(proximal_non_targeting_reg_effects["effects"], key=lambda x: x.significance)
-    response = client.get(f"/search/regeffect/nontarget/{source.closest_gene.accession_id}?accept=application/json")
+    response = client.get(
+        f"/search/feature/accession/{source.closest_gene.accession_id}/nontargets?accept=application/json"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -32,7 +34,7 @@ def test_proximal_reg_effects_list_json(client: Client, proximal_non_targeting_r
     source = proximal_non_targeting_reg_effects["source"]
     effects = sorted(proximal_non_targeting_reg_effects["effects"], key=lambda x: x.significance)
     response = client.get(
-        f"/search/regeffect/nontarget/{source.closest_gene.accession_id}?sig_only=false&accept=application/json"
+        f"/search/feature/accession/{source.closest_gene.accession_id}/nontargets?sig_only=false&accept=application/json"
     )
 
     assert response.status_code == 200
@@ -43,7 +45,9 @@ def test_proximal_reg_effects_list_json(client: Client, proximal_non_targeting_r
 
 def test_get_proximal_reg_effects_with_anonymous_client(client: Client, private_proximal_non_targeting_reg_effects):
     source = private_proximal_non_targeting_reg_effects["source"]
-    response = client.get(f"/search/regeffect/nontarget/{source.closest_gene.accession_id}?accept=application/json")
+    response = client.get(
+        f"/search/feature/accession/{source.closest_gene.accession_id}/nontargets?accept=application/json"
+    )
     assert response.status_code == 302
 
 
@@ -52,7 +56,7 @@ def test_get_proximal_reg_effects_with_authenticated_client(
 ):
     source = private_proximal_non_targeting_reg_effects["source"]
     response = login_client.get(
-        f"/search/regeffect/nontarget/{source.closest_gene.accession_id}?accept=application/json"
+        f"/search/feature/accession/{source.closest_gene.accession_id}/nontargets?accept=application/json"
     )
     assert response.status_code == 403
 
@@ -63,7 +67,9 @@ def test_get_proximal_reg_effects_with_authenticated_authorized_client(
     source = private_proximal_non_targeting_reg_effects["source"]
     private_gene = source.closest_gene
     login_client.set_user_experiments([private_gene.experiment_accession])
-    response = login_client.get(f"/search/regeffect/nontarget/{private_gene.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{private_gene.accession_id}/nontargets?accept=application/json"
+    )
     assert response.status_code == 200
 
 
@@ -74,20 +80,24 @@ def test_get_proximal_reg_effects_with_authenticated_authorized_group_client(
 
     group_login_client.set_group_experiments([cast(str, private_feature.experiment_accession_id)])
     response = group_login_client.get(
-        f"/search/regeffect/nontarget/{private_feature.accession_id}?accept=application/json"
+        f"/search/feature/accession/{private_feature.accession_id}/nontargets?accept=application/json"
     )
     assert response.status_code == 200
 
 
 def test_get_archived_proximal_reg_effects_with_anonymous_client(client: Client, archived_feature: DNAFeature):
-    response = client.get(f"/search/regeffect/nontarget/{archived_feature.accession_id}?accept=application/json")
+    response = client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/nontargets?accept=application/json"
+    )
     assert response.status_code == 403
 
 
 def test_get_archived_proximal_reg_effects_with_authenticated_client(
     login_client: SearchClient, archived_feature: DNAFeature
 ):
-    response = login_client.get(f"/search/regeffect/nontarget/{archived_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/nontargets?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -97,7 +107,9 @@ def test_get_archived_proximal_reg_effects_with_authenticated_authorized_client(
     assert archived_feature.experiment_accession_id is not None
 
     login_client.set_user_experiments([cast(str, archived_feature.experiment_accession)])
-    response = login_client.get(f"/search/regeffect/nontarget/{archived_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/nontargets?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -108,7 +120,7 @@ def test_get_archived_proximal_reg_effects_with_authenticated_authorized_group_c
 
     group_login_client.set_group_experiments([cast(str, archived_feature.experiment_accession_id)])
     response = group_login_client.get(
-        f"/search/regeffect/nontarget/{archived_feature.accession_id}?accept=application/json"
+        f"/search/feature/accession/{archived_feature.accession_id}/nontargets?accept=application/json"
     )
     assert response.status_code == 403
 
@@ -117,7 +129,7 @@ def test_proximal_reg_effects_list_page_json(client: Client, proximal_non_target
     source = proximal_non_targeting_reg_effects["source"]
     effects = sorted(proximal_non_targeting_reg_effects["effects"], key=lambda x: x.significance)
     response = client.get(
-        f"/search/regeffect/nontarget/{source.closest_gene.accession_id}?accept=application/json&page=1&per_page=1"
+        f"/search/feature/accession/{source.closest_gene.accession_id}/nontargets?accept=application/json&page=1&per_page=1"
     )
 
     assert response.status_code == 200
@@ -136,7 +148,7 @@ def test_proximal_reg_effects_list_page_json(client: Client, proximal_non_target
 
 
 def test_source_regeffect_html(client: Client, feature: DNAFeature):
-    response = client.get(f"/search/regeffect/nontarget/{feature.accession_id}")
+    response = client.get(f"/search/feature/accession/{feature.accession_id}/nontargets")
 
     # The content of the page isn't necessarily stable, so we just want to make sure
     # we don't get a 400 or 500 error here

--- a/cegs_portal/search/views/v1/tests/test_source_reg_effects.py
+++ b/cegs_portal/search/views/v1/tests/test_source_reg_effects.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 def test_source_reg_effects_list_json(client: Client, source_reg_effects):
     source = source_reg_effects["source"]
     effects = sorted(source_reg_effects["effects"], key=lambda x: x.accession_id)
-    response = client.get(f"/search/regeffect/source/{source.accession_id}?accept=application/json")
+    response = client.get(f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json")
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -29,7 +29,9 @@ def test_source_reg_effects_list_json(client: Client, source_reg_effects):
 
 def test_sig_only_source_reg_effects_list_json(client: Client, sig_only_source_reg_effects):
     source = sig_only_source_reg_effects["source"]
-    response = client.get(f"/search/regeffect/source/{source.accession_id}?accept=application/json&sig_only=True")
+    response = client.get(
+        f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json&sig_only=True"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -40,7 +42,9 @@ def test_sig_only_source_reg_effects_list_json(client: Client, sig_only_source_r
 
 def test_sig_only_false_source_reg_effects_list_json(client: Client, sig_only_source_reg_effects):
     source = sig_only_source_reg_effects["source"]
-    response = client.get(f"/search/regeffect/source/{source.accession_id}?accept=application/json&sig_only=False")
+    response = client.get(
+        f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json&sig_only=False"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -52,7 +56,7 @@ def test_sig_only_false_source_reg_effects_list_json(client: Client, sig_only_so
 
 def test_hidden_source_reg_effects_list_json(client: Client, hidden_source_reg_effects):
     source = hidden_source_reg_effects["source"]
-    response = client.get(f"/search/regeffect/source/{source.accession_id}?accept=application/json")
+    response = client.get(f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json")
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -61,12 +65,16 @@ def test_hidden_source_reg_effects_list_json(client: Client, hidden_source_reg_e
 
 
 def test_get_source_reg_effects_with_anonymous_client(client: Client, private_feature: DNAFeature):
-    response = client.get(f"/search/regeffect/source/{private_feature.accession_id}?accept=application/json")
+    response = client.get(
+        f"/search/feature/accession/{private_feature.accession_id}/source_for?accept=application/json"
+    )
     assert response.status_code == 302
 
 
 def test_get_source_reg_effects_with_authenticated_client(login_client: SearchClient, private_feature: DNAFeature):
-    response = login_client.get(f"/search/regeffect/source/{private_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{private_feature.accession_id}/source_for?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -74,7 +82,9 @@ def test_get_source_reg_effects_with_authenticated_authorized_client(
     login_client: SearchClient, private_feature: DNAFeature
 ):
     login_client.set_user_experiments([private_feature.experiment_accession])
-    response = login_client.get(f"/search/regeffect/source/{private_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{private_feature.accession_id}/source_for?accept=application/json"
+    )
     assert response.status_code == 200
 
 
@@ -85,20 +95,24 @@ def test_get_source_reg_effects_with_authenticated_authorized_group_client(
 
     group_login_client.set_group_experiments([cast(str, private_feature.experiment_accession_id)])
     response = group_login_client.get(
-        f"/search/regeffect/source/{private_feature.accession_id}?accept=application/json"
+        f"/search/feature/accession/{private_feature.accession_id}/source_for?accept=application/json"
     )
     assert response.status_code == 200
 
 
 def test_get_archived_source_reg_effects_with_anonymous_client(client: Client, archived_feature: DNAFeature):
-    response = client.get(f"/search/regeffect/source/{archived_feature.accession_id}?accept=application/json")
+    response = client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/source_for?accept=application/json"
+    )
     assert response.status_code == 403
 
 
 def test_get_archived_source_reg_effects_with_authenticated_client(
     login_client: SearchClient, archived_feature: DNAFeature
 ):
-    response = login_client.get(f"/search/regeffect/source/{archived_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/source_for?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -108,7 +122,9 @@ def test_get_archived_source_reg_effects_with_authenticated_authorized_client(
     assert archived_feature.experiment_accession_id is not None
 
     login_client.set_user_experiments([cast(str, archived_feature.experiment_accession)])
-    response = login_client.get(f"/search/regeffect/source/{archived_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/source_for?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -119,7 +135,7 @@ def test_get_archived_source_reg_effects_with_authenticated_authorized_group_cli
 
     group_login_client.set_group_experiments([cast(str, archived_feature.experiment_accession_id)])
     response = group_login_client.get(
-        f"/search/regeffect/source/{archived_feature.accession_id}?accept=application/json"
+        f"/search/feature/accession/{archived_feature.accession_id}/source_for?accept=application/json"
     )
     assert response.status_code == 403
 
@@ -127,7 +143,9 @@ def test_get_archived_source_reg_effects_with_authenticated_authorized_group_cli
 def test_source_reg_effects_list_page_json(client: Client, source_reg_effects):
     source = source_reg_effects["source"]
     effects = sorted(source_reg_effects["effects"], key=lambda x: x.accession_id)
-    response = client.get(f"/search/regeffect/source/{source.accession_id}?accept=application/json&page=1&per_page=1")
+    response = client.get(
+        f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json&page=1&per_page=1"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -145,7 +163,7 @@ def test_source_reg_effects_list_page_json(client: Client, source_reg_effects):
 
 
 def test_source_regeffect_html(client: Client, feature: DNAFeature):
-    response = client.get(f"/search/regeffect/source/{feature.accession_id}")
+    response = client.get(f"/search/feature/accession/{feature.accession_id}/source_for")
 
     # The content of the page isn't necessarily stable, so we just want to make sure
     # we don't get a 400 or 500 error here

--- a/cegs_portal/search/views/v1/tests/test_target_reg_effects.py
+++ b/cegs_portal/search/views/v1/tests/test_target_reg_effects.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 def test_target_reg_effects_list_json(client: Client, target_reg_effects):
     target = target_reg_effects["target"]
     effects = sorted(target_reg_effects["effects"], key=lambda x: x.accession_id)
-    response = client.get(f"/search/regeffect/target/{target.accession_id}?accept=application/json")
+    response = client.get(f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json")
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -29,7 +29,9 @@ def test_target_reg_effects_list_json(client: Client, target_reg_effects):
 
 def test_sig_only_target_reg_effects_list_json(client: Client, sig_only_target_reg_effects):
     target = sig_only_target_reg_effects["target"]
-    response = client.get(f"/search/regeffect/target/{target.accession_id}?accept=application/json&sig_only=True")
+    response = client.get(
+        f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json&sig_only=True"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -42,7 +44,9 @@ def test_sig_only_target_reg_effects_list_json(client: Client, sig_only_target_r
 
 def test_sig_only_false_target_reg_effects_list_json(client: Client, sig_only_target_reg_effects):
     target = sig_only_target_reg_effects["target"]
-    response = client.get(f"/search/regeffect/target/{target.accession_id}?accept=application/json&sig_only=False")
+    response = client.get(
+        f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json&sig_only=False"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -54,7 +58,7 @@ def test_sig_only_false_target_reg_effects_list_json(client: Client, sig_only_ta
 
 def test_hidden_target_reg_effects_list_json(client: Client, hidden_target_reg_effects):
     target = hidden_target_reg_effects["target"]
-    response = client.get(f"/search/regeffect/target/{target.accession_id}?accept=application/json")
+    response = client.get(f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json")
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -63,14 +67,16 @@ def test_hidden_target_reg_effects_list_json(client: Client, hidden_target_reg_e
 
 
 def test_get_target_reg_effects_with_anonymous_client(client: Client, private_feature: DNAFeature):
-    response = client.get(f"/search/regeffect/target/{private_feature.accession_id}?accept=application/json")
+    response = client.get(f"/search/feature/accession/{private_feature.accession_id}/target_of?accept=application/json")
     assert response.status_code == 302
 
 
 def test_get_target_reg_effects_with_authenticated_client(
     login_client: SearchClient, private_feature: DNAFeature, django_user_model
 ):
-    response = login_client.get(f"/search/regeffect/target/{private_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{private_feature.accession_id}/target_of?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -78,7 +84,9 @@ def test_get_target_reg_effects_with_authenticated_authorized_client(
     login_client: SearchClient, private_feature: DNAFeature
 ):
     login_client.set_user_experiments([private_feature.experiment_accession])
-    response = login_client.get(f"/search/regeffect/target/{private_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{private_feature.accession_id}/target_of?accept=application/json"
+    )
     assert response.status_code == 200
 
 
@@ -89,20 +97,24 @@ def test_get_target_reg_effects_with_authenticated_authorized_group_client(
 
     group_login_client.set_group_experiments([cast(str, private_feature.experiment_accession_id)])
     response = group_login_client.get(
-        f"/search/regeffect/target/{private_feature.accession_id}?accept=application/json"
+        f"/search/feature/accession/{private_feature.accession_id}/target_of?accept=application/json"
     )
     assert response.status_code == 200
 
 
 def test_get_archived_target_reg_effects_with_anonymous_client(client: Client, archived_feature: DNAFeature):
-    response = client.get(f"/search/regeffect/target/{archived_feature.accession_id}?accept=application/json")
+    response = client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/target_of?accept=application/json"
+    )
     assert response.status_code == 403
 
 
 def test_get_archived_target_reg_effects_with_authenticated_client(
     login_client: SearchClient, archived_feature: DNAFeature
 ):
-    response = login_client.get(f"/search/regeffect/target/{archived_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/target_of?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -112,7 +124,9 @@ def test_get_archived_target_reg_effects_with_authenticated_authorized_client(
     assert archived_feature.experiment_accession_id is not None
 
     login_client.set_user_experiments([cast(str, archived_feature.experiment_accession)])
-    response = login_client.get(f"/search/regeffect/target/{archived_feature.accession_id}?accept=application/json")
+    response = login_client.get(
+        f"/search/feature/accession/{archived_feature.accession_id}/target_of?accept=application/json"
+    )
     assert response.status_code == 403
 
 
@@ -123,7 +137,7 @@ def test_get_archived_target_reg_effects_with_authenticated_authorized_group_cli
 
     group_login_client.set_user_experiments([cast(str, archived_feature.experiment_accession_id)])
     response = group_login_client.get(
-        f"/search/regeffect/target/{archived_feature.accession_id}?accept=application/json"
+        f"/search/feature/accession/{archived_feature.accession_id}/target_of?accept=application/json"
     )
     assert response.status_code == 403
 
@@ -131,7 +145,9 @@ def test_get_archived_target_reg_effects_with_authenticated_authorized_group_cli
 def test_target_reg_effects_list_page_json(client: Client, target_reg_effects):
     target = target_reg_effects["target"]
     effects = sorted(target_reg_effects["effects"], key=lambda x: x.accession_id)
-    response = client.get(f"/search/regeffect/target/{target.accession_id}?accept=application/json&page=1&per_page=1")
+    response = client.get(
+        f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json&page=1&per_page=1"
+    )
 
     assert response.status_code == 200
     json_content = json.loads(response.content)
@@ -149,7 +165,7 @@ def test_target_reg_effects_list_page_json(client: Client, target_reg_effects):
 
 
 def test_target_regeffect_html(client: Client, feature: DNAFeature):
-    response = client.get(f"/search/regeffect/target/{feature.accession_id}")
+    response = client.get(f"/search/feature/accession/{feature.accession_id}/target_of")
 
     # The content of the page isn't necessarily stable, so we just want to make sure
     # we don't get a 400 or 500 error here


### PR DESCRIPTION
Instead of "search/regeffect". These URLs return data related to a feature, not related to an REO, so their URLs should reflect that these are parts of features.