### PR TITLE
Use *_data instead of *_file variables in upload

### DIFF
--- a/cegs_portal/uploads/views/uploads.py
+++ b/cegs_portal/uploads/views/uploads.py
@@ -40,7 +40,7 @@ def upload(request):
             elif (analysis_file := request.FILES.get("analysis_file")) is not None:
                 analysis_data = analysis_file
 
-            match experiment_file, analysis_file:
+            match experiment_data, analysis_data:
                 case (None, None):
                     desc = "Null Upload"
                 case (_, None):


### PR DESCRIPTION
This fixes a bug in the upload code that causes an error when metadata locations are urls instead of files.