### PR TITLE
Add WHITENOISE_SKIP_COMPRESS_EXTENSIONS to settings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ build-prod:
       alias: postgres
   before_script:
     - cd /app
-    - python manage.py collectstatic -i "*.ecd" -i "*.pd"
+    - python manage.py collectstatic
     - python manage.py migrate
   script:
     - pytest

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ typecheck:
 exp_cov:
 	./scripts/data_generation/gen_experiment_coverage_viz.sh
 
-collectstatic:
-	python manage.py collectstatic -i "*.ecd" -i "*.pd"  -i "*.fd" # ignore binary files in the static_data directory
+cs:
+	python manage.py collectstatic --clear

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput --ignore "*.ecd" --ignore "*.fd" --ignore "*.pd"
+python /app/manage.py collectstatic --noinput
 
 
 /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker

--- a/compose/production/django/start_huey
+++ b/compose/production/django/start_huey
@@ -5,6 +5,6 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput --ignore "*.ecd"
+python /app/manage.py collectstatic --noinput
 
 python /app/manage.py run_huey

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,6 +1,7 @@
 """
 Base settings to build other settings files upon.
 """
+
 from pathlib import Path
 
 import environ
@@ -297,3 +298,24 @@ HUEY = {
 # ------------------------------------------------------------------------------
 TESTING = False
 PROMETHEUS_EXPORT_MIGRATIONS = False
+WHITENOISE_SKIP_COMPRESS_EXTENSIONS = (
+    "jpg",
+    "jpeg",
+    "png",
+    "gif",
+    "webp",
+    "zip",
+    "gz",
+    "tgz",
+    "bz2",
+    "tbz",
+    "xz",
+    "br",
+    "swf",
+    "flv",
+    "woff",
+    "woff2",
+    "ecd",  # Experiment coverage data
+    "pd",  # Plot Data
+    "fd",  # Feature Data
+)


### PR DESCRIPTION
This tells whitenoise which file types not to compress during a collectstatic run. We added three binary file types to this because they can be large and just aren't very compressable. Trying to do so slowed down the compresstatic step a lot.

This is a change from using --ignore flags because we don't actually want these files ignored. We want whitenoise to serve them, we just don't want the to be compressed.