### PR TITLE
Associated cCREs with tested elements

### DIFF
--- a/cegs_portal/search/models/__init__.py
+++ b/cegs_portal/search/models/__init__.py
@@ -1,6 +1,6 @@
 from . import signals
 from .accession import Accessioned, AccessionIdLog, AccessionIds
-from .dna_feature import DNAFeature
+from .dna_feature import DNAFeature, GrnaType, PromoterType
 from .dna_feature_type import DNAFeatureSourceType, DNAFeatureType
 from .experiment import (
     Analysis,

--- a/cegs_portal/search/models/dna_feature.py
+++ b/cegs_portal/search/models/dna_feature.py
@@ -15,6 +15,17 @@ from cegs_portal.search.models.file import File
 from cegs_portal.search.models.validators import validate_gene_ids
 
 
+class GrnaType(Enum):
+    POSITIVE_CONTROL = "Positive Control"
+    NEGATIVE_CONTROL = "Negative Control"
+    TARGETING = "Targeting"
+
+
+class PromoterType(Enum):
+    PROMOTER = "Promoter"
+    NON_PROMOTER = "Non-promoter"
+
+
 class DNAFeature(Accessioned, Faceted, AccessControlled):
     class Meta(Accessioned.Meta):
         indexes = [
@@ -32,6 +43,7 @@ class DNAFeature(Accessioned, Faceted, AccessControlled):
         CCRE_CATEGORIES = "cCRE Category"
         DHS_CCRE_OVERLAP_CATEGORIES = "cCRE Overlap"
         GRNA_TYPE = "gRNA Type"
+        PROMOTER = "Promoter Classification"
 
     FEATURE_TYPE = (
         (str(DNAFeatureType.GENE), DNAFeatureType.GENE.value),

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPRa_2022.sh
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPRa_2022.sh
@@ -7,12 +7,5 @@ ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/
 
 echo "Loading DCPEXPR0000000008"
 
-# # generate ccre overlaps
-# ./scripts/data_generation/ccre_overlaps.sh \
-#     ${DATA_DIR}/DCPEXPR0000000008_mccutcheon_scCERES_cd8_CRISPRa_2022/crispra.mast.volcano.all.min_thres_4.with_coords.tsv \
-#     GRCh38 \
-#     chr start end \
-#     ${CLOSEST_CCRE_FILE}
-
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.run(\"${ANALYSIS_FILE}\")"

--- a/scripts/data_loading/DCPEXPR0000000009_load_mccutcheon_scCERES_cd8_CRISPRi_2022.sh
+++ b/scripts/data_loading/DCPEXPR0000000009_load_mccutcheon_scCERES_cd8_CRISPRi_2022.sh
@@ -7,12 +7,5 @@ ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/
 
 echo "Loading DCPEXPR0000000009"
 
-# # generate ccre overlaps
-# ./scripts/data_generation/ccre_overlaps.sh \
-#     ${DATA_DIR}/DCPEXPR0000000009_mccutcheon_scCERES_cd8_CRISPRi_2022/crispri.mast.volcano.all.min_thres_4.with_coords.tsv \
-#     GRCh38 \
-#     chr start end \
-#     ${CLOSEST_CCRE_FILE}
-
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis; DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.run(\"${ANALYSIS_FILE}\")"

--- a/scripts/data_loading/db.py
+++ b/scripts/data_loading/db.py
@@ -150,7 +150,7 @@ def feature_entry(
     genome_assembly_patch="0",
     feature_subtype="\\N",
     strand="\\N",
-    source_file_id="\\N",
+    source_file_id=None,
     experiment_accession_id="\\N",
     parent_id=None,
     parent_accession_id=None,
@@ -160,6 +160,7 @@ def feature_entry(
 ):
     ids = "\\N" if ids is None else json.dumps(ids)
     misc = "\\N" if misc is None else json.dumps(misc)
+    source_file_id = "\\N" if source_file_id is None else source_file_id
     parent_id = "\\N" if parent_id is None else parent_id
     parent_accession_id = "\\N" if parent_accession_id is None else parent_accession_id
     return f"{id_}\t{accession_id}\t{ids}\t{ensembl_id}\t{name}\t{cell_line}\t{chrom_name}\t{closest_gene_id}\t{closest_gene_distance}\t{closest_gene_name}\t{closest_gene_ensembl_id}\t{location}\t{strand}\t{genome_assembly}\t{genome_assembly_patch}\t{feature_type}\t{feature_subtype}\t{source_file_id}\t{experiment_accession_id}\t{parent_id}\t{parent_accession_id}\t{misc}\t{archived}\t{public}\n"
@@ -179,6 +180,10 @@ def target_entry(reo_id, target_id):
 
 def direction_entry(reo_id, direction_id):
     return f"{reo_id}\t{direction_id}\n"
+
+
+def ccre_associate_entry(feature_id, ccre_id):
+    return f"{feature_id}\t{ccre_id}\n"
 
 
 def bulk_feature_save(features: StringIO):
@@ -227,4 +232,12 @@ def bulk_feature_facet_save(facets):
                 "dnafeature_id",
                 "facetvalue_id",
             ),
+        )
+
+
+def bulk_save_associations(associations):
+    associations.seek(0, SEEK_SET)
+    with transaction.atomic(), connection.cursor() as cursor:
+        cursor.copy_from(
+            associations, "search_dnafeature_associated_ccres", columns=("from_dnafeature_id", "to_dnafeature_id")
         )

--- a/scripts/data_loading/tests/conftest.py
+++ b/scripts/data_loading/tests/conftest.py
@@ -1,0 +1,64 @@
+import pytest
+from psycopg2.extras import NumericRange
+
+from cegs_portal.search.models import DNAFeature, DNAFeatureType, GrnaType, PromoterType
+from cegs_portal.search.models.tests.dna_feature_factory import DNAFeatureFactory
+from cegs_portal.search.models.tests.experiment_factory import ExperimentFactory
+from cegs_portal.search.models.tests.facet_factory import (
+    FacetFactory,
+    FacetValueFactory,
+)
+from utils.file import FileMetadata
+
+
+class MockExperimentMetadata:
+    features = None
+    parent_features = None
+
+    def __init__(self):
+        self.experiment = ExperimentFactory()
+        self.accession_id = self.experiment.accession_id
+        self.file_metadata = [
+            FileMetadata({"file": "elements_file", "genome_assembly": "GRCh38"}, "/"),
+            FileMetadata({"file": "elements_parent_file", "genome_assembly": "GRCh38"}, "/"),
+        ]
+        self.tested_elements_file = self.file_metadata[0]
+        self.tested_elements_parent_file = self.file_metadata[1]
+
+    def db_save(self):
+        return self.experiment
+
+    def db_del(self):
+        pass
+
+
+@pytest.fixture
+def experiment_metadata():
+    return MockExperimentMetadata()
+
+
+@pytest.fixture(autouse=True)
+def facets():
+    grna_facet = FacetFactory(description="", name=DNAFeature.Facet.GRNA_TYPE.value)
+    _ = FacetValueFactory(facet=grna_facet, value=GrnaType.POSITIVE_CONTROL.value)
+    _ = FacetValueFactory(facet=grna_facet, value=GrnaType.NEGATIVE_CONTROL.value)
+    _ = FacetValueFactory(facet=grna_facet, value=GrnaType.TARGETING.value)
+
+    promoter_facet = FacetFactory(description="", name=DNAFeature.Facet.PROMOTER.value)
+    _ = FacetValueFactory(facet=promoter_facet, value=PromoterType.PROMOTER.value)
+    _ = FacetValueFactory(facet=promoter_facet, value=PromoterType.NON_PROMOTER.value)
+
+
+@pytest.fixture
+def ccres():
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(100, 200))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(300, 400))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(500, 600))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(700, 800))
+
+
+@pytest.fixture
+def gene():
+    _ = DNAFeatureFactory(
+        feature_type=DNAFeatureType.GENE, chrom_name="chr1", location=NumericRange(1000, 2000), strand="+"
+    )

