### PR TITLE
Fixed the filter container over extension

### DIFF
--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -293,7 +293,7 @@
             {% if tab_summary_selected %}data-te-tab-active{% endif %}
         >
             <div class="flex flex-row items-start gap-x-10 min-w-full">
-                <div class="flex flex-col gap-4">
+                <div class="flex flex-col gap-4 basis-1/4">
                     <div id="facets" class="container">
                         <div class="search-results-table-title table-container-header">
                             <div class="table-container-title">
@@ -358,7 +358,7 @@
                     {% endif %}
                 </div>
 
-                <div class="flex flex-col gap-4">
+                <div class="flex flex-col gap-4 basis-3/4">
                     {% if feature_counts %}
                     <div class="container" id="feature-counts">
                     {% include "search/v1/partials/_search_feature_counts.html" with feature_counts=feature_counts sig_reo_count_features=sig_reo_count_features %}

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -293,7 +293,7 @@
             {% if tab_summary_selected %}data-te-tab-active{% endif %}
         >
             <div class="flex flex-row items-start gap-x-10 min-w-full">
-                <div class="flex flex-col gap-4 flex-none">
+                <div class="flex flex-col gap-4">
                     <div id="facets" class="container">
                         <div class="search-results-table-title table-container-header">
                             <div class="table-container-title">


### PR DESCRIPTION
Now that we have more items to filter, the container is being extended. This causes the tables to be pushed off screen and/or makes the browser enable horizontal scrolling.

![image](https://github.com/ReddyLab/cegs-portal/assets/19657615/a83ff60f-0597-40f3-abbc-3b1d9724b3e4)
![image](https://github.com/ReddyLab/cegs-portal/assets/19657615/3ae8a72a-bccf-4c2e-b930-91574aa5dc5e)

