### PR TITLE
Adds a "buffer" around gene in the browser

### DIFF
--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -482,8 +482,6 @@
 
     if (assemblies.length == 1 && assemblies[0].type == "Gene") {
         let assembly = assemblies[0];
-        let geneLength = assembly.end - assembly.start;
-        let geneBuffer = Math.round(geneLength * .5);
 
         new CEGSGenoverse({
             container : '#genoverse', // Where to inject Genoverse (css/jQuery selector/DOM element)
@@ -492,8 +490,8 @@
             genome    : assembly.assembly, // see js/genomes/
             assembly  : assembly.assembly,
             chr       : assembly.chromo.replace("chr", ""),
-            start     : assembly.start - geneBuffer,
-            end       : assembly.end + geneBuffer,
+            start     : assembly.start - 1000,
+            end       : assembly.end + 1000,
             plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips' ],
             useHash   : true,
             hideEmptyTracks: false,

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -482,6 +482,8 @@
 
     if (assemblies.length == 1 && assemblies[0].type == "Gene") {
         let assembly = assemblies[0];
+        let geneLength = assembly.end - assembly.start;
+        let geneBuffer = Math.round(geneLength * .5);
 
         new CEGSGenoverse({
             container : '#genoverse', // Where to inject Genoverse (css/jQuery selector/DOM element)
@@ -490,8 +492,8 @@
             genome    : assembly.assembly, // see js/genomes/
             assembly  : assembly.assembly,
             chr       : assembly.chromo.replace("chr", ""),
-            start     : assembly.start,
-            end       : assembly.end,
+            start     : assembly.start - geneBuffer,
+            end       : assembly.end + geneBuffer,
             plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips' ],
             useHash   : true,
             hideEmptyTracks: false,


### PR DESCRIPTION
This lets users see the gene with more context

<img width="1045" alt="Screenshot 2024-01-26 at 9 51 35 AM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/3b1b8f43-ae7c-451b-8a44-dc92fb5f44df">
