### PR TITLE
Fixed broken table routing on dna feature page

### DIFF
--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -439,8 +439,8 @@
             {% for feature, sources, targets, reo in feature_reos %}
             {% if feature.children.exists %}
                         {% for child in feature.children.all %}
-                        <tr data-href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}?assembly={{ child.ref_genome }}">
-                            <td><a href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}?assembly={{ child.ref_genome }}">{{ child.ensembl_id }}</a></td>
+                        <tr data-href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}?assembly={{ feature.ref_genome }}">
+                            <td><a href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}?assembly={{ feature.ref_genome }}">{{ child.ensembl_id }}</a></td>
                             <td>{{ child.get_feature_type_display }}</td>
                             <td>{{ child.name }}</td>
                             <td>

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -322,9 +322,9 @@
             {% for feature in features %}
             {% if feature.closest_features.exists %}
                     {% for close_feature in feature.closest_features.all %}
-                    <tr data-href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}">
+                    <tr data-href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}?assembly={{close_feature.ref_genome}}">
                         <td>
-                            <a href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}">{{ close_feature.accession_id }}</a>
+                            <a href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}?assembly={{close_feature.ref_genome}}">{{ close_feature.accession_id }}</a>
                         </td>
                         <td>{{ close_feature.get_feature_type_display }}</td>
                         <td>{{ close_feature.cell_line|default:"N/A" }}</td>
@@ -439,8 +439,8 @@
             {% for feature, sources, targets, reo in feature_reos %}
             {% if feature.children.exists %}
                         {% for child in feature.children.all %}
-                        <tr data-href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}">
-                            <td><a href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}">{{ child.ensembl_id }}</a></td>
+                        <tr data-href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}?assembly={{ child.ref_genome }}">
+                            <td><a href="{% url 'search:dna_features' 'ensembl' child.ensembl_id %}?assembly={{ child.ref_genome }}">{{ child.ensembl_id }}</a></td>
                             <td>{{ child.get_feature_type_display }}</td>
                             <td>{{ child.name }}</td>
                             <td>

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -322,9 +322,9 @@
             {% for feature in features %}
             {% if feature.closest_features.exists %}
                     {% for close_feature in feature.closest_features.all %}
-                    <tr data-href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}?assembly={{close_feature.ref_genome}}">
+                    <tr data-href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}">
                         <td>
-                            <a href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}?assembly={{close_feature.ref_genome}}">{{ close_feature.accession_id }}</a>
+                            <a href="{% url 'search:dna_features' 'accession' close_feature.accession_id %}">{{ close_feature.accession_id }}</a>
                         </td>
                         <td>{{ close_feature.get_feature_type_display }}</td>
                         <td>{{ close_feature.cell_line|default:"N/A" }}</td>

--- a/cegs_portal/search/templates/search/v1/partials/_features.html
+++ b/cegs_portal/search/templates/search/v1/partials/_features.html
@@ -39,7 +39,7 @@
                     <td>{{ feature.name|default:"N/A" }}</a></td>
                     <td>{{ feature.get_feature_type_display }}</td>
                     <td><span>{{ feature.chrom_name }}</span>: <span>{{ feature.location.lower }}-{{ feature.location.upper|add:"-1" }}:{{ feature.strand|if_strand }}</span></td>
-                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}">{{ feature.closest_gene_ensembl_id }}</a>{% else %}{% endif %}</td>
+                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}?assembly={{ feature.ref_genome }}">{{ feature.closest_gene_ensembl_id }}</a>{% else %}{% endif %}</td>
                     <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
                     <td>{{ feature.parent.name }}</td>
                     <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}">

--- a/cegs_portal/search/templates/search/v1/partials/_features.html
+++ b/cegs_portal/search/templates/search/v1/partials/_features.html
@@ -35,14 +35,14 @@
                 <th class="chrom-last-end-cap chrom-dark-band">Details</th>
             </tr>
             {% for feature in features %}
-                <tr class="data-row" data-href="{% url 'search:dna_features' 'accession' feature.accession_id %}">
+                <tr class="data-row" data-href="{% url 'search:dna_features' 'accession' feature.accession_id %}?assembly={{ feature.ref_genome }}">
                     <td>{{ feature.name|default:"N/A" }}</a></td>
                     <td>{{ feature.get_feature_type_display }}</td>
                     <td><span>{{ feature.chrom_name }}</span>: <span>{{ feature.location.lower }}-{{ feature.location.upper|add:"-1" }}:{{ feature.strand|if_strand }}</span></td>
-                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}">{{ feature.closest_gene_ensembl_id }}</a>{% else %}{% endif %}</td>
+                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}?assembly={{ feature.ref_genome }}">{{ feature.closest_gene_ensembl_id }}</a>{% else %}{% endif %}</td>
                     <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
                     <td>{{ feature.parent.name }}</td>
-                    <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}">
+                    <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}?assembly={{ feature.ref_genome }}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="svg-link-arrow bi bi-arrow-up-right-square-fill" viewBox="0 0 16 16">
                             <path fill-rule="evenodd" d="M14 0a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2zM5.904 10.803 10 6.707v2.768a.5.5 0 0 0 1 0V5.5a.5.5 0 0 0-.5-.5H6.525a.5.5 0 1 0 0 1h2.768l-4.096 4.096a.5.5 0 0 0 .707.707z"/>
                         </svg>

--- a/cegs_portal/search/templates/search/v1/partials/_features.html
+++ b/cegs_portal/search/templates/search/v1/partials/_features.html
@@ -35,14 +35,14 @@
                 <th class="chrom-last-end-cap chrom-dark-band">Details</th>
             </tr>
             {% for feature in features %}
