### PR TITLE
Update all loading scripts to use backend/frontend loading arch

### DIFF
--- a/scripts/data_loading/DCPEXPR0000000002_ensembl.py
+++ b/scripts/data_loading/DCPEXPR0000000002_ensembl.py
@@ -1,0 +1,47 @@
+import csv
+
+from psycopg2.extras import NumericRange
+
+from cegs_portal.search.models import DNAFeature
+from utils.experiment import ExperimentMetadata
+
+from .load_experiment import Experiment
+
+
+def run(experiment_filename):
+    metadata = ExperimentMetadata.file_load(experiment_filename)
+    exp = Experiment(metadata)
+
+    dhs_file = exp.metadata.tested_elements_file
+    genome_assembly = dhs_file.genome_assembly
+
+    genes = {}
+    with open(dhs_file.filename, "r") as feature_tsv:
+        reader = csv.DictReader(feature_tsv, delimiter=dhs_file.delimiter(), quoting=csv.QUOTE_NONE)
+        for line in reader:
+            gene_name = line["gene_symbol"]
+            gene_start = int(line["start"]) - 1
+            gene_end = int(line["end"])
+            gene_location = NumericRange(gene_start, gene_end, "[)")
+            if gene_name not in genes:
+                gene_objects = DNAFeature.objects.filter(
+                    name=gene_name, location=gene_location, ref_genome=genome_assembly
+                ).all()
+
+                if len(gene_objects) == 1:
+                    gene = gene_objects[0]
+                    genes[gene_name] = gene.ensembl_id
+                elif len(gene_objects) == 0:
+                    # This case shouldn't happen
+                    genes[gene_name] = None
+                else:
+                    # There is ONE instance where there are two genes with the same name
+                    # in the exact same location. This handles that situation.
+                    # The two gene IDs are ENSG00000272333 and ENSG00000105663.
+                    # I decided that ENSG00000272333 was the "correct" gene to use here
+                    # because it's the one that still exists in GRCh38.
+                    genes[gene_name] = "ENSG00000272333"
+
+    with open("genes.txt", "w") as output:
+        for key, value in genes.items():
+            output.write(f"{key}\t{value}\n")

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_analysis.py
@@ -1,163 +1,61 @@
 import csv
-import math
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    Analysis,
-    DNAFeature,
-    DNAFeatureType,
-    Facet,
-    FacetValue,
-    RegulatoryEffectObservation,
-)
-from utils import timer
-from utils.db_ids import ReoIds
 from utils.experiment import AnalysisMetadata
 
-from .db import bulk_reo_save, reo_entry
-
-DIR_FACET = Facet.objects.get(name="Direction")
-DIR_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=DIR_FACET.id).all()}
+from .load_analysis import Analysis, ObservationRow, SourceInfo
+from .types import DirectionFacets, FeatureType, NumericFacets
 
 
-CORRECT_FEATURES = ["ENSG00000272333"]
+def gene_ensembl_mapping(genes_filename):
+    gene_name_map = {}
+    with open(genes_filename, newline="") as genes_file:
+        reader = csv.reader(genes_file, delimiter="\t")
+        for row in reader:
+            gene_name_map[row[0]] = row[1]
 
