### PR TITLE
Update django and whitenoise

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ python-slugify==5.0.2  # https://github.com/un33k/python-slugify
 Pillow==10.1.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==20.1.0  # https://github.com/hynek/argon2_cffi
 brotli==1.0.9  # https://github.com/google/brotli
-whitenoise==6.3.0  # https://github.com/evansd/whitenoise
+whitenoise==6.6.0  # https://github.com/evansd/whitenoise
 redis==4.5.4  # https://github.com/andymccurdy/redis-py
 hiredis==2.2.2  # https://github.com/redis/hiredis-py
 uvicorn[standard]==0.26.0  # https://github.com/encode/uvicorn
@@ -16,7 +16,7 @@ gunicorn==21.2.0  # https://github.com/benoitc/gunicorn
 
 # Django
 # ------------------------------------------------------------------------------
-django==4.2.7  # pyup: < 4.1  # https://www.djangoproject.com/
+django==4.2.11  # pyup: < 4.1  # https://www.djangoproject.com/
 django-environ==0.9.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.2.0  # https://github.com/jazzband/django-model-utils
 django-allauth==0.52.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
Django has had some security updates. Whitenoise didn't technically support django 4.2 until version 6.4.