-                <tr class="data-row" data-href="{% url 'search:dna_features' 'accession' feature.accession_id %}?assembly={{ feature.ref_genome }}">
+                <tr class="data-row" data-href="{% url 'search:dna_features' 'accession' feature.accession_id %}">
                     <td>{{ feature.name|default:"N/A" }}</a></td>
                     <td>{{ feature.get_feature_type_display }}</td>
                     <td><span>{{ feature.chrom_name }}</span>: <span>{{ feature.location.lower }}-{{ feature.location.upper|add:"-1" }}:{{ feature.strand|if_strand }}</span></td>
-                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}?assembly={{ feature.ref_genome }}">{{ feature.closest_gene_ensembl_id }}</a>{% else %}{% endif %}</td>
+                    <td>{% if feature.closest_gene_ensembl_id %}<a href="/search/feature/ensembl/{{ feature.closest_gene_ensembl_id }}">{{ feature.closest_gene_ensembl_id }}</a>{% else %}{% endif %}</td>
                     <td>{{ feature.ref_genome }}.{{ feature.ref_genome_patch|default:"0" }}</td>
                     <td>{{ feature.parent.name }}</td>
-                    <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}?assembly={{ feature.ref_genome }}">
+                    <td><a href="{% url 'search:dna_features' 'accession' feature.accession_id %}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="svg-link-arrow bi bi-arrow-up-right-square-fill" viewBox="0 0 16 16">
                             <path fill-rule="evenodd" d="M14 0a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2zM5.904 10.803 10 6.707v2.768a.5.5 0 0 0 1 0V5.5a.5.5 0 0 0-.5-.5H6.525a.5.5 0 1 0 0 1h2.768l-4.096 4.096a.5.5 0 0 0 .707.707z"/>
                         </svg>

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -41,7 +41,7 @@ class DNAFeatureSearch:
         cls,
         id_type: str,
         feature_id: str,
-        assembly: Optional[str],
+        assembly: Optional[str] = None,
         feature_properties: Optional[list[str]] = None,
         distinct=True,
     ) -> QuerySet[DNAFeature]:

--- a/cegs_portal/search/views/v1/dna_features.py
+++ b/cegs_portal/search/views/v1/dna_features.py
@@ -16,6 +16,8 @@ from cegs_portal.search.views.custom_views import (
 from cegs_portal.utils.http_exceptions import Http400
 
 DEFAULT_TABLE_LENGTH = 20
+GRCH37 = "GRCh37"
+GRCH38 = "GRCh38"
 
 
 class DNAFeatureId(ExperimentAccessMixin, MultiResponseFormatView):
@@ -76,31 +78,32 @@ class DNAFeatureId(ExperimentAccessMixin, MultiResponseFormatView):
     def get(self, request, options, data, id_type, feature_id):
         feature_reos = []
         reo_page = None
-        all_assemblies = ["GRCh37", "GRCh38"]
+        all_assemblies = [GRCH37, GRCH38]
         feature_assemblies = []
 
         for feature in data.all():
             feature_assemblies.append(feature.ref_genome)
-            sources = DNAFeatureSearch.source_reo_search(feature.accession_id)
-            if sources.exists():
-                sources = {"nav_prefix": f"source_for_{feature.accession_id}"}
-            else:
-                sources = None
+            if feature.ref_genome == options["assembly"]:
+                sources = DNAFeatureSearch.source_reo_search(feature.accession_id)
+                if sources.exists():
+                    sources = {"nav_prefix": f"source_for_{feature.accession_id}"}
+                else:
+                    sources = None
 
-            targets = DNAFeatureSearch.target_reo_search(feature.accession_id)
-            if targets.exists():
-                targets = {"nav_prefix": f"target_for_{feature.accession_id}"}
-            else:
-                targets = None
+                targets = DNAFeatureSearch.target_reo_search(feature.accession_id)
+                if targets.exists():
+                    targets = {"nav_prefix": f"target_for_{feature.accession_id}"}
+                else:
+                    targets = None
 
-            reos = DNAFeatureSearch.non_targeting_reo_search(feature.accession_id, options.get("sig_only"))
-            if reos.exists():
-                paginated_reos = Paginator(reos, DEFAULT_TABLE_LENGTH)
-                reo_page = paginated_reos.page(1)
-            else:
-                reo_page = None
+                reos = DNAFeatureSearch.non_targeting_reo_search(feature.accession_id, options.get("sig_only"))
+                if reos.exists():
+                    paginated_reos = Paginator(reos, DEFAULT_TABLE_LENGTH)
+                    reo_page = paginated_reos.page(1)
+                else:
+                    reo_page = None
 
-            feature_reos.append((feature, sources, targets, reo_page))
+                feature_reos.append((feature, sources, targets, reo_page))
 
         def sort_key(feature_reo):
             feature = feature_reo[0]

--- a/cegs_portal/search/views/v1/dna_features.py
+++ b/cegs_portal/search/views/v1/dna_features.py
@@ -83,6 +83,12 @@ class DNAFeatureId(ExperimentAccessMixin, MultiResponseFormatView):
 
         for feature in data.all():
             feature_assemblies.append(feature.ref_genome)
+
+            if GRCH37 in feature_assemblies and GRCH38 not in feature_assemblies:
+                options["assembly"] = GRCH37
+            else:
+                options["assembly"] = GRCH38
+
             if feature.ref_genome != options["assembly"]:
                 continue
 


### PR DESCRIPTION
Changes were made to accommodate the reference genome selection feature on the dna feature page which caused a few tables with feature data links to break. Added assembly parameter to routes to direct user to the working page.