--- a/scripts/data_loading/tests/test_experiment_saving.py
+++ b/scripts/data_loading/tests/test_experiment_saving.py
@@ -105,3 +105,53 @@ def test_ccre_associations(experiment_metadata):
     clean_features()
 
     assert len(generated_features()) == 0
+
+
+@pytest.mark.usefixtures("ccres", "gene")
+def test_close_ccre_associations(experiment_metadata):
+    # Make sure the algorithm works correctly for features that abut existing cCREs
+    # Neither of these features should "overlap" so they should both result in
+    # two new pseudo cCREs
+
+    # This has to happen hear because load_experiment does DB calls on load
+    # which isn't allowed in the pytest suite outside of tests with a django_db mark
+    from scripts.data_loading.load_experiment import Experiment, FeatureRow
+
+    def load_features(_):
+        features = [
+            FeatureRow(
+                name="0",
+                chrom_name="chr1",
+                location=(90, 100, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "0"},
+            ),
+            FeatureRow(
+                name="1",
+                chrom_name="chr1",
+                location=(200, 220, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "1"},
+            ),
+        ]
+        return features, None
+
+    old_ids = ccre_ids()
+
+    Experiment(experiment_metadata).load(load_features).save()
+
+    for feature in generated_features():
+        for ccre in [ccre for ccre in feature.associated_ccres.all()]:
+            assert ccre.id not in old_ids
+
+    clean_features()
+
+    assert len(generated_features()) == 0

