### PR TITLE
Don't collect .ecd or .fd files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ build-prod:
       alias: postgres
   before_script:
     - cd /app
-    - python manage.py collectstatic
+    - python manage.py collectstatic -i "*.ecd" -i "*.fd"
     - python manage.py migrate
   script:
     - pytest

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ exp_cov:
 	./scripts/data_generation/gen_experiment_coverage_viz.sh
 
 cs:
-	python manage.py collectstatic --clear
+	python manage.py collectstatic --clear -i "*.ecd" -i "*.fd"

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -5,7 +5,7 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput
+python /app/manage.py collectstatic --noinput -i "*.ecd" -i "*.fd"
 
 
 /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker

--- a/compose/production/django/start_huey
+++ b/compose/production/django/start_huey
@@ -5,6 +5,6 @@ set -o pipefail
 set -o nounset
 
 
-python /app/manage.py collectstatic --noinput
+python /app/manage.py collectstatic --noinput -i "*.ecd" -i "*.fd"
 
 python /app/manage.py run_huey


### PR DESCRIPTION
.ecd (experiment coverage data) and .fd (feature data) files are not directly accessed by the client (the web browser). They are only used by the server and so don't need to be "collected" for django to serve.