### PR TITLE
Add TSV/bed download buttons to targeting REO table

### DIFF
--- a/cegs_portal/search/templates/search/v1/partials/_target_reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/partials/_target_reg_effect.html
@@ -18,6 +18,15 @@
         </svg>
         Targeting Regulatory Effect Observations
     </div>
+    <div style="position: absolute; right: 0;">
+        <span class="text-lg">Download:</span>
+        <a href="{% url 'search:target_effects' feature.accession_id %}?accept=text/tab-separated-values&tsv_format=original">
+            <button class="tsv-button" id="downloadButton">TSV</button>
+        </a>
+        <a href="{% url 'search:target_effects' feature.accession_id %}?accept=text/tab-separated-values&tsv_format=bed6">
+            <button class="tsv-button" id="downloadButtonNew">BED6</button>
+        </a>
+    </div>
 </div>
     <table class="data-table" hx-target="#target-table">
         <tr>


### PR DESCRIPTION
The functionality was already there, we just didn't have the buttons

<img width="1441" alt="Screenshot 2024-01-26 at 10 05 58 AM" src="https://github.com/ReddyLab/cegs-portal/assets/719958/da73b3c3-a08c-43a4-a38c-929ef1c51656">