--- a/scripts/data_loading/tests/test_experiment_saving.py
+++ b/scripts/data_loading/tests/test_experiment_saving.py
@@ -1,0 +1,107 @@
+import pytest
+
+from cegs_portal.search.models import DNAFeature, DNAFeatureType
+
+pytestmark = pytest.mark.django_db
+
+
+def ccre_ids():
+    return set(DNAFeature.objects.filter(feature_type=DNAFeatureType.CCRE).values_list("id", flat=True))
+
+
+def generated_features():
+    return DNAFeature.objects.exclude(feature_type__in=[DNAFeatureType.CCRE, DNAFeatureType.GENE]).all()
+
+
+def clean_features():
+    for feature in generated_features():
+        feature.delete()
+
+    for ccre in DNAFeature.objects.filter(feature_type=DNAFeatureType.CCRE, misc__pseudo=True).all():
+        ccre.delete()
+
+
+@pytest.mark.usefixtures("ccres", "gene")
+def test_ccre_associations(experiment_metadata):
+    # This has to happen hear because load_experiment does DB calls on load
+    # which isn't allowed in the pytest suite outside of tests with a django_db mark
+    from scripts.data_loading.load_experiment import Experiment, FeatureRow
+
+    def load_features(_):
+        features = [
+            FeatureRow(
+                name="0",
+                chrom_name="chr1",
+                location=(0, 10, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "0"},
+            ),
+            FeatureRow(
+                name="1",
+                chrom_name="chr1",
+                location=(90, 120, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "1"},
+            ),
+            FeatureRow(
+                name="2",
+                chrom_name="chr1",
+                location=(290, 410, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "1"},
+            ),
+            FeatureRow(
+                name="3",
+                chrom_name="chr1",
+                location=(510, 590, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "1"},
+            ),
+            FeatureRow(
+                name="4",
+                chrom_name="chr1",
+                location=(940, 950, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type="gRNA",
+                facets=["Targeting"],
+                misc={"grna": "2"},
+            ),
+        ]
+        return features, None
+
+    old_ids = ccre_ids()
+
+    Experiment(experiment_metadata).load(load_features).save()
+
+    overlap_ccre_count = 0
+
+    for feature in generated_features():
+        for ccre in [ccre for ccre in feature.associated_ccres.all()]:
+            if ccre.id in old_ids:
+                assert ccre.misc.get("pseudo") is None
+                overlap_ccre_count += 1
+            else:
+                assert ccre.misc["pseudo"]
+
+    assert overlap_ccre_count == 3
+    clean_features()
+
+    assert len(generated_features()) == 0

--- a/utils/ccres.py
+++ b/utils/ccres.py
@@ -1,5 +1,4 @@
 import csv
-import json
 from collections import defaultdict
 from dataclasses import dataclass, field
 from io import StringIO
@@ -11,6 +10,11 @@ from django.db.models import F, Func
 from psycopg2.extras import NumericRange
 
 from cegs_portal.search.models import AccessionType, DNAFeature, DNAFeatureType
+from scripts.data_loading.db import (
+    bulk_feature_save,
+    ccre_associate_entry,
+    feature_entry,
+)
 
 from .db_ids import FeatureIds
 
@@ -33,34 +37,6 @@ class CcreSource:
     new_location: Optional[NumericRange] = None
     feature_type: DNAFeatureType = DNAFeatureType.CCRE
     misc: dict = field(default_factory=lambda: {"pseudo": True})
-
-
-def save_ccres(ccres: StringIO):
-    ccres.seek(0, SEEK_SET)
-    with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            ccres,
-            "search_dnafeature",
-            columns=(
-                "id",
-                "accession_id",
-                "cell_line",
-                "chrom_name",
-                "closest_gene_id",
-                "closest_gene_distance",
-                "closest_gene_name",
-                "closest_gene_ensembl_id",
-                "location",
-                "ref_genome",
-                "ref_genome_patch",
-                "misc",
-                "feature_type",
-                "source_file_id",
-                "experiment_accession_id",
-                "archived",
-                "public",
-            ),
-        )
 
 
 def save_associations(associations):
