### PR TITLE
Remove signal receivers, combine expr/an load tasks

### DIFF
--- a/cegs_portal/search/models/experiment.py
+++ b/cegs_portal/search/models/experiment.py
@@ -9,6 +9,8 @@ from cegs_portal.search.models.dna_feature_type import DNAFeatureSourceType
 from cegs_portal.search.models.facets import Faceted
 from cegs_portal.search.models.file import File
 
+from .signals import update_analysis_access, update_experiment_access
+
 
 class TissueType(Accessioned):
     name = models.CharField(max_length=100)
@@ -66,6 +68,11 @@ class Experiment(Accessioned, Faceted, AccessControlled):
     def assay(self):
         return self.facet_values.get(facet__name=Experiment.Facet.ASSAYS.value).value
 
+    def save(self, *args, **kwargs):
+        created = self.pk is None
+        super(Experiment, self).save(*args, **kwargs)
+        update_experiment_access(self, created)
+
     def __str__(self):
         return f"{self.accession_id}: {self.name} ({self.experiment_type})"
 
@@ -104,6 +111,11 @@ class Analysis(Accessioned, Faceted, AccessControlled):
     genome_assembly_patch = models.CharField(max_length=10, null=True, blank=True)
     p_value_threshold = models.FloatField(default=0.05)
     p_value_adj_method = models.CharField(max_length=128, default="unknown")
+
+    def save(self, *args, **kwargs):
+        created = self.pk is None
+        super(Analysis, self).save(*args, **kwargs)
+        update_analysis_access(self, created)
 
     def __str__(self):
         description = self.description

--- a/cegs_portal/search/models/signals.py
+++ b/cegs_portal/search/models/signals.py
@@ -1,25 +1,13 @@
-import logging
-
 from django.db import connection
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from huey.contrib.djhuey import db_task
 
-from cegs_portal.search.models.experiment import Analysis, Experiment
 from cegs_portal.utils.decorators import skip_receiver_in_testing
 
-logger = logging.getLogger("django.task")
 
-
-@receiver(post_save, sender=Experiment)
 @skip_receiver_in_testing
 @db_task()
-def update_experiment_access(sender, instance, created, raw, using, update_fields, **kwargs):
-    """This reciever is run when access permissions are changed on an experiment. It updates
-    the access permissions on the dna features and REOs associated with the experiment.
-    """
+def update_experiment_access(experiment, created):
     if created:
-        # Don't do anything if the experiment has just been created
         return
 
     with connection.cursor() as cursor:
@@ -27,31 +15,26 @@ def update_experiment_access(sender, instance, created, raw, using, update_field
             """UPDATE search_analysis
                SET public = %s, archived = %s
                WHERE experiment_accession_id = %s""",
-            [instance.public, instance.archived, instance.accession_id],
+            [experiment.public, experiment.archived, experiment.accession_id],
         )
         cursor.execute(
             """UPDATE search_dnafeature
                SET public = %s, archived = %s
                WHERE experiment_accession_id = %s""",
-            [instance.public, instance.archived, instance.accession_id],
+            [experiment.public, experiment.archived, experiment.accession_id],
         )
         cursor.execute(
             """UPDATE search_regulatoryeffectobservation
                SET public = %s, archived = %s
                WHERE experiment_accession_id = %s""",
-            [instance.public, instance.archived, instance.accession_id],
+            [experiment.public, experiment.archived, experiment.accession_id],
         )
 
 
-@receiver(post_save, sender=Analysis)
 @skip_receiver_in_testing
 @db_task()
-def update_analysis_access(sender, instance, created, raw, using, update_fields, **kwargs):
-    """This reciever is run when access permissions are changed on an analysis. It updates
-    the access permissions on the dna features and REOs associated with the experiment.
-    """
+def update_analysis_access(analysis, created):
     if created:
-        # Don't do anything if the analysis has just been created
         return
 
     with connection.cursor() as cursor:
@@ -59,5 +42,5 @@ def update_analysis_access(sender, instance, created, raw, using, update_fields,
             """UPDATE search_regulatoryeffectobservation
                SET public = %s, archived = %s
                WHERE analysis_accession_id = %s""",
-            [instance.public, instance.archived, instance.accession_id],
+            [analysis.public, analysis.archived, analysis.accession_id],
         )


### PR DESCRIPTION
Uploading experiments on test, because of the different way huey is configured to run vs. locally where the code was developed, didn't work.

These two changes, removing post-save signal receivers and combining experiment and analysis load tasks, fix the two problems.

I think there was a weird interaction between signals and huey that broke things. There's a weak reference that was unable to be serialized.

The experiment and analysis loading needs to be done serially instead of in parallel so combining them into a single task ensures that happens.