### PR TITLE
Fix index page links

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -93,6 +93,12 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]  # noqa F405
+
+# WhiteNoise
+# ------------------------------------------------------------------------------
+# http://whitenoise.evans.io/en/latest/django.html#using-whitenoise-in-development
+INSTALLED_APPS = ["whitenoise.runserver_nostatic"] + INSTALLED_APPS  # noqa F405
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 # https://anymail.readthedocs.io/en/stable/esps


### PR DESCRIPTION
These links didn't work. The single experiment had the wrong accession format and
the multi-experiment picked experiments that were analyzed on different assemblies
so nothing was shown as they are incompatible.