-MIN_SIG = 1e-100
-
-
-@timer("Load Reg Effects")
-def load_reg_effects(reo_file, accession_ids, analysis, ref_genome, ref_genome_patch, delimiter=","):
-    experiment = analysis.experiment
-    experiment_id = experiment.id
-    experiment_accession_id = experiment.accession_id
-    analysis_accession_id = analysis.accession_id
-    reader = csv.DictReader(reo_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    sources = StringIO()
-    targets = StringIO()
-    effects = StringIO()
-    effect_directions = StringIO()
-    dhss = {}
-    target_genes = {}
-
-    with ReoIds() as reo_ids:
-        for reo_id, line in zip(reo_ids, reader):
-            chrom_name = line["dhs_chrom"]
-
-            dhs_start = int(line["dhs_start"])
-            dhs_end = int(line["dhs_end"])
-            dhs_string = f"{chrom_name}:{dhs_start}-{dhs_end}:{ref_genome}"
-
-            gene_start = int(line["start"]) - 1
-            gene_end = int(line["end"])
-
-            if dhs_string not in dhss:
-                dhss[dhs_string] = DNAFeature.objects.filter(
-                    experiment_accession=experiment,
-                    chrom_name=chrom_name,
-                    location=NumericRange(dhs_start, dhs_end, "[)"),
-                    ref_genome=ref_genome,
-                    feature_type=DNAFeatureType.DHS,
-                ).values_list("id", flat=True)[0]
-
-            sources.write(f"{reo_id}\t{dhss[dhs_string]}\n")
-
-            significance = float(line["pval_empirical"])
-            effect_size = float(line["avg_logFC"])
-            if significance >= 0.01:
-                direction = DIR_FACET_VALUES["Non-significant"]
-            elif effect_size > 0:
-                direction = DIR_FACET_VALUES["Enriched Only"]
-            elif effect_size < 0:
-                direction = DIR_FACET_VALUES["Depleted Only"]
-            else:
-                direction = DIR_FACET_VALUES["Non-significant"]
-
-            target_location = NumericRange(gene_start, gene_end, "[)")
-            gene_key = f"{line['gene_symbol']}:{target_location}"
-            if gene_key not in target_genes:
-                target_genes[gene_key] = DNAFeature.objects.filter(
-                    ref_genome=ref_genome,
-                    ref_genome_patch=ref_genome_patch,
-                    name=line["gene_symbol"],
-                    location=target_location,
-                ).values_list("id", flat=True)
-                if len(target_genes[gene_key]) > 1:
-                    # There is ONE instance where there are two genes with the same name
-                    # in the exact same location. This handles that situation.
-                    # The two gene IDs are ENSG00000272333 and ENSG00000105663.
-                    # I decided that ENSG00000272333 was the "correct" gene to use here
-                    # because it's the one that still exists in GRCh38.
-                    target_genes[gene_key] = DNAFeature.objects.filter(
-                        ref_genome=ref_genome,
-                        ref_genome_patch=ref_genome_patch,
-                        name=line["gene_symbol"],
-                        location=NumericRange(gene_start, gene_end, "[)"),
-                        ensembl_id__in=CORRECT_FEATURES,
-                    ).values_list("id", flat=True)
-
-            try:
-                targets.write(f"{reo_id}\t{target_genes[gene_key][0]}\n")
-            except IndexError as ie:
-                print(f"{ref_genome} {ref_genome_patch} {line['gene_symbol']} [{gene_start}, {gene_end})")
-                raise ie
-
-            facet_num_values = {
-                RegulatoryEffectObservation.Facet.EFFECT_SIZE.value: effect_size,
-                RegulatoryEffectObservation.Facet.RAW_P_VALUE.value: float(line["p_val"]),
-                RegulatoryEffectObservation.Facet.SIGNIFICANCE.value: significance,
-                RegulatoryEffectObservation.Facet.LOG_SIGNIFICANCE.value: -math.log10(max(significance, MIN_SIG)),
-            }
-            effects.write(
-                reo_entry(
-                    id_=reo_id,
-                    accession_id=accession_ids.incr(AccessionType.REGULATORY_EFFECT_OBS),
-                    experiment_id=experiment_id,
-                    experiment_accession_id=experiment_accession_id,
-                    analysis_accession_id=analysis_accession_id,
-                    facet_num_values=facet_num_values,
-                )
-            )
-            effect_directions.write(f"{reo_id}\t{direction.id}\n")
-    bulk_reo_save(effects, effect_directions, sources, targets)
+    return gene_name_map
 
 
-def unload_analysis(analysis_metadata):
-    analysis = Analysis.objects.get(
-        experiment_id=analysis_metadata.experiment_accession_id, name=analysis_metadata.name
+def get_observations(analysis_metadata: AnalysisMetadata):
+    gene_name_map = gene_ensembl_mapping(analysis_metadata.misc_files[0].filename)
+    results_file = open(analysis_metadata.results.file_metadata.filename)
+    reader = csv.DictReader(
+        results_file, delimiter=analysis_metadata.results.file_metadata.delimiter(), quoting=csv.QUOTE_NONE
     )
-    RegulatoryEffectObservation.objects.filter(analysis=analysis).delete()
-    analysis_metadata.db_del(analysis)
+    observations: list[ObservationRow] = []
 
+    for line in reader:
+        chrom_name = line["dhs_chrom"]
 
-def check_filename(analysis_filename: str):
-    if len(analysis_filename) == 0:
-        raise ValueError(f"scCERES analysis filename '{analysis_filename}' must not be blank")
+        dhs_start = int(line["dhs_start"])
+        dhs_end = int(line["dhs_end"])
+
+        sources = [SourceInfo(chrom_name, dhs_start, dhs_end, "[)", None, FeatureType.DHS)]
+
+        targets = [gene_name_map[line["gene_symbol"]]]
+
+        significance = float(line["pval_empirical"])
+        effect_size = float(line["avg_logFC"])
+        if significance >= 0.01:
+            direction = DirectionFacets.NON_SIGNIFICANT
+        elif effect_size > 0:
+            direction = DirectionFacets.ENRICHED
+        elif effect_size < 0:
+            direction = DirectionFacets.DEPLETED
+        else:
+            direction = DirectionFacets.NON_SIGNIFICANT
+
+        num_facets = {
+            NumericFacets.EFFECT_SIZE: effect_size,
+            NumericFacets.SIGNIFICANCE: significance,
+            NumericFacets.RAW_P_VALUE: float(line["p_val"]),
+        }
+
+        observations.append(ObservationRow(sources, targets, [direction], num_facets))
+    results_file.close()
+    return observations
 
 
 def run(analysis_filename):
-    with open(analysis_filename) as analysis_file:
-        analysis_metadata = AnalysisMetadata.json_load(analysis_file)
-    check_filename(analysis_metadata.name)
-
-    # Only run unload_analysis if you want to delete the analysis, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_analysis() uncommented is not, strictly, idempotent.
-    # unload_analysis(analysis_metadata)
-
-    analysis = analysis_metadata.db_save()
-
-    with AccessionIds(message=f"{analysis.accession_id}: {analysis.name}"[:200]) as accession_ids:
-        for reo_file, file_info, delimiter in analysis_metadata.metadata():
-            load_reg_effects(
-                reo_file,
-                accession_ids,
-                analysis,
-                file_info.ref_genome,
-                file_info.ref_genome_patch,
-                delimiter,
-            )
+    metadata = AnalysisMetadata.file_load(analysis_filename)
+    Analysis(metadata).load(get_observations).save()

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_analysis.py
@@ -52,6 +52,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
         }
 
         observations.append(ObservationRow(sources, targets, [direction], num_facets))
+
     results_file.close()
     return observations
 

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_data.sh
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_data.sh
@@ -5,19 +5,8 @@ DATA_DIR=$1
 
 EXPERIMENT_FILE=${DATA_DIR}/DCPEXPR0000000002_klann_scCERES_K562_2021/experiment.json
 ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000002_klann_scCERES_K562_2021/analysis001.json
-CLOSEST_CCRE_FILE=${DATA_DIR}/DCPEXPR0000000002_klann_scCERES_K562_2021/dhs_bed_klann_2021_scceres_closest_ccres.txt
 
 echo "Loading DCPEXPR0000000002"
 
-# generate ccre overlaps
-./scripts/data_generation/ccre_overlaps.sh \
-    ${DATA_DIR}/DCPEXPR0000000002_klann_scCERES_K562_2021/supplementary_table_17_grna.de.markers.all.filtered.empirical_pvals.w_gene_info.csv \
-    GRCh37 \
-    dhs_chrom dhs_start dhs_end \
-    ${CLOSEST_CCRE_FILE}
-
-
-python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000002_load_klann_2021_scceres_experiment; DCPEXPR0000000002_load_klann_2021_scceres_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\")"
+python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000002_load_klann_2021_scceres_experiment; DCPEXPR0000000002_load_klann_2021_scceres_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000002_load_klann_2021_scceres_analysis; DCPEXPR0000000002_load_klann_2021_scceres_analysis.run(\"${ANALYSIS_FILE}\")"
-
-rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_experiment.py
@@ -1,120 +1,42 @@
 import csv
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    DNAFeature,
-    DNAFeatureType,
-    Experiment,
-)
-from utils import timer
-from utils.ccres import CcreSource, associate_ccres
-from utils.db_ids import FeatureIds
 from utils.experiment import ExperimentMetadata
 
-from . import get_closest_gene
-from .db import bulk_feature_save, feature_entry
-
-CORRECT_FEATURES = ["ENSG00000272333"]
+from .load_experiment import Experiment, FeatureRow
+from .types import FeatureType
 
 
-# loading does buffered writes to the DB, with a buffer size of 10,000 annotations
-@timer("Load DHSs")
-def load_dhss(
-    dhs_file, closest_ccre_filename, accession_ids, experiment, cell_line, ref_genome, region_source, delimiter=","
-):
-    reader = csv.DictReader(dhs_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    new_dhss: dict[str, CcreSource] = {}
-    dhss = StringIO()
-    region_source_id = region_source.id
-    experiment_accession_id = experiment.accession_id
+def get_features(experiment_metadata: ExperimentMetadata):
+    new_dhss: dict[str, FeatureRow] = {}
 
-    with FeatureIds() as feature_ids:
-        for feature_id, line in zip(feature_ids, reader):
-            chrom_name = line["dhs_chrom"]
+    dhs_file = experiment_metadata.tested_elements_file
+    dhs_cell_line = dhs_file.biosample.cell_line
 
-            dhs_start = int(line["dhs_start"])
-            dhs_end = int(line["dhs_end"])
-            dhs_location = f"[{dhs_start},{dhs_end})"
+    feature_tsv = open(dhs_file.filename, "r")
+    reader = csv.DictReader(feature_tsv, delimiter=dhs_file.delimiter(), quoting=csv.QUOTE_NONE)
 
-            dhs_name = f"{chrom_name}:{dhs_location}"
+    for line in reader:
+        chrom_name = line["dhs_chrom"]
 
-            if dhs_name not in new_dhss:
-                closest_gene, distance, gene_name = get_closest_gene(ref_genome, chrom_name, dhs_start, dhs_end)
-                closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
+        dhs_start = int(line["dhs_start"])
+        dhs_end = int(line["dhs_end"])
+        dhs_location = f"[{dhs_start},{dhs_end})"
 
-                dhss.write(
-                    feature_entry(
-                        id_=feature_id,
-                        accession_id=accession_ids.incr(AccessionType.DHS),
-                        cell_line=cell_line,
-                        chrom_name=chrom_name,
-                        location=dhs_location,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        ref_genome=ref_genome,
-                        feature_type=DNAFeatureType.DHS,
-                        source_file_id=region_source_id,
-                        experiment_accession_id=experiment_accession_id,
-                    )
-                )
-                new_dhss[dhs_name] = CcreSource(
-                    _id=feature_id,
-                    chrom_name=chrom_name,
-                    test_location=NumericRange(dhs_start, dhs_end),
-                    cell_line=cell_line,
-                    closest_gene_id=closest_gene["id"],
-                    closest_gene_distance=distance,
-                    closest_gene_name=gene_name,
-                    closest_gene_ensembl_id=closest_gene_ensembl_id,
-                    ref_genome=ref_genome,
-                    source_file_id=region_source_id,
-                    experiment_accession_id=experiment_accession_id,
-                )
-    print(f"DHS Count: {len(new_dhss)}")
-    bulk_feature_save(dhss)
+        dhs_name = f"{chrom_name}:{dhs_location}"
 
-    associate_ccres(closest_ccre_filename, new_dhss.values(), ref_genome, accession_ids)
-
-
-def unload_experiment(experiment_metadata):
-    experiment = Experiment.objects.get(accession_id=experiment_metadata.accession_id)
-    DNAFeature.objects.filter(experiment_accession=experiment).delete()
-    experiment_metadata.db_del()
-
-
-def check_filename(experiment_filename: str):
-    if len(experiment_filename) == 0:
-        raise ValueError(f"scCERES experiment filename '{experiment_filename}' must not be blank")
-
-
-def run(experiment_filename, closest_ccre_filename):
-    with open(experiment_filename) as experiment_file:
-        experiment_metadata = ExperimentMetadata.json_load(experiment_file)
-    check_filename(experiment_metadata.name)
-
-    # Only run unload_experiment if you want to delete the experiment, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_experiment() uncommented is not, strictly, idempotent.
-    # unload_experiment(experiment_metadata)
-
-    experiment = experiment_metadata.db_save()
-
-    with AccessionIds(message=f"{experiment.accession_id}: {experiment.name}"[:200]) as accession_ids:
-        for dhs_file, file_info, delimiter in experiment_metadata.metadata():
-            load_dhss(
-                dhs_file,
-                closest_ccre_filename,
-                accession_ids,
-                experiment,
-                experiment_metadata.biosamples[0].cell_line,
-                file_info.misc["ref_genome"],
-                experiment.files.all()[0],
-                delimiter,
+        if dhs_name not in new_dhss:
+            new_dhss[dhs_name] = FeatureRow(
+                name=dhs_name,
+                chrom_name=chrom_name,
+                location=(dhs_start, dhs_end, "[)"),
+                genome_assembly=dhs_file.genome_assembly,
+                cell_line=dhs_cell_line,
+                feature_type=FeatureType.DHS,
             )
+
+    return new_dhss.values(), None
+
+
+def run(experiment_filename):
+    metadata = ExperimentMetadata.file_load(experiment_filename)
+    Experiment(metadata).load(get_features).save()

--- a/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000002_load_klann_2021_scceres_experiment.py
@@ -34,6 +34,7 @@ def get_features(experiment_metadata: ExperimentMetadata):
                 feature_type=FeatureType.DHS,
             )
 
+    feature_tsv.close()
     return new_dhss.values(), None
 
 

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_analysis.py
@@ -1,138 +1,58 @@
 import csv
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    Analysis,
-    DNAFeature,
-    DNAFeatureType,
-    Facet,
-    FacetValue,
-    RegulatoryEffectObservation,
-)
-from utils import timer
-from utils.db_ids import ReoIds
 from utils.experiment import AnalysisMetadata
 
-from .db import bulk_reo_save, reo_entry
-
-DIR_FACET = Facet.objects.get(name="Direction")
-DIR_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=DIR_FACET.id).all()}
+from .load_analysis import Analysis, ObservationRow, SourceInfo
+from .types import DirectionFacets, FeatureType, NumericFacets
 
 
-@timer("Load Reg Effects")
-def load_reg_effects(reo_file, accession_ids, analysis, ref_genome, ref_genome_patch, delimiter=","):
-    experiment = analysis.experiment
-    experiment_id = experiment.id
-    experiment_accession_id = experiment.accession_id
-    analysis_accession_id = analysis.accession_id
-    reader = csv.DictReader(reo_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    sources = StringIO()
-    effects = StringIO()
-    effect_directions = StringIO()
-    dhss = {}
-
-    with ReoIds() as reo_ids:
-        for reo_id, line in zip(reo_ids, reader):
-            try:
-                chrom_name = line["chrom"]
-            except KeyError as ke:
-                print(f"delimiter: '{delimiter}'")
-                print(line)
-                raise ke
-
-            dhs_start = int(line["chromStart"])
-            dhs_end = int(line["chromEnd"])
-            dhs_string = f"{chrom_name}:{dhs_start}-{dhs_end}:{ref_genome}"
-
-            if dhs_string not in dhss:
-                dhss[dhs_string] = DNAFeature.objects.filter(
-                    experiment_accession=experiment,
-                    chrom_name=chrom_name,
-                    location=NumericRange(dhs_start, dhs_end, "[)"),
-                    ref_genome=ref_genome,
-                    feature_type=DNAFeatureType.DHS,
-                ).values_list("id", flat=True)[0]
-
-            sources.write(f"{reo_id}\t{dhss[dhs_string]}\n")
-
-            effect_size_field = line["wgCERES_score_top3_wg"].strip()
-            if effect_size_field == "":
-                effect_size = None
-            else:
-                effect_size = float(effect_size_field)
-
-            direction_line = line["direction_wg"]
-            if direction_line == "non_sig":
-                direction = DIR_FACET_VALUES["Non-significant"]
-            elif direction_line == "enriched":
-                direction = DIR_FACET_VALUES["Enriched Only"]
-            elif direction_line == "depleted":
-                direction = DIR_FACET_VALUES["Depleted Only"]
-            elif direction_line == "both":
-                direction = DIR_FACET_VALUES["Mixed"]
-            else:
-                direction = None
-
-            facet_num_values = {
-                RegulatoryEffectObservation.Facet.EFFECT_SIZE.value: effect_size,
-                # line[pValue] is -log10(actual p-value), so raw_p_value uses the inverse operation
-                RegulatoryEffectObservation.Facet.RAW_P_VALUE.value: pow(10, -float(line["pValue"])),
-                # line[pValue] is -log10(actual p-value), but we want significance between 0 and 1
-                # we perform the inverse operation.
-                RegulatoryEffectObservation.Facet.SIGNIFICANCE.value: pow(10, -float(line["pValue"])),
-                RegulatoryEffectObservation.Facet.LOG_SIGNIFICANCE.value: float(line["pValue"]),
-            }
-            effects.write(
-                reo_entry(
-                    id_=reo_id,
-                    accession_id=accession_ids.incr(AccessionType.REGULATORY_EFFECT_OBS),
-                    experiment_id=experiment_id,
-                    experiment_accession_id=experiment_accession_id,
-                    analysis_accession_id=analysis_accession_id,
-                    facet_num_values=facet_num_values,
-                )
-            )
-            effect_directions.write(f"{reo_id}\t{direction.id}\n")
-    bulk_reo_save(effects, effect_directions, sources)
-
-
-def unload_analysis(analysis_metadata):
-    analysis = Analysis.objects.get(
-        experiment_id=analysis_metadata.experiment_accession_id, name=analysis_metadata.name
+def get_observations(analysis_metadata: AnalysisMetadata):
+    results_file = open(analysis_metadata.results.file_metadata.filename)
+    reader = csv.DictReader(
+        results_file, delimiter=analysis_metadata.results.file_metadata.delimiter(), quoting=csv.QUOTE_NONE
     )
-    RegulatoryEffectObservation.objects.filter(analysis=analysis).delete()
-    analysis_metadata.db_del(analysis)
+    observations: list[ObservationRow] = []
 
+    for line in reader:
+        chrom_name = line["chrom"]
+        dhs_start = int(line["chromStart"])
+        dhs_end = int(line["chromEnd"])
 
-def check_filename(analysis_filename: str):
-    if len(analysis_filename) == 0:
-        raise ValueError(f"wgCERES analysis filename '{analysis_filename}' must not be blank")
+        sources = [SourceInfo(chrom_name, dhs_start, dhs_end, "[)", FeatureType.DHS)]
+
+        effect_size_field = line["wgCERES_score_top3_wg"].strip()
+        if effect_size_field == "":
+            effect_size = None
+        else:
+            effect_size = float(effect_size_field)
+
+        direction_line = line["direction_wg"]
+        if direction_line == "non_sig":
+            direction = DirectionFacets.NON_SIGNIFICANT
+        elif direction_line == "enriched":
+            direction = DirectionFacets.ENRICHED
+        elif direction_line == "depleted":
+            direction = DirectionFacets.DEPLETED
+        elif direction_line == "both":
+            direction = DirectionFacets.BOTH
+        else:
+            direction = None
+
+        facet_num_values = {
+            NumericFacets.EFFECT_SIZE: effect_size,
+            # line[pValue] is -log10(actual p-value), so raw_p_value uses the inverse operation
+            NumericFacets.RAW_P_VALUE: pow(10, -float(line["pValue"])),
+            # line[pValue] is -log10(actual p-value), but we want significance between 0 and 1
+            # we perform the inverse operation.
+            NumericFacets.SIGNIFICANCE: pow(10, -float(line["pValue"])),
+            NumericFacets.LOG_SIGNIFICANCE: float(line["pValue"]),
+        }
+
+        observations.append(ObservationRow(sources, [], [direction], facet_num_values))
+
+    return observations
 
 
 def run(analysis_filename):
-    with open(analysis_filename) as analysis_file:
-        analysis_metadata = AnalysisMetadata.json_load(analysis_file)
-    check_filename(analysis_metadata.name)
-
-    # Only run unload_analysis if you want to delete the analysis, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_analysis() uncommented is not, strictly, idempotent.
-    # unload_analysis(analysis_metadata)
-
-    analysis = analysis_metadata.db_save()
-
-    with AccessionIds(message=f"{analysis.accession_id}: {analysis.name}"[:200]) as accession_ids:
-        for reo_file, file_info, delimiter in analysis_metadata.metadata():
-            load_reg_effects(
-                reo_file,
-                accession_ids,
-                analysis,
-                file_info.ref_genome,
-                file_info.ref_genome_patch,
-                delimiter,
-            )
+    metadata = AnalysisMetadata.file_load(analysis_filename)
+    Analysis(metadata).load(get_observations).save()

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_analysis.py
@@ -50,6 +50,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
 
         observations.append(ObservationRow(sources, [], [direction], facet_num_values))
 
+    results_file.close()
     return observations
 
 

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_analysis.py
@@ -18,7 +18,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
         dhs_start = int(line["chromStart"])
         dhs_end = int(line["chromEnd"])
 
-        sources = [SourceInfo(chrom_name, dhs_start, dhs_end, "[)", FeatureType.DHS)]
+        sources = [SourceInfo(chrom_name, dhs_start, dhs_end, "[)", None, FeatureType.DHS)]
 
         effect_size_field = line["wgCERES_score_top3_wg"].strip()
         if effect_size_field == "":

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_data.sh
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_data.sh
@@ -5,18 +5,8 @@ DATA_DIR=$1
 
 EXPERIMENT_FILE=${DATA_DIR}/DCPEXPR0000000003_klann_wgCERES_K562_2021/experiment.json
 ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000003_klann_wgCERES_K562_2021/analysis001.json
-CLOSEST_CCRE_FILE=${DATA_DIR}/DCPEXPR0000000003_klann_wgCERES_K562_2021/dhs_bed_klann_2021_scceres_closest_ccres.txt
 
 echo "Loading DCPEXPR0000000003"
 
-# generate ccre overlaps
-./scripts/data_generation/ccre_overlaps.sh \
-    ${DATA_DIR}/DCPEXPR0000000003_klann_wgCERES_K562_2021/supplementary_table_5_DHS_summary_results.tsv \
-    GRCh37 \
-    chrom chromStart chromEnd \
-    ${CLOSEST_CCRE_FILE}
-
-python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000003_load_klann_2021_wgceres_experiment; DCPEXPR0000000003_load_klann_2021_wgceres_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\")"
+python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000003_load_klann_2021_wgceres_experiment; DCPEXPR0000000003_load_klann_2021_wgceres_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000003_load_klann_2021_wgceres_analysis; DCPEXPR0000000003_load_klann_2021_wgceres_analysis.run(\"${ANALYSIS_FILE}\")"
-
-rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_experiment.py
@@ -1,118 +1,42 @@
 import csv
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    DNAFeature,
-    DNAFeatureType,
-    Experiment,
-)
-from utils import timer
-from utils.ccres import CcreSource, associate_ccres
-from utils.db_ids import FeatureIds
 from utils.experiment import ExperimentMetadata
 
-from . import get_closest_gene
-from .db import bulk_feature_save, feature_entry
+from .load_experiment import Experiment, FeatureRow
+from .types import FeatureType
 
 
-# loading does buffered writes to the DB, with a buffer size of 10,000 annotations
-@timer("Load DHSs")
-def load_dhss(
-    dhs_file, closest_ccre_filename, accession_ids, experiment, cell_line, ref_genome, region_source, delimiter=","
-):
-    reader = csv.DictReader(dhs_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    new_dhss: dict[str, CcreSource] = {}
-    dhss = StringIO()
-    region_source_id = region_source.id
-    experiment_accession_id = experiment.accession_id
+def get_features(experiment_metadata: ExperimentMetadata):
+    new_dhss: dict[str, FeatureRow] = {}
 
-    with FeatureIds() as feature_ids:
-        for feature_id, line in zip(feature_ids, reader):
-            chrom_name = line["chrom"]
+    dhs_file = experiment_metadata.tested_elements_file
+    dhs_cell_line = dhs_file.biosample.cell_line
 
-            dhs_start = int(line["chromStart"])
-            dhs_end = int(line["chromEnd"])
-            dhs_location = f"[{dhs_start},{dhs_end})"
+    feature_tsv = open(dhs_file.filename, "r")
+    reader = csv.DictReader(feature_tsv, delimiter=dhs_file.delimiter(), quoting=csv.QUOTE_NONE)
 
-            dhs_name = f"{chrom_name}:{dhs_location}"
+    for line in reader:
+        chrom_name = line["chrom"]
 
-            if dhs_name not in new_dhss:
-                closest_gene, distance, gene_name = get_closest_gene(ref_genome, chrom_name, dhs_start, dhs_end)
-                closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
+        dhs_start = int(line["chromStart"])
+        dhs_end = int(line["chromEnd"])
+        dhs_location = f"[{dhs_start},{dhs_end})"
 
-                dhss.write(
-                    feature_entry(
-                        id_=feature_id,
-                        accession_id=accession_ids.incr(AccessionType.DHS),
-                        cell_line=cell_line,
-                        chrom_name=chrom_name,
-                        location=dhs_location,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        ref_genome=ref_genome,
-                        feature_type=DNAFeatureType.DHS,
-                        source_file_id=region_source_id,
-                        experiment_accession_id=experiment_accession_id,
-                    )
-                )
-                new_dhss[dhs_name] = CcreSource(
-                    _id=feature_id,
-                    chrom_name=chrom_name,
-                    test_location=NumericRange(dhs_start, dhs_end),
-                    cell_line=cell_line,
-                    closest_gene_id=closest_gene["id"],
-                    closest_gene_distance=distance,
-                    closest_gene_name=gene_name,
-                    closest_gene_ensembl_id=closest_gene_ensembl_id,
-                    ref_genome=ref_genome,
-                    source_file_id=region_source_id,
-                    experiment_accession_id=experiment_accession_id,
-                )
-    print(f"DHS Count: {len(new_dhss)}")
-    bulk_feature_save(dhss)
+        dhs_name = f"{chrom_name}:{dhs_location}"
 
-    associate_ccres(closest_ccre_filename, new_dhss.values(), ref_genome, accession_ids)
-
-
-def unload_experiment(experiment_metadata):
-    experiment = Experiment.objects.get(accession_id=experiment_metadata.accession_id)
-    DNAFeature.objects.filter(experiment_accession=experiment).delete()
-    experiment_metadata.db_del()
-
-
-def check_filename(experiment_filename: str):
-    if len(experiment_filename) == 0:
-        raise ValueError(f"wgCERES experiment filename '{experiment_filename}' must not be blank")
-
-
-def run(experiment_filename, closest_ccre_filename):
-    with open(experiment_filename) as experiment_file:
-        experiment_metadata = ExperimentMetadata.json_load(experiment_file)
-    check_filename(experiment_metadata.name)
-
-    # Only run unload_experiment if you want to delete the experiment, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_experiment() uncommented is not, strictly, idempotent.
-    # unload_experiment(experiment_metadata)
-
-    experiment = experiment_metadata.db_save()
-
-    with AccessionIds(message=f"{experiment.accession_id}: {experiment.name}"[:200]) as accession_ids:
-        for dhs_file, file_info, delimiter in experiment_metadata.metadata():
-            load_dhss(
-                dhs_file,
-                closest_ccre_filename,
-                accession_ids,
-                experiment,
-                experiment_metadata.biosamples[0].cell_line,
-                file_info.misc["ref_genome"],
-                experiment.files.all()[0],
-                delimiter,
+        if dhs_name not in new_dhss:
+            new_dhss[dhs_name] = FeatureRow(
+                name=dhs_name,
+                chrom_name=chrom_name,
+                location=(dhs_start, dhs_end, "[)"),
+                genome_assembly=dhs_file.genome_assembly,
+                cell_line=dhs_cell_line,
+                feature_type=FeatureType.DHS,
             )
+
+    return new_dhss.values(), None
+
+
+def run(experiment_filename):
+    metadata = ExperimentMetadata.file_load(experiment_filename)
+    Experiment(metadata).load(get_features).save()

--- a/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000003_load_klann_2021_wgceres_experiment.py
@@ -34,6 +34,7 @@ def get_features(experiment_metadata: ExperimentMetadata):
                 feature_type=FeatureType.DHS,
             )
 
+    feature_tsv.close()
     return new_dhss.values(), None
 
 

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021.sh
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021.sh
@@ -5,18 +5,8 @@ DATA_DIR=$1
 
 EXPERIMENT_FILE=${DATA_DIR}/DCPEXPR0000000004_bounds_scCERES_mhc_ipsc_2021/experiment.json
 ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000004_bounds_scCERES_mhc_ipsc_2021/analysis001.json
-CLOSEST_CCRE_FILE=${DATA_DIR}/DCPEXPR0000000004_bounds_scCERES_mhc_ipsc_2021/closest_ccres.txt
 
 echo "Loading DCPEXPR0000000004"
 
-# generate ccre overlaps
-./scripts/data_generation/ccre_overlaps.sh \
-    ${DATA_DIR}/DCPEXPR0000000004_bounds_scCERES_mhc_ipsc_2021/ipsc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    GRCh38 \
-    grna.chr grna.start grna.end \
-    ${CLOSEST_CCRE_FILE}
-
-python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\")"
+python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.run(\"${ANALYSIS_FILE}\")"
-
-rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.py
@@ -1,185 +1,59 @@
 import csv
-import math
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    Analysis,
-    DNAFeature,
-    DNAFeatureType,
-    Facet,
-    FacetValue,
-    RegulatoryEffectObservation,
-)
-from utils import timer
-from utils.db_ids import ReoIds
 from utils.experiment import AnalysisMetadata
 
-from .db import bulk_reo_save, reo_entry
-
-DIR_FACET = Facet.objects.get(name="Direction")
-DIR_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=DIR_FACET.id).all()}
-
-MIN_SIG = 1e-100
+from .DCPEXPR0000000004_utils import grna_loc
+from .load_analysis import Analysis, ObservationRow, SourceInfo
+from .types import DirectionFacets, FeatureType, NumericFacets
 
 
-# loading does buffered writes to the DB, with a buffer size of 10,000 annotations
-@timer("Load Reg Effects")
-def load_reg_effects(ceres_file, accession_ids, analysis, ref_genome, ref_genome_patch, delimiter=","):
-    experiment = analysis.experiment
-    experiment_id = experiment.id
-    experiment_accession_id = experiment.accession_id
-    analysis_accession_id = analysis.accession_id
-    cell_line = experiment.biosamples.first().cell_line_name
-    reader = csv.DictReader(ceres_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    effects = StringIO()
-    effect_directions = StringIO()
-    sources = StringIO()
-    targets = StringIO()
-    grnas = {}
-    target_genes = {}
-    with ReoIds() as reo_ids:
-        for i, line in enumerate(reader):
-            # every other line in this file is basically a duplicate of the previous line
-            if i % 2 == 0:
-                continue
-
-            grna_label = line["grna"]
-            grna_info = grna_label.split("-")
-
-            # Skip non-targeting guides and guides with no assigned enhancer
-            if not grna_info[0].startswith("chr") or line["dhs.chr"] == "NA":
-                continue
-
-            reo_id = reo_ids.next_id()
-
-            if grna_label not in grnas:
-                grna_type = line["type"]
-
-                if len(grna_info) == 5:
-                    chrom_name, grna_start_str, grna_end_str, strand, _grna_seq = grna_info
-                elif len(grna_info) == 6:
-                    chrom_name, grna_start_str, grna_end_str, _x, _y, _grna_seq = grna_info
-                    strand = "-"
-
-                if strand == "+":
-                    bounds = "[)"
-                elif strand == "-":
-                    bounds = "(]"
-
-                if grna_type == "targeting":
-                    grna_start = int(grna_start_str)
-                    grna_end = int(grna_end_str)
-                else:
-                    if strand == "+":
-                        grna_start = int(grna_start_str)
-                        grna_end = int(grna_start_str) + 20
-                    elif strand == "-":
-                        grna_start = int(grna_end_str) - 20
-                        grna_end = int(grna_end_str)
-
-                grna_location = NumericRange(grna_start, grna_end, bounds)
-
-                try:
-                    grnas[grna_label] = DNAFeature.objects.filter(
-                        experiment_accession=experiment,
-                        chrom_name=chrom_name,
-                        location=grna_location,
-                        strand=strand,
-                        misc__grna=grna_label,
-                        ref_genome=ref_genome,
-                        feature_type=DNAFeatureType.GRNA,
-                    ).values_list("id", flat=True)[0]
-                except IndexError as e:
-                    print(
-                        f"{grna_label} {cell_line} {chrom_name}:{grna_location} {ref_genome} {ref_genome_patch} {DNAFeatureType.GRNA}"
-                    )
-                    raise e
-            sources.write(f"{reo_id}\t{grnas[grna_label]}\n")
-
-            significance = float(line["pval_fdr_corrected"])
-            effect_size = float(line["avg_logFC"])
-            if significance >= 0.01:
-                direction = DIR_FACET_VALUES["Non-significant"]
-            elif effect_size > 0:
-                direction = DIR_FACET_VALUES["Enriched Only"]
-            elif effect_size < 0:
-                direction = DIR_FACET_VALUES["Depleted Only"]
-            else:
-                direction = DIR_FACET_VALUES["Non-significant"]
-
-            # Find targets
-            gene_stable_id = line["gene_stable_id"]
-            if gene_stable_id not in target_genes:
-                target_gene_id = DNAFeature.objects.filter(
-                    ref_genome=ref_genome, ensembl_id=gene_stable_id
-                ).values_list("id", flat=True)
-                target_genes[gene_stable_id] = target_gene_id
-
-            try:
-                targets.write(f"{reo_id}\t{target_genes[gene_stable_id][0]}\n")
-            except IndexError as ie:
-                print(f'"{ref_genome}", "{gene_stable_id}"')
-                raise ie
-
-            facet_num_values = {
-                RegulatoryEffectObservation.Facet.EFFECT_SIZE.value: effect_size,
-                RegulatoryEffectObservation.Facet.RAW_P_VALUE.value: float(line["p_val"]),
-                RegulatoryEffectObservation.Facet.SIGNIFICANCE.value: significance,
-                RegulatoryEffectObservation.Facet.LOG_SIGNIFICANCE.value: -math.log10(max(significance, MIN_SIG)),
-            }
-
-            effects.write(
-                reo_entry(
-                    id_=reo_id,
-                    accession_id=accession_ids.incr(AccessionType.REGULATORY_EFFECT_OBS),
-                    experiment_id=experiment_id,
-                    experiment_accession_id=experiment_accession_id,
-                    analysis_accession_id=analysis_accession_id,
-                    facet_num_values=facet_num_values,
-                )
-            )
-            effect_directions.write(f"{reo_id}\t{direction.id}\n")
-
-    bulk_reo_save(effects, effect_directions, sources, targets)
-
-
-def unload_analysis(analysis_metadata):
-    analysis = Analysis.objects.get(
-        experiment_id=analysis_metadata.experiment_accession_id, name=analysis_metadata.name
+def get_observations(analysis_metadata: AnalysisMetadata):
+    results_file = open(analysis_metadata.results.file_metadata.filename)
+    reader = csv.DictReader(
+        results_file, delimiter=analysis_metadata.results.file_metadata.delimiter(), quoting=csv.QUOTE_NONE
     )
-    RegulatoryEffectObservation.objects.filter(analysis=analysis).delete()
-    analysis_metadata.db_del(analysis)
+    observations: list[ObservationRow] = []
+    for i, line in enumerate(reader):
+        # every other line in this file is basically a duplicate of the previous line
+        if i % 2 == 0:
+            continue
 
+        grna_label = line["grna"]
+        grna_info = grna_label.split("-")
 
-def check_filename(analysis_filename: str):
-    if len(analysis_filename) == 0:
-        raise ValueError(f"scCERES analysis filename '{analysis_filename}' must not be blank")
+        # Skip non-targeting guides and guides with no assigned enhancer
+        if not grna_info[0].startswith("chr") or line["dhs.chr"] == "NA":
+            continue
+
+        chrom_name, grna_start, grna_end, grna_bounds, grna_strand = grna_loc(line)
+
+        sources = [SourceInfo(chrom_name, grna_start, grna_end, grna_bounds, grna_strand, FeatureType.GRNA)]
+
+        targets = [line["gene_stable_id"]]
+
+        significance = float(line["pval_fdr_corrected"])
+        effect_size = float(line["avg_logFC"])
+        if significance >= 0.01:
+            direction = DirectionFacets.NON_SIGNIFICANT
+        elif effect_size > 0:
+            direction = DirectionFacets.ENRICHED
+        elif effect_size < 0:
+            direction = DirectionFacets.DEPLETED
+        else:
+            direction = DirectionFacets.NON_SIGNIFICANT
+
+        num_facets = {
+            NumericFacets.EFFECT_SIZE: effect_size,
+            NumericFacets.SIGNIFICANCE: significance,
+            NumericFacets.RAW_P_VALUE: float(line["p_val"]),
+        }
+
+        observations.append(ObservationRow(sources, targets, [direction], num_facets))
+
+    results_file.close()
+    return observations
 
 
 def run(analysis_filename):
-    with open(analysis_filename) as analysis_file:
-        analysis_metadata = AnalysisMetadata.json_load(analysis_file)
-    check_filename(analysis_metadata.name)
-
-    # Only run unload_analysis if you want to delete the analysis, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_analysis() uncommented is not, strictly, idempotent.
-    # unload_analysis(analysis_metadata)
-
-    analysis = analysis_metadata.db_save()
-
-    with AccessionIds(message=f"{analysis.accession_id}: {analysis.name}"[:200]) as accession_ids:
-        for ceres_file, file_info, delimiter in analysis_metadata.metadata():
-            load_reg_effects(
-                ceres_file,
-                accession_ids,
-                analysis,
-                file_info.ref_genome,
-                file_info.ref_genome_patch,
-                delimiter,
-            )
+    metadata = AnalysisMetadata.file_load(analysis_filename)
+    Analysis(metadata).load(get_observations).save()

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
@@ -26,9 +26,6 @@ def get_features(experiment_metadata: ExperimentMetadata):
             continue
 
         grna_id = line["grna"]
-        grna_type = line["type"]
-        grna_promoter_class = line["annotation_manual"]
-
         grna_info = grna_id.split("-")
 
         # Skip non-targeting guides and guides with no assigned enhancer
@@ -56,6 +53,9 @@ def get_features(experiment_metadata: ExperimentMetadata):
         dhs_row = new_dhss[dhs_name]
 
         if grna_id not in new_grnas:
+            grna_type = line["type"]
+            grna_promoter_class = line["annotation_manual"]
+
             chrom_name, grna_start, grna_end, grna_bounds, grna_strand = grna_loc(line)
 
             categorical_facets = []
@@ -72,7 +72,7 @@ def get_features(experiment_metadata: ExperimentMetadata):
             new_grnas[grna_id] = FeatureRow(
                 name=grna_id,
                 chrom_name=chrom_name,
-                location=(int(grna_start), int(grna_end), grna_bounds),
+                location=(grna_start, grna_end, grna_bounds),
                 strand=grna_strand,
                 genome_assembly=grna_file.genome_assembly,
                 cell_line=grna_cell_line,

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
@@ -1,234 +1,91 @@
 import csv
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    DNAFeature,
-    DNAFeatureType,
-    Experiment,
-    Facet,
-    FacetValue,
-)
-from utils import timer
-from utils.ccres import CcreSource, associate_ccres
-from utils.db_ids import FeatureIds
 from utils.experiment import ExperimentMetadata
 
-from . import get_closest_gene
-from .db import bulk_feature_facet_save, bulk_feature_save, feature_entry
-
-GRNA_TYPE_FACET = Facet.objects.get(name="gRNA Type")
-GRNA_TYPE_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=GRNA_TYPE_FACET.id).all()}
-GRNA_TYPE_POS_CTRL = GRNA_TYPE_FACET_VALUES["Positive Control"]
-GRNA_TYPE_TARGETING = GRNA_TYPE_FACET_VALUES["Targeting"]
-
-PROMOTER_FACET = Facet.objects.get(name="Promoter Classification")
-PROMOTER_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=PROMOTER_FACET.id).all()}
-PROMOTER_PROMOTER = PROMOTER_FACET_VALUES["Promoter"]
-PROMOTER_NON_PROMOTER = PROMOTER_FACET_VALUES["Non-promoter"]
+from .DCPEXPR0000000004_utils import grna_loc
+from .load_experiment import Experiment, FeatureRow
+from .types import FeatureType, GrnaFacet, PromoterFacet
 
 
-@timer("Load gRNAs")
-def load_grnas(
-    grna_file,
-    closest_ccre_filename,
-    accession_ids,
-    experiment,
-    region_source,
-    cell_line,
-    ref_genome,
-    delimiter=",",
-):
-    reader = csv.DictReader(grna_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    new_grnas = {}
-    grnas = StringIO()
-    grna_type_facets = StringIO()
-    grna_promoter_facets = StringIO()
-    new_dhss: dict[str, int] = {}
-    new_ccre_sources: list[CcreSource] = []
-    dhss = StringIO()
-    region_source_id = region_source.id
-    experiment_accession_id = experiment.accession_id
+def get_features(experiment_metadata: ExperimentMetadata):
+    new_grnas: dict[str, FeatureRow] = {}
+    new_dhss: dict[str, FeatureRow] = {}
 
-    with FeatureIds() as feature_ids:
-        for i, line in enumerate(reader):
-            # every other line in this file is basically a duplicate of the previous line
-            if i % 2 == 0:
-                continue
+    dhs_file = experiment_metadata.tested_elements_parent_file
+    dhs_cell_line = dhs_file.biosample.cell_line
 
-            grna_id = line["grna"]
-            grna_type = line["type"]
-            grna_promoter_class = line["annotation_manual"]
+    grna_file = experiment_metadata.tested_elements_file
+    grna_cell_line = grna_file.biosample.cell_line
 
-            grna_info = grna_id.split("-")
+    feature_tsv = open(grna_file.filename, "r")
+    reader = csv.DictReader(feature_tsv, delimiter=grna_file.delimiter(), quoting=csv.QUOTE_NONE)
 
-            # Skip non-targeting guides and guides with no assigned enhancer
-            if not grna_info[0].startswith("chr") or line["dhs.chr"] == "NA":
-                continue
+    for i, line in enumerate(reader):
+        # every other line in this file is basically a duplicate of the previous line
+        if i % 2 == 0:
+            continue
 
-            dhs_chrom_name = line["dhs.chr"]
+        grna_id = line["grna"]
+        grna_type = line["type"]
+        grna_promoter_class = line["annotation_manual"]
 
-            dhs_start = int(line["dhs.start"])
-            dhs_end = int(line["dhs.end"])
-            dhs_location = f"[{dhs_start},{dhs_end})"
+        grna_info = grna_id.split("-")
 
-            dhs_name = f"{dhs_chrom_name}:{dhs_location}"
+        # Skip non-targeting guides and guides with no assigned enhancer
+        if not grna_info[0].startswith("chr") or line["dhs.chr"] == "NA":
+            continue
 
-            if dhs_name not in new_dhss:
-                closest_gene, distance, gene_name = get_closest_gene(ref_genome, dhs_chrom_name, dhs_start, dhs_end)
-                closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
-                dhs_feature_id = feature_ids.next_id()
-                dhs_accession_id = accession_ids.incr(AccessionType.DHS)
-                dhss.write(
-                    feature_entry(
-                        id_=dhs_feature_id,
-                        accession_id=dhs_accession_id,
-                        cell_line=cell_line,
-                        chrom_name=dhs_chrom_name,
-                        location=dhs_location,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        ref_genome=ref_genome,
-                        feature_type=DNAFeatureType.DHS,
-                        source_file_id=region_source_id,
-                        experiment_accession_id=experiment_accession_id,
-                    )
-                )
-                new_dhss[dhs_name] = (dhs_feature_id, dhs_accession_id, NumericRange(dhs_start, dhs_end, "[)"))
+        dhs_chrom_name = line["dhs.chr"]
 
-            dhs_feature_id, dhs_accession_id, dhs_location = new_dhss[dhs_name]
+        dhs_start = int(line["dhs.start"])
+        dhs_end = int(line["dhs.end"])
+        dhs_location = f"[{dhs_start},{dhs_end})"
 
-            if grna_id not in new_grnas:
-                feature_id = feature_ids.next_id()
+        dhs_name = f"{dhs_chrom_name}:{dhs_location}"
 
-                if len(grna_info) == 5:
-                    chrom_name, grna_start_str, grna_end_str, strand, _grna_seq = grna_info
-                elif len(grna_info) == 6:
-                    chrom_name, grna_start_str, grna_end_str, _x, _y, _grna_seq = grna_info
-                    strand = "-"
-
-                if grna_type == "targeting":
-                    grna_type_facets.write(f"{feature_id}\t{GRNA_TYPE_TARGETING.id}\n")
-                elif grna_type.startswith("positive_control") == "":
-                    grna_type_facets.write(f"{feature_id}\t{GRNA_TYPE_POS_CTRL.id}\n")
-
-                if grna_promoter_class == "promoter":
-                    grna_promoter_facets.write(f"{feature_id}\t{PROMOTER_PROMOTER.id}\n")
-                else:
-                    grna_promoter_facets.write(f"{feature_id}\t{PROMOTER_NON_PROMOTER.id}\n")
-
-                if grna_type == "targeting":
-                    grna_start = int(grna_start_str)
-                    grna_end = int(grna_end_str)
-                else:
-                    if strand == "+":
-                        grna_start = int(grna_start_str)
-                        grna_end = int(grna_start_str) + 20
-                    elif strand == "-":
-                        grna_start = int(grna_end_str) - 20
-                        grna_end = int(grna_end_str)
-
-                if strand == "+":
-                    grna_location = f"[{grna_start},{grna_end})"
-                elif strand == "-":
-                    grna_location = f"({grna_start},{grna_end}]"
-
-                closest_gene, distance, gene_name = get_closest_gene(ref_genome, chrom_name, grna_start, grna_end)
-                closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
-
-                grnas.write(
-                    feature_entry(
-                        id_=feature_id,
-                        accession_id=accession_ids.incr(AccessionType.GRNA),
-                        cell_line=cell_line,
-                        chrom_name=chrom_name,
-                        location=grna_location,
-                        strand=strand,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        ref_genome=ref_genome,
-                        feature_type=DNAFeatureType.GRNA,
-                        parent_id=dhs_feature_id,
-                        parent_accession_id=dhs_accession_id,
-                        source_file_id=region_source_id,
-                        experiment_accession_id=experiment_accession_id,
-                        misc={"grna": grna_id},
-                    )
-                )
-                new_ccre_sources.append(
-                    CcreSource(
-                        _id=feature_id,
-                        _new_id=dhs_feature_id,
-                        chrom_name=chrom_name,
-                        test_location=NumericRange(grna_start, grna_end, "[)"),
-                        new_location=dhs_location,
-                        cell_line=cell_line,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        source_file_id=region_source_id,
-                        ref_genome=ref_genome,
-                        experiment_accession_id=experiment_accession_id,
-                    )
-                )
-                new_grnas[grna_id] = feature_id
-
-    bulk_feature_save(dhss)
-    bulk_feature_save(grnas)
-    bulk_feature_facet_save(grna_type_facets)
-    bulk_feature_facet_save(grna_promoter_facets)
-
-    associate_ccres(closest_ccre_filename, new_ccre_sources, ref_genome, accession_ids)
-
-
-def unload_experiment(experiment_metadata):
-    try:
-        print(experiment_metadata.accession_id)
-        experiment = Experiment.objects.get(accession_id=experiment_metadata.accession_id)
-    except Experiment.DoesNotExist:
-        return
-    except Exception as e:
-        raise e
-
-    DNAFeature.objects.filter(experiment_accession=experiment).delete()
-    experiment_metadata.db_del()
-
-
-def check_filename(experiment_filename: str):
-    if len(experiment_filename) == 0:
-        raise ValueError(f"scCERES experiment filename '{experiment_filename}' must not be blank")
-
-
-def run(experiment_filename, closest_ccre_filename):
-    with open(experiment_filename) as experiment_file:
-        experiment_metadata = ExperimentMetadata.json_load(experiment_file)
-    check_filename(experiment_metadata.name)
-
-    # Only run unload_experiment if you want to delete the experiment, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_experiment() uncommented is not, strictly, idempotent.
-    # unload_experiment(experiment_metadata)
-
-    experiment = experiment_metadata.db_save()
-
-    with AccessionIds(message=f"{experiment.accession_id}: {experiment.name}"[:200]) as accession_ids:
-        for grna_file, file_info, delimiter in experiment_metadata.metadata():
-            load_grnas(
-                grna_file,
-                closest_ccre_filename,
-                accession_ids,
-                experiment,
-                experiment.files.all()[0],
-                experiment_metadata.biosamples[0].cell_line,
-                file_info.misc["ref_genome"],
-                delimiter,
+        if dhs_name not in new_dhss:
+            new_dhss[dhs_name] = FeatureRow(
+                name=dhs_name,
+                chrom_name=dhs_chrom_name,
+                location=(int(dhs_start), int(dhs_end), "[)"),
+                genome_assembly=dhs_file.genome_assembly,
+                cell_line=dhs_cell_line,
+                feature_type=FeatureType.DHS,
             )
+
+        dhs_row = new_dhss[dhs_name]
+
+        if grna_id not in new_grnas:
+            chrom_name, grna_start, grna_end, grna_bounds, grna_strand = grna_loc(line)
+
+            categorical_facets = []
+            if grna_type == "targeting":
+                categorical_facets.append(GrnaFacet.TARGETING)
+            elif grna_type.startswith("positive_control") == "":
+                categorical_facets.append(GrnaFacet.POSITIVE_CONTROL)
+
+            if grna_promoter_class == "promoter":
+                categorical_facets.append(PromoterFacet.PROMOTER)
+            else:
+                categorical_facets.append(PromoterFacet.NON_PROMOTER)
+
+            new_grnas[grna_id] = FeatureRow(
+                name=grna_id,
+                chrom_name=chrom_name,
+                location=(int(grna_start), int(grna_end), grna_bounds),
+                strand=grna_strand,
+                genome_assembly=grna_file.genome_assembly,
+                cell_line=grna_cell_line,
+                feature_type=FeatureType.GRNA,
+                facets=categorical_facets,
+                parent_name=dhs_row.name,
+                misc={"grna": grna_id},
+            )
+
+    feature_tsv.close()
+    return new_grnas.values(), new_dhss.values()
+
+
+def run(experiment_filename):
+    metadata = ExperimentMetadata.file_load(experiment_filename)
+    Experiment(metadata).load(get_features).save()

--- a/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.py
@@ -44,7 +44,7 @@ def get_features(experiment_metadata: ExperimentMetadata):
             new_dhss[dhs_name] = FeatureRow(
                 name=dhs_name,
                 chrom_name=dhs_chrom_name,
-                location=(int(dhs_start), int(dhs_end), "[)"),
+                location=(dhs_start, dhs_end, "[)"),
                 genome_assembly=dhs_file.genome_assembly,
                 cell_line=dhs_cell_line,
                 feature_type=FeatureType.DHS,

--- a/scripts/data_loading/DCPEXPR0000000004_utils.py
+++ b/scripts/data_loading/DCPEXPR0000000004_utils.py
@@ -1,0 +1,27 @@
+def grna_loc(line):
+    grna_id = line["grna"]
+    grna_type = line["type"]
+    grna_info = grna_id.split("-")
+    if len(grna_info) == 5:
+        chrom_name, grna_start_str, grna_end_str, grna_strand, _grna_seq = grna_info
+    elif len(grna_info) == 6:
+        chrom_name, grna_start_str, grna_end_str, _x, _y, _grna_seq = grna_info
+        grna_strand = "-"
+
+    if grna_type == "targeting":
+        grna_start = int(grna_start_str)
+        grna_end = int(grna_end_str)
+    else:
+        if grna_strand == "+":
+            grna_start = int(grna_start_str)
+            grna_end = int(grna_start_str) + 20
+        elif grna_strand == "-":
+            grna_start = int(grna_end_str) - 20
+            grna_end = int(grna_end_str)
+
+    if grna_strand == "+":
+        grna_bounds = "[)"
+    elif grna_strand == "-":
+        grna_bounds = "(]"
+
+    return chrom_name, grna_start, grna_end, grna_bounds, grna_strand

--- a/scripts/data_loading/DCPEXPR0000000005_load_bounds_scCERES_mhc_2021.sh
+++ b/scripts/data_loading/DCPEXPR0000000005_load_bounds_scCERES_mhc_2021.sh
@@ -5,18 +5,8 @@ DATA_DIR=$1
 
 EXPERIMENT_FILE=${DATA_DIR}/DCPEXPR0000000005_bounds_scCERES_mhc_k562_2021/experiment.json
 ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000005_bounds_scCERES_mhc_k562_2021/analysis001.json
-CLOSEST_CCRE_FILE=${DATA_DIR}/DCPEXPR0000000005_bounds_scCERES_mhc_k562_2021/closest_ccres.txt
 
 echo "Loading DCPEXPR0000000005"
 
-# generate ccre overlaps
-./scripts/data_generation/ccre_overlaps.sh \
-    ${DATA_DIR}/DCPEXPR0000000005_bounds_scCERES_mhc_k562_2021/k562.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    GRCh38 \
-    grna.chr grna.start grna.end \
-    ${CLOSEST_CCRE_FILE}
-
-python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\")"
+python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.run(\"${ANALYSIS_FILE}\")"
-
-rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000006_load_bounds_scCERES_mhc_2021.sh
+++ b/scripts/data_loading/DCPEXPR0000000006_load_bounds_scCERES_mhc_2021.sh
@@ -5,18 +5,8 @@ DATA_DIR=$1
 
 EXPERIMENT_FILE=${DATA_DIR}/DCPEXPR0000000006_bounds_scCERES_mhc_npc_2021/experiment.json
 ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000006_bounds_scCERES_mhc_npc_2021/analysis001.json
-CLOSEST_CCRE_FILE=${DATA_DIR}/DCPEXPR0000000006_bounds_scCERES_mhc_npc_2021/closest_ccres.txt
 
 echo "Loading DCPEXPR0000000006"
 
-# generate ccre overlaps
-./scripts/data_generation/ccre_overlaps.sh \
-    ${DATA_DIR}/DCPEXPR0000000006_bounds_scCERES_mhc_npc_2021/npc.expect_cells.grna.de.markers.MAST.annotatedfull.final.update20220117.LRB.tsv \
-    GRCh38 \
-    grna.chr grna.start grna.end \
-    ${CLOSEST_CCRE_FILE}
-
-python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\")"
+python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis; DCPEXPR0000000004_load_bounds_scCERES_mhc_2021_analysis.run(\"${ANALYSIS_FILE}\")"
-
-rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022.sh
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022.sh
@@ -4,18 +4,8 @@ set -euo pipefail
 DATA_DIR=$1
 EXPERIMENT_FILE=${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/experiment.json
 ANALYSIS_FILE=${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/analysis001.json
-CLOSEST_CCRE_FILE=${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/closest_ccres.txt
 
 echo "Loading DCPEXPR0000000007"
 
-# generate ccre overlaps
-./scripts/data_generation/ccre_overlaps.sh \
-    ${DATA_DIR}/DCPEXPR0000000007_siklenka_atac-starr-seq_K562_2022/atacSTARR.ultra_deep.csaw.hg38.v10.common_file_formatted.tsv \
-    GRCh38 \
-    seqnames start end \
-    ${CLOSEST_CCRE_FILE}
-
-python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment; DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment.run(\"${EXPERIMENT_FILE}\", \"${CLOSEST_CCRE_FILE}\")"
+python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment; DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment.run(\"${EXPERIMENT_FILE}\")"
 python manage.py shell -c "from scripts.data_loading import DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis; DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.run(\"${ANALYSIS_FILE}\")"
-
-rm ${CLOSEST_CCRE_FILE}

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.py
@@ -1,134 +1,61 @@
 import csv
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    Analysis,
-    DNAFeature,
-    DNAFeatureType,
-    Facet,
-    FacetValue,
-    RegulatoryEffectObservation,
-)
-from utils import timer
-from utils.db_ids import ReoIds
 from utils.experiment import AnalysisMetadata
 
-from .db import bulk_reo_save, reo_entry
-
-DIR_FACET = Facet.objects.get(name="Direction")
-DIR_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=DIR_FACET.id).all()}
+from .load_analysis import Analysis, ObservationRow, SourceInfo
+from .types import DirectionFacets, FeatureType, NumericFacets
 
 
-# loading does buffered writes to the DB, with a buffer size of 10,000 annotations
-@timer("Load Reg Effects")
-def load_reg_effects(reo_file, accession_ids, analysis, ref_genome, delimiter=","):
-    experiment = analysis.experiment
-    experiment_id = experiment.id
-    experiment_accession_id = experiment.accession_id
-    analysis_accession_id = analysis.accession_id
-    reader = csv.DictReader(reo_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    sources = StringIO()
-    effects = StringIO()
-    effect_directions = StringIO()
-    cars = {}
-
-    with ReoIds() as reo_ids:
-        for reo_id, line in zip(reo_ids, reader):
-            chrom_name = line["seqnames"]
-
-            car_start = int(line["start"])
-            car_end = int(line["end"])
-
-            car_string = f"{chrom_name}:{car_start}-{car_end}:{ref_genome}"
-
-            if car_string not in cars:
-                cars[car_string] = DNAFeature.objects.filter(
-                    experiment_accession=experiment,
-                    chrom_name=chrom_name,
-                    location=NumericRange(car_start, car_end, "[)"),
-                    ref_genome=ref_genome,
-                    feature_type=DNAFeatureType.CAR,
-                ).values_list("id", flat=True)[0]
-
-            sources.write(f"{reo_id}\t{cars[car_string]}\n")
-
-            effect_size_field = line["logFC"].strip()
-            if effect_size_field == "":
-                effect_size = None
-            else:
-                effect_size = float(effect_size_field)
-
-            significance = float(line["minusLog10PValue"])
-            if significance < 2:  # p-value < 0.01, we're being stricter about significance with this data set
-                direction = DIR_FACET_VALUES["Non-significant"]
-            elif effect_size > 0:
-                direction = DIR_FACET_VALUES["Enriched Only"]
-            elif effect_size < 0:
-                direction = DIR_FACET_VALUES["Depleted Only"]
-            else:
-                direction = None
-
-            facet_num_values = {
-                RegulatoryEffectObservation.Facet.EFFECT_SIZE.value: effect_size,
-                # significance is -log10(actual significance), but we want significance between 0 and 1
-                # we perform the inverse operation.
-                RegulatoryEffectObservation.Facet.SIGNIFICANCE.value: pow(10, -float(significance)),
-                RegulatoryEffectObservation.Facet.LOG_SIGNIFICANCE.value: significance,
-                # significance is -log10(actual p-value), so raw_p_value uses the inverse operation
-                RegulatoryEffectObservation.Facet.RAW_P_VALUE.value: pow(10, -float(significance)),
-                RegulatoryEffectObservation.Facet.AVG_COUNTS_PER_MILLION.value: float(line["input_avg_counts.cpm"]),
-            }
-
-            effects.write(
-                reo_entry(
-                    id_=reo_id,
-                    accession_id=accession_ids.incr(AccessionType.REGULATORY_EFFECT_OBS),
-                    experiment_id=experiment_id,
-                    experiment_accession_id=experiment_accession_id,
-                    analysis_accession_id=analysis_accession_id,
-                    facet_num_values=facet_num_values,
-                )
-            )
-            effect_directions.write(f"{reo_id}\t{direction.id}\n")
-    bulk_reo_save(effects, effect_directions, sources)
-
-
-def unload_analysis(analysis_metadata):
-    analysis = Analysis.objects.get(
-        experiment_id=analysis_metadata.experiment_accession_id, name=analysis_metadata.name
+def get_observations(analysis_metadata: AnalysisMetadata):
+    results_file = open(analysis_metadata.results.file_metadata.filename)
+    reader = csv.DictReader(
+        results_file, delimiter=analysis_metadata.results.file_metadata.delimiter(), quoting=csv.QUOTE_NONE
     )
-    RegulatoryEffectObservation.objects.filter(analysis=analysis).delete()
-    analysis_metadata.db_del(analysis)
+    observations: list[ObservationRow] = []
 
+    for line in reader:
+        chrom_name = line["seqnames"]
 
-def check_filename(analysis_filename: str):
-    if len(analysis_filename) == 0:
-        raise ValueError(f"wgCERES analysis filename '{analysis_filename}' must not be blank")
+        car_start = int(line["start"])
+        car_end = int(line["end"])
+
+        sources = [SourceInfo(chrom_name, car_start, car_end, "[)", FeatureType.CAR)]
+
+        effect_size_field = line["logFC"].strip()
+        if effect_size_field == "":
+            effect_size = None
+        else:
+            effect_size = float(effect_size_field)
+
+        log_significance = float(line["minusLog10PValue"])
+        if log_significance < 2:  # p-value < 0.01, we're being stricter about significance with this data set
+            direction = DirectionFacets.NON_SIGNIFICANT
+        elif effect_size > 0:
+            direction = DirectionFacets.ENRICHED
+        elif effect_size < 0:
+            direction = DirectionFacets.DEPLETED
+        else:
+            direction = None
+
+        significance = pow(10, -float(log_significance))
+        p_val = significance
+
+        facet_num_values = {
+            NumericFacets.EFFECT_SIZE: effect_size,
+            # significance is -log10(actual significance), but we want significance between 0 and 1
+            # we perform the inverse operation.
+            NumericFacets.SIGNIFICANCE: significance,
+            NumericFacets.LOG_SIGNIFICANCE: log_significance,
+            # significance is -log10(actual p-value), so raw_p_value uses the inverse operation
+            NumericFacets.RAW_P_VALUE: p_val,
+            NumericFacets.AVG_COUNTS_PER_MILLION: float(line["input_avg_counts.cpm"]),
+        }
+
+        observations.append(ObservationRow(sources, [], [direction], facet_num_values))
+
+    return observations
 
 
 def run(analysis_filename):
-    with open(analysis_filename) as analysis_file:
-        analysis_metadata = AnalysisMetadata.json_load(analysis_file)
-    check_filename(analysis_metadata.name)
-
-    # Only run unload_analysis if you want to delete the analysis, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_analysis() uncommented is not, strictly, idempotent.
-    # unload_analysis(analysis_metadata)
-
-    analysis = analysis_metadata.db_save()
-
-    with AccessionIds(message=f"{analysis.accession_id}: {analysis.name}"[:200]) as accession_ids:
-        for ceres_file, file_info, _delimiter in analysis_metadata.metadata():
-            load_reg_effects(
-                ceres_file,
-                accession_ids,
-                analysis,
-                file_info.ref_genome,
-                "\t",
-            )
+    metadata = AnalysisMetadata.file_load(analysis_filename)
+    Analysis(metadata).load(get_observations).save()

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.py
@@ -53,6 +53,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
 
         observations.append(ObservationRow(sources, [], [direction], facet_num_values))
 
+    results_file.close()
     return observations
 
 

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_analysis.py
@@ -19,7 +19,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
         car_start = int(line["start"])
         car_end = int(line["end"])
 
-        sources = [SourceInfo(chrom_name, car_start, car_end, "[)", FeatureType.CAR)]
+        sources = [SourceInfo(chrom_name, car_start, car_end, "[)", None, FeatureType.CAR)]
 
         effect_size_field = line["logFC"].strip()
         if effect_size_field == "":

--- a/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000007_load_siklenka_atacstarrseq_K562_2022_experiment.py
@@ -1,116 +1,40 @@
 import csv
-from io import StringIO
 
-from psycopg2.extras import NumericRange
-
-from cegs_portal.search.models import (
-    AccessionIds,
-    AccessionType,
-    DNAFeature,
-    DNAFeatureType,
-    Experiment,
-)
-from utils import timer
-from utils.ccres import CcreSource, associate_ccres
-from utils.db_ids import FeatureIds
 from utils.experiment import ExperimentMetadata
 
-from . import get_closest_gene
-from .db import bulk_feature_save, feature_entry
+from .load_experiment import Experiment, FeatureRow
+from .types import FeatureType
 
 
-# loading does buffered writes to the DB, with a buffer size of 10,000 annotations
-@timer("Load CARs")
-def load_cars(
-    ceres_file, closest_ccre_filename, accession_ids, experiment, cell_line, ref_genome, region_source, delimiter=","
-):
-    reader = csv.DictReader(ceres_file, delimiter=delimiter, quoting=csv.QUOTE_NONE)
-    new_cars: dict[str, CcreSource] = {}
-    cars = StringIO()
-    region_source_id = region_source.id
-    experiment_accession_id = experiment.accession_id
-    with FeatureIds() as feature_ids:
-        for feature_id, line in zip(feature_ids, reader):
-            chrom_name = line["seqnames"]
+def get_features(experiment_metadata: ExperimentMetadata):
+    feature_file = experiment_metadata.tested_elements_file
+    feature_tsv = open(feature_file.filename, "r")
+    reader = csv.DictReader(feature_tsv, delimiter=feature_file.delimiter(), quoting=csv.QUOTE_NONE)
+    new_cars: dict[str, FeatureRow] = {}
 
-            car_start = int(line["start"])
-            car_end = int(line["end"])
-            car_location = f"[{car_start},{car_end})"
+    for line in reader:
+        chrom_name = line["seqnames"]
 
-            car_name = f"{chrom_name}:{car_location}"
+        car_start = int(line["start"])
+        car_end = int(line["end"])
+        car_location = f"[{car_start},{car_end})"
 
-            if car_name not in new_cars:
-                closest_gene, distance, gene_name = get_closest_gene(ref_genome, chrom_name, car_start, car_end)
-                closest_gene_ensembl_id = closest_gene["ensembl_id"] if closest_gene is not None else None
+        car_name = f"{chrom_name}:{car_location}"
 
-                cars.write(
-                    feature_entry(
-                        id_=feature_id,
-                        accession_id=accession_ids.incr(AccessionType.CAR),
-                        cell_line=cell_line,
-                        chrom_name=chrom_name,
-                        location=car_location,
-                        closest_gene_id=closest_gene["id"],
-                        closest_gene_distance=distance,
-                        closest_gene_name=gene_name,
-                        closest_gene_ensembl_id=closest_gene_ensembl_id,
-                        ref_genome=ref_genome,
-                        feature_type=DNAFeatureType.CAR,
-                        source_file_id=region_source_id,
-                        experiment_accession_id=experiment_accession_id,
-                    )
-                )
-                new_cars[car_name] = CcreSource(
-                    _id=feature_id,
-                    chrom_name=chrom_name,
-                    test_location=NumericRange(car_start, car_end),
-                    cell_line=cell_line,
-                    closest_gene_id=closest_gene["id"],
-                    closest_gene_distance=distance,
-                    closest_gene_name=gene_name,
-                    closest_gene_ensembl_id=closest_gene_ensembl_id,
-                    ref_genome=ref_genome,
-                    source_file_id=region_source_id,
-                    experiment_accession_id=experiment_accession_id,
-                )
-    bulk_feature_save(cars)
-
-    associate_ccres(closest_ccre_filename, new_cars.values(), ref_genome, accession_ids)
-
-
-def unload_experiment(experiment_metadata):
-    experiment = Experiment.objects.get(accession_id=experiment_metadata.accession_id)
-    DNAFeature.objects.filter(experiment_accession=experiment).delete()
-    experiment_metadata.db_del()
-
-
-def check_filename(experiment_filename: str):
-    if len(experiment_filename) == 0:
-        raise ValueError(f"wgCERES experiment filename '{experiment_filename}' must not be blank")
-
-
-def run(experiment_filename, closest_ccre_filename):
-    with open(experiment_filename) as experiment_file:
-        experiment_metadata = ExperimentMetadata.json_load(experiment_file)
-    check_filename(experiment_metadata.name)
-
-    # Only run unload_experiment if you want to delete the experiment, all
-    # associated reg effects, and any DNAFeatures created from the DB.
-    # Please note that it won't reset DB id numbers, so running this script with
-    # unload_experiment() uncommented is not, strictly, idempotent.
-    # unload_experiment(experiment_metadata)
-
-    experiment = experiment_metadata.db_save()
-
-    with AccessionIds(message=f"{experiment.accession_id}: {experiment.name}"[:200]) as accession_ids:
-        for ceres_file, file_info, _delimiter in experiment_metadata.metadata():
-            load_cars(
-                ceres_file,
-                closest_ccre_filename,
-                accession_ids,
-                experiment,
-                experiment_metadata.biosamples[0].cell_line,
-                file_info.misc["ref_genome"],
-                experiment.files.all()[0],
-                "\t",
+        if car_name not in new_cars:
+            new_cars[car_name] = FeatureRow(
+                name=car_name,
+                chrom_name=chrom_name,
+                location=(car_start, car_end, "[)"),
+                genome_assembly=feature_file.genome_assembly,
+                cell_line=feature_file.biosample.cell_line,
+                feature_type=FeatureType.CAR,
             )
+
+    feature_tsv.close()
+    return new_cars.values(), None
+
+
+def run(experiment_filename):
+    metadata = ExperimentMetadata.file_load(experiment_filename)
+    Experiment(metadata).load(get_features).save()

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
@@ -45,7 +45,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
         elif strand == "-":
             bounds = "(]"
 
-        sources = [SourceInfo(chrom_name, grna_start, grna_end, bounds, FeatureType.GRNA)]
+        sources = [SourceInfo(chrom_name, grna_start, grna_end, bounds, strand, FeatureType.GRNA)]
 
         targets = [gene_name_map[target_gene]]
 

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
@@ -7,10 +7,10 @@ from .load_analysis import Analysis, ObservationRow, SourceInfo
 from .types import DirectionFacets, FeatureType, NumericFacets
 
 
-def gene_ensembl_mapping(features_file):
+def gene_ensembl_mapping(genes_filename):
     gene_name_map = {}
-    with open(features_file, newline="") as facet_file:
-        reader = csv.reader(facet_file, delimiter="\t")
+    with open(genes_filename, newline="") as genes_file:
+        reader = csv.reader(genes_file, delimiter="\t")
         for row in reader:
             if row[2] != "Gene Expression":
                 continue

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
@@ -67,6 +67,7 @@ def get_observations(analysis_metadata: AnalysisMetadata):
         }
 
         observations.append(ObservationRow(sources, targets, [direction], num_facets))
+
     results_file.close()
     return observations
 

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_analysis.py
@@ -4,6 +4,7 @@ from utils.experiment import AnalysisMetadata
 
 from .DCPEXPR0000000008_consts import DROP_GENE_NAMES, TRIM_GENE_NAMES
 from .load_analysis import Analysis, ObservationRow, SourceInfo
+from .types import DirectionFacets, FeatureType, NumericFacets
 
 
 def gene_ensembl_mapping(features_file):
@@ -44,24 +45,28 @@ def get_observations(analysis_metadata: AnalysisMetadata):
         elif strand == "-":
             bounds = "(]"
 
-        sources = [SourceInfo(chrom_name, grna_start, grna_end, bounds, "gRNA")]
+        sources = [SourceInfo(chrom_name, grna_start, grna_end, bounds, FeatureType.GRNA)]
 
         targets = [gene_name_map[target_gene]]
 
         significance = float(line["p_val_adj"])
         effect_size = float(line["avg_log2FC"])
         if significance >= 0.01:
-            direction = "Non-significant"
+            direction = DirectionFacets.NON_SIGNIFICANT
         elif effect_size > 0:
-            direction = "Enriched Only"
+            direction = DirectionFacets.ENRICHED
         elif effect_size < 0:
-            direction = "Depleted Only"
+            direction = DirectionFacets.DEPLETED
         else:
-            direction = "Non-significant"
+            direction = DirectionFacets.NON_SIGNIFICANT
 
-        observations.append(
-            ObservationRow(sources, targets, direction, effect_size, float(line["p_val"]), significance)
-        )
+        num_facets = {
+            NumericFacets.EFFECT_SIZE: effect_size,
+            NumericFacets.SIGNIFICANCE: significance,
+            NumericFacets.RAW_P_VALUE: float(line["p_val"]),
+        }
+
+        observations.append(ObservationRow(sources, targets, [direction], num_facets))
     results_file.close()
     return observations
 

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
@@ -3,6 +3,7 @@ import csv
 from utils.experiment import ExperimentMetadata
 
 from .load_experiment import Experiment, FeatureRow
+from .types import FeatureType, GrnaFacet
 
 # These gene names appear in the data and have a "version" ("".1") in a few instances.
 # We don't know why. It's safe to remove the version for processing though.
@@ -60,7 +61,7 @@ def get_features(experiment_metadata: ExperimentMetadata):
                 location=(int(dhs_start), int(dhs_end), "[)"),
                 genome_assembly=dhs_file.genome_assembly,
                 cell_line=dhs_cell_line,
-                feature_type="DHS",
+                feature_type=FeatureType.DHS,
             )
 
         dhs_row = new_dhss[dhs_name]
@@ -84,8 +85,8 @@ def get_features(experiment_metadata: ExperimentMetadata):
                 strand=strand,
                 genome_assembly=grna_file.genome_assembly,
                 cell_line=grna_cell_line,
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 parent_name=dhs_row.name,
                 misc={"grna": grna_id},
             )

--- a/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000008_load_mccutcheon_scCERES_cd8_CRISPR_2022_experiment.py
@@ -81,7 +81,7 @@ def get_features(experiment_metadata: ExperimentMetadata):
             new_grnas[grna_id] = FeatureRow(
                 name=grna_id,
                 chrom_name=chrom_name,
-                location=(int(grna_start), int(grna_end), bounds),
+                location=(grna_start, grna_end, bounds),
                 strand=strand,
                 genome_assembly=grna_file.genome_assembly,
                 cell_line=grna_cell_line,

--- a/scripts/data_loading/db.py
+++ b/scripts/data_loading/db.py
@@ -79,7 +79,7 @@ def reo_entry(
 
 def bulk_reo_save(
     effects: StringIO,
-    effect_directions: StringIO,
+    categorical_facets: StringIO,
     source_associations: StringIO,
     target_associations: Optional[StringIO] = None,
 ):
@@ -102,10 +102,10 @@ def bulk_reo_save(
         )
 
     with transaction.atomic(), connection.cursor() as cursor:
-        effect_directions.seek(0, SEEK_SET)
-        print("Adding effect directions to effects")
+        categorical_facets.seek(0, SEEK_SET)
+        print("Adding categorical facets to effects")
         cursor.copy_from(
-            effect_directions,
+            categorical_facets,
             "search_regulatoryeffectobservation_facet_values",
             columns=(
                 "regulatoryeffectobservation_id",
@@ -178,8 +178,8 @@ def target_entry(reo_id, target_id):
     return f"{reo_id}\t{target_id}\n"
 
 
-def direction_entry(reo_id, direction_id):
-    return f"{reo_id}\t{direction_id}\n"
+def cat_facet_entry(reo_id, facet_id):
+    return f"{reo_id}\t{facet_id}\n"
 
 
 def ccre_associate_entry(feature_id, ccre_id):
@@ -188,6 +188,7 @@ def ccre_associate_entry(feature_id, ccre_id):
 
 def bulk_feature_save(features: StringIO):
     features.seek(0, SEEK_SET)
+    print("Adding features")
     with transaction.atomic(), connection.cursor() as cursor:
         cursor.copy_from(
             features,
@@ -224,7 +225,7 @@ def bulk_feature_save(features: StringIO):
 def bulk_feature_facet_save(facets):
     with transaction.atomic(), connection.cursor() as cursor:
         facets.seek(0, SEEK_SET)
-        print("Adding facets to gRNAs")
+        print("Adding facets to features")
         cursor.copy_from(
             facets,
             "search_dnafeature_facet_values",
@@ -237,6 +238,7 @@ def bulk_feature_facet_save(facets):
 
 def bulk_save_associations(associations):
     associations.seek(0, SEEK_SET)
+    print("Adding ccre associations to features")
     with transaction.atomic(), connection.cursor() as cursor:
         cursor.copy_from(
             associations, "search_dnafeature_associated_ccres", columns=("from_dnafeature_id", "to_dnafeature_id")

--- a/scripts/data_loading/db.py
+++ b/scripts/data_loading/db.py
@@ -141,7 +141,7 @@ def feature_entry(
     feature_type,
     ids=None,
     ensembl_id="\\N",
-    name="\\N",
+    name=None,
     cell_line="\\N",
     closest_gene_id="\\N",
     closest_gene_distance="\\N",
@@ -159,6 +159,7 @@ def feature_entry(
     public="true",
 ):
     ids = "\\N" if ids is None else json.dumps(ids)
+    name = "\\N" if name is None else name
     misc = "\\N" if misc is None else json.dumps(misc)
     strand = "\\N" if strand is None else strand
     source_file_id = "\\N" if source_file_id is None else source_file_id

--- a/scripts/data_loading/db.py
+++ b/scripts/data_loading/db.py
@@ -149,7 +149,7 @@ def feature_entry(
     closest_gene_ensembl_id="\\N",
     genome_assembly_patch="0",
     feature_subtype="\\N",
-    strand="\\N",
+    strand=None,
     source_file_id=None,
     experiment_accession_id="\\N",
     parent_id=None,
@@ -160,6 +160,7 @@ def feature_entry(
 ):
     ids = "\\N" if ids is None else json.dumps(ids)
     misc = "\\N" if misc is None else json.dumps(misc)
+    strand = "\\N" if strand is None else strand
     source_file_id = "\\N" if source_file_id is None else source_file_id
     parent_id = "\\N" if parent_id is None else parent_id
     parent_accession_id = "\\N" if parent_accession_id is None else parent_accession_id

--- a/scripts/data_loading/load_analysis.py
+++ b/scripts/data_loading/load_analysis.py
@@ -45,6 +45,7 @@ class SourceInfo:
     start: int
     end: int
     bounds: str
+    strand: Optional[str]
     feature_type: FeatureType
 
     def __post_init__(self):
@@ -91,13 +92,14 @@ class Analysis:
         with ReoIds() as reo_ids:
             for reo_id, reo in zip(reo_ids, reos):
                 for source in reo.sources:
-                    source_string = f"{source.chrom}:{source.start}-{source.end}:{genome_assembly}"
+                    source_string = f"{source.chrom}:{source.start}-{source.end}:{source.strand}:{genome_assembly}"
 
                     if source_string not in source_cache:
                         source_cache[source_string] = DNAFeature.objects.filter(
                             experiment_accession_id=experiment_accession_id,
                             chrom_name=source.chrom,
                             location=NumericRange(source.start, source.end, source.bounds),
+                            strand=source.strand,
                             ref_genome=genome_assembly,
                             feature_type=DNAFeatureType(source.feature_type),
                         ).values_list("id", flat=True)[0]

--- a/scripts/data_loading/load_experiment.py
+++ b/scripts/data_loading/load_experiment.py
@@ -27,6 +27,7 @@ from .db import (
     feature_entry,
     feature_facet_entry,
 )
+from .types import FeatureType
 
 GRNA_TYPE_FACET = Facet.objects.get(name=DNAFeature.Facet.GRNA_TYPE.value)
 GRNA_TYPE_FACET_VALUES = {facet.value: facet for facet in FacetValue.objects.filter(facet_id=GRNA_TYPE_FACET.id).all()}
@@ -54,7 +55,7 @@ class FeatureRow:
     location: tuple[int, int, str]  # start, end, bounds ("[]", "()", "[)", "(]")
     genome_assembly: str  # ("GRCh38", "GRCh37")
     cell_line: str
-    feature_type: str  # ("cCRE", "DHS", "gRNA", "Chromatin Accessible Region")
+    feature_type: FeatureType  # ("cCRE", "DHS", "gRNA", "Chromatin Accessible Region")
     facets: Optional[list[str]] = None  # list[("Positive Control", "Targeting", "Promoter", "Non-promoter")]
     parent_name: Optional[str] = None
     misc: Optional[Any] = None

--- a/scripts/data_loading/tests/conftest.py
+++ b/scripts/data_loading/tests/conftest.py
@@ -62,3 +62,13 @@ def gene():
     _ = DNAFeatureFactory(
         feature_type=DNAFeatureType.GENE, chrom_name="chr1", location=NumericRange(1000, 2000), strand="+"
     )
+
+
+@pytest.fixture
+def cleanup_gen_features():
+    yield
+    for feature in DNAFeature.objects.exclude(feature_type__in=[DNAFeatureType.CCRE, DNAFeatureType.GENE]).all():
+        feature.delete()
+
+    for ccre in DNAFeature.objects.filter(feature_type=DNAFeatureType.CCRE, misc__pseudo=True).all():
+        ccre.delete()

--- a/scripts/data_loading/tests/test_experiment_saving.py
+++ b/scripts/data_loading/tests/test_experiment_saving.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cegs_portal.search.models import DNAFeature, DNAFeatureType
+from scripts.data_loading.types import FeatureType, GrnaFacet
 
 pytestmark = pytest.mark.django_db
 
@@ -36,8 +37,8 @@ def test_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "0"},
             ),
             FeatureRow(
@@ -47,8 +48,8 @@ def test_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "1"},
             ),
             FeatureRow(
@@ -58,8 +59,8 @@ def test_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "1"},
             ),
             FeatureRow(
@@ -69,8 +70,8 @@ def test_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "1"},
             ),
             FeatureRow(
@@ -80,8 +81,8 @@ def test_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "2"},
             ),
         ]
@@ -126,8 +127,8 @@ def test_close_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "0"},
             ),
             FeatureRow(
@@ -137,8 +138,8 @@ def test_close_ccre_associations(experiment_metadata):
                 strand="+",
                 genome_assembly="GRCh38",
                 cell_line="iPSC",
-                feature_type="gRNA",
-                facets=["Targeting"],
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
                 misc={"grna": "1"},
             ),
         ]

--- a/scripts/data_loading/tests/test_experiment_saving.py
+++ b/scripts/data_loading/tests/test_experiment_saving.py
@@ -14,15 +14,7 @@ def generated_features():
     return DNAFeature.objects.exclude(feature_type__in=[DNAFeatureType.CCRE, DNAFeatureType.GENE]).all()
 
 
-def clean_features():
-    for feature in generated_features():
-        feature.delete()
-
-    for ccre in DNAFeature.objects.filter(feature_type=DNAFeatureType.CCRE, misc__pseudo=True).all():
-        ccre.delete()
-
-
-@pytest.mark.usefixtures("ccres", "gene")
+@pytest.mark.usefixtures("ccres", "gene", "cleanup_gen_features")
 def test_ccre_associations(experiment_metadata):
     # This has to happen hear because load_experiment does DB calls on load
     # which isn't allowed in the pytest suite outside of tests with a django_db mark
@@ -103,12 +95,9 @@ def test_ccre_associations(experiment_metadata):
                 assert ccre.misc["pseudo"]
 
     assert overlap_ccre_count == 3
-    clean_features()
-
-    assert len(generated_features()) == 0
 
 
-@pytest.mark.usefixtures("ccres", "gene")
+@pytest.mark.usefixtures("ccres", "gene", "cleanup_gen_features")
 def test_close_ccre_associations(experiment_metadata):
     # Make sure the algorithm works correctly for features that abut existing cCREs
     # Neither of these features should "overlap" so they should both result in
@@ -153,6 +142,148 @@ def test_close_ccre_associations(experiment_metadata):
         for ccre in [ccre for ccre in feature.associated_ccres.all()]:
             assert ccre.id not in old_ids
 
-    clean_features()
 
-    assert len(generated_features()) == 0
+@pytest.mark.usefixtures("ccres", "gene", "cleanup_gen_features")
+def test_parent_ccre_associations(experiment_metadata):
+    # This has to happen hear because load_experiment does DB calls on load
+    # which isn't allowed in the pytest suite outside of tests with a django_db mark
+    from scripts.data_loading.load_experiment import Experiment, FeatureRow
+
+    def load_features(_):
+        parent_features = [
+            FeatureRow(
+                name="a",
+                chrom_name="chr1",
+                location=(0, 50, "[)"),
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.DHS,
+            ),
+            FeatureRow(
+                name="b",
+                chrom_name="chr1",
+                location=(90, 190, "[)"),
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.DHS,
+            ),
+            FeatureRow(
+                name="c",
+                chrom_name="chr1",
+                location=(210, 290, "[)"),
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.DHS,
+            ),
+        ]
+        features = [
+            FeatureRow(
+                name="0",
+                chrom_name="chr1",
+                location=(5, 10, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="a",
+                misc={"grna": "0"},
+            ),
+            FeatureRow(
+                name="1",
+                chrom_name="chr1",
+                location=(15, 25, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="a",
+                misc={"grna": "1"},
+            ),
+            FeatureRow(
+                name="2",
+                chrom_name="chr1",
+                location=(30, 40, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="a",
+                misc={"grna": "2"},
+            ),
+            FeatureRow(
+                name="3",
+                chrom_name="chr1",
+                location=(91, 99, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="b",
+                misc={"grna": "3"},
+            ),
+            FeatureRow(
+                name="4",
+                chrom_name="chr1",
+                location=(120, 130, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="b",
+                misc={"grna": "4"},
+            ),
+            FeatureRow(
+                name="5",
+                chrom_name="chr1",
+                location=(120, 130, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="c",
+                misc={"grna": "5"},
+            ),
+            FeatureRow(
+                name="6",
+                chrom_name="chr1",
+                location=(120, 130, "[)"),
+                strand="+",
+                genome_assembly="GRCh38",
+                cell_line="iPSC",
+                feature_type=FeatureType.GRNA,
+                facets=[GrnaFacet.TARGETING],
+                parent_name="c",
+                misc={"grna": "6"},
+            ),
+        ]
+        return features, parent_features
+
+    old_ids = ccre_ids()
+    new_ccre_ids = set()
+
+    Experiment(experiment_metadata).load(load_features).save()
+
+    overlap_ccre_count = 0
+    non_overlap_ccre_count = 0
+
+    assert len(generated_features()) == 10
+
+    for feature in generated_features():
+        for ccre in [ccre for ccre in feature.associated_ccres.all()]:
+            if ccre.id in old_ids:
+                assert ccre.misc.get("pseudo") is None
+                overlap_ccre_count += 1
+            else:
+                new_ccre_ids.add(ccre.id)
+                assert ccre.misc["pseudo"]
+                non_overlap_ccre_count += 1
+
+    assert overlap_ccre_count == 3
+    assert non_overlap_ccre_count == 7
+    assert len(new_ccre_ids) == 2

--- a/scripts/data_loading/types.py
+++ b/scripts/data_loading/types.py
@@ -1,0 +1,45 @@
+from enum import StrEnum
+
+from cegs_portal.search.models import (
+    DNAFeatureType,
+    EffectObservationDirectionType,
+    GrnaType,
+    PromoterType,
+    RegulatoryEffectObservation,
+)
+
+
+class GrnaFacet(StrEnum):
+    POSITIVE_CONTROL = GrnaType.POSITIVE_CONTROL.value
+    NEGATIVE_CONTROL = GrnaType.NEGATIVE_CONTROL.value
+    TARGETING = GrnaType.TARGETING.value
+
+
+class PromoterFacet(StrEnum):
+    PROMOTER = PromoterType.PROMOTER.value
+    NON_PROMOTER = PromoterType.NON_PROMOTER.value
+
+
+class FeatureType(StrEnum):
+    GENE = DNAFeatureType.GENE.value
+    TRANSCRIPT = DNAFeatureType.TRANSCRIPT.value
+    EXON = DNAFeatureType.EXON.value
+    CCRE = DNAFeatureType.CCRE.value
+    DHS = DNAFeatureType.DHS.value
+    GRNA = DNAFeatureType.GRNA.value
+    CAR = DNAFeatureType.CAR.value
+
+
+class NumericFacets(StrEnum):
+    EFFECT_SIZE = RegulatoryEffectObservation.Facet.EFFECT_SIZE.value
+    SIGNIFICANCE = RegulatoryEffectObservation.Facet.SIGNIFICANCE.value
+    LOG_SIGNIFICANCE = RegulatoryEffectObservation.Facet.LOG_SIGNIFICANCE.value
+    RAW_P_VALUE = RegulatoryEffectObservation.Facet.RAW_P_VALUE.value
+    AVG_COUNTS_PER_MILLION = RegulatoryEffectObservation.Facet.AVG_COUNTS_PER_MILLION.value
+
+
+class DirectionFacets(StrEnum):
+    DEPLETED = EffectObservationDirectionType.DEPLETED.value
+    ENRICHED = EffectObservationDirectionType.ENRICHED.value
+    NON_SIGNIFICANT = EffectObservationDirectionType.NON_SIGNIFICANT.value
+    BOTH = EffectObservationDirectionType.BOTH.value

--- a/utils/experiment.py
+++ b/utils/experiment.py
@@ -75,7 +75,7 @@ class AnalysisMetadata:
 
         self.results = ExperimentFileMetadata(analysis_dict["results"], base_path)
 
-        self.misc_files = [FileMetadata(file, base_path) for file in analysis_dict["misc_files"]]
+        self.misc_files = [FileMetadata(file, base_path) for file in analysis_dict.get("misc_files", [])]
 
     def db_save(self):
         experiment = Experiment.objects.get(accession_id=self.experiment_accession_id)


### PR DESCRIPTION
The backend/frontend refactor was done just using EXPRs 8 and 9 as the working data. This PR converts the rest of the experiments (2-7) to the new architecture. With a larger set of experiments more useful modifications have been made like:

* Replacing many strings with StrEnums
* performing the gene name->ensembl id mapping work in a separate script so the results can be saved
* Modifying the cCRE association algorithm. If there are parent features, association is performed on those first and then children are associated with their parent's associated cCRE.
* Another cCRE association test
* Move manual test cleanup into a fixture
* Save tested element strand information
* Fix "bulk save" output messages

All these changes on top of the work just removing db access code from the various _analysis and _experiment files and we're still -500 lines!