### PR TITLE
Fix index page links

### DIFF
--- a/cegs_portal/search/templates/search/index.html
+++ b/cegs_portal/search/templates/search/index.html
@@ -267,7 +267,7 @@
             </div>
         </a>
 
-        <a href="{% url 'search:experiments' %}s?exp=DCPEXPR0000000002&exp=DCPEXPR0000000004&exp=DCPEXPR0000000007" class="content-container-link">
+        <a href="{% url 'search:experiments' %}s?exp=DCPEXPR0000000007&exp=DCPEXPR0000000008" class="content-container-link">
             <div class="search-container">
                 <div class="flex flex-col items-center">
                 <div class="flex flex-row">
@@ -290,7 +290,7 @@
             </div>
         </a>
 
-        <a href="{% url 'search:experiments' %}/DCPEXPR00000004" class="content-container-link">
+        <a href="{% url 'search:experiments' %}/DCPEXPR0000000004" class="content-container-link">
             <div class="search-container">
                     <div class="flex flex-col items-center">
                     <div class="flex flex-row">


### PR DESCRIPTION
These links didn't work. The single experiment had the wrong accession format and the multi-experiment picked experiments that were analyzed on different assemblies so nothing was shown as they are incompatible.