@@ -109,17 +85,34 @@ def associate_ccres(closest_ccre_filename, sources: list[CcreSource], ref_genome
             if len(ccres) > 0:
                 found += 1
                 for ccre_id in get_ccres(ccres).all():
-                    ccre_associations.write(f"{source._id}\t{ccre_id}\n")
+                    ccre_associations.write(ccre_associate_entry(source._id, ccre_id))
             else:
                 missing += 1
                 feature_id = feature_ids.next_id()
                 location = source.new_location if source.new_location is not None else source.test_location
-                source_id = source._new_id if source._new_id is not None else source._id
                 new_ccres.write(
-                    f"{feature_id}\t{accession_ids.incr(AccessionType.CCRE)}\t{source.cell_line}\t{source.chrom_name}\t{source.closest_gene_id}\t{source.closest_gene_distance}\t{source.closest_gene_name}\t{source.closest_gene_ensembl_id}\t{location}\t{source.ref_genome}\t{source.ref_genome_patch}\t{json.dumps({'pseudo': True})}\t{DNAFeatureType.CCRE}\t{source.source_file_id}\t{source.experiment_accession_id}\tfalse\ttrue\n"
+                    feature_entry(
+                        id_=feature_id,
+                        accession_id=accession_ids.incr(AccessionType.CCRE),
+                        cell_line=source.cell_line,
+                        chrom_name=source.chrom_name,
+                        closest_gene_id=source.closest_gene_id,
+                        closest_gene_distance=source.closest_gene_distance,
+                        closest_gene_name=source.closest_gene_name,
+                        closest_gene_ensembl_id=source.closest_gene_ensembl_id,
+                        location=location,
+                        genome_assembly=source.ref_genome,
+                        genome_assembly_patch=source.ref_genome_patch,
+                        misc={"pseudo": True},
+                        feature_type=DNAFeatureType.CCRE,
+                        source_file_id=source.source_file_id,
+                        experiment_accession_id=source.experiment_accession_id,
+                    )
                 )
-                ccre_associations.write(f"{source_id}\t{feature_id}\n")
-    save_ccres(new_ccres)
+
+                source_id = source._new_id if source._new_id is not None else source._id
+                ccre_associations.write(ccre_associate_entry(source_id, feature_id))
+    bulk_feature_save(new_ccres)
     save_associations(ccre_associations)
     print(f"Found: {found}")
     print(f"Missing: {missing}")


### PR DESCRIPTION
Part of loading the data is associating tested elements with cCREs for "normalization" purposes. This had been done with a mix of python scripts and `bedtools intersect` but requiring bedtools either directly or implicitly (with `pybedtools`) is kind of overkill when we just need to perform a relatively simple task.

This PR adds the algorithm to match tested elements (or their parents) with cCREs or create new "pseudo" cCREs if no matches are found.

Here's my explanation (from a comment in the code):

    To associate features with cCREs we need two lists -- The list of all current cCREs for a genome
    assembly and the the list of features. These two lists must be sorted, and must be sorted in the
    same manner.

    We work our way through both lists linearly, on each iteration moving forward on one or the other
    (but not both). Which list we move forward on depends on the comparison between the current ccre
    and current feature.

    If the current feature is AFTER the current cCRE we just advance to the next cCRE.

    If the current feature is BEFORE the current cCRE, then we create a new pseudo-cCRE from that
    feature. The new pseudo-cCRE get associated with the current feature. We then advance to the next
    feature.

    If the current feature OVERLAPS with this current cCRE then we associate the feature with the cCRE.

    Afterwards we look ahead to see if we advance the feature or the cCRE. If the feature also overlaps
    the next cCRE we advance the cCRE -- this way if a feature overlaps multiple cCREs it will be
    associated with all of them. Otherwise we advance to the next feature.

    If we get through all the features without getting through the cCREs, then we're done. If we get
    through all the cCREs without getting through all the features then we have to make new psudeo-cCREs
    with the remaining features, and do the association.
    
    Once we're through the lists we save all the new pseudo-cCREs and then the associations.
    By sorting the lists and advancing through only one at a time we can be sure to catch all the matches
    without incurring massive algorithmic overhead. This is an O(n+m) algorithm, modulo the list sorting.

There's also some code clean up and tests to make sure that the algorithm works as expected.