### PR TITLE
QQ plot improvements

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -824,9 +824,10 @@
 
                     return {categoryNames, xLabel, yLabel, values};
                 }).then((data) => {
-                    const scale = {
-                        domain: data.categoryNames,
-                        range: ['#5377A3', '#ff8c00', '#aec7e8', '#1f77b4', '#9467bd']
+                    let catColors = ['#5377A3', '#ff8c00', '#aec7e8', '#1f77b4', '#9467bd'];
+                    const pValueScale = {
+                        domain: [...data.categoryNames, "y = x"],
+                        range: [...catColors.slice(0, data.categoryNames.length), "#ffcccc"]
                     };
 
                     let maxX = 0;
@@ -841,18 +842,18 @@
                     let pValues = vl.markCircle({tooltip: true})
                     .data(data)
                     .encode(
-                        vl.color().fieldN('cat').scale(scale).title(''),
+                        vl.color().fieldN('cat').scale(pValueScale).title(''),
                         vl.x().fieldQ('t').title(data.xLabel),
                         vl.y().fieldQ('o').title(data.yLabel),
                     );
 
                     // Draw a faint red line where y = x
                     let xy = vl.markLine({clip: true})
-                    .data([{x: 0, y: 0}, {x: max, y: max}])
+                    .data([{x: 0, y: 0, cat: "y = x"}, {x: max, y: max, cat: "y = x"}])
                     .encode(
+                        vl.color().fieldN('cat').scale(pValueScale),
                         vl.x().fieldQ('x').scale({domain: [0, maxX]}),
-                        vl.y().fieldQ('y').scale({domain: [0, maxY]}),
-                        vl.color().value("#FFCCCC")
+                        vl.y().fieldQ('y').scale({domain: [0, maxY]})
                     );
 
                     let plot = vl.layer(xy, pValues)

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -829,17 +829,39 @@
                         range: ['#5377A3', '#ff8c00', '#aec7e8', '#1f77b4', '#9467bd']
                     };
 
-                    return vl.markCircle({tooltip: true})
+                    let maxX = 0;
+                    let maxY = 0;
+                    for (let value of data.values) {
+                        maxX = Math.max(value.t, maxX);
+                        maxY = Math.max(value.o, maxY);
+                    }
+
+                    let max = Math.max(maxX, maxY);
+
+                    let pValues = vl.markCircle({tooltip: true})
                     .data(data)
-                    .width(450)
-                    .height(400)
-                    .title('Q-Q Plot')
                     .encode(
                         vl.color().fieldN('cat').scale(scale).title(''),
                         vl.x().fieldQ('t').title(data.xLabel),
                         vl.y().fieldQ('o').title(data.yLabel),
-                    )
-                    .render()
+                    );
+
+                    // Draw a faint red line where y = x
+                    let xy = vl.markLine({clip: true})
+                    .data([{x: 0, y: 0}, {x: max, y: max}])
+                    .encode(
+                        vl.x().fieldQ('x').scale({domain: [0, maxX]}),
+                        vl.y().fieldQ('y').scale({domain: [0, maxY]}),
+                        vl.color().value("#FFCCCC")
+                    );
+
+                    let plot = vl.layer(xy, pValues)
+                    .width(450)
+                    .height(400)
+                    .title('Q-Q Plot')
+                    .render();
+
+                    return plot;
                 }).then((viewElement) => {
                     // render returns a promise to a DOM element containing the chart
                     // viewElement.value contains the Vega View object instance

--- a/cegs_portal/uploads/data_generation/qq_plot.py
+++ b/cegs_portal/uploads/data_generation/qq_plot.py
@@ -1,3 +1,4 @@
+import math
 import os
 import struct
 
@@ -11,6 +12,8 @@ from cegs_portal.search.models import (
     GrnaType,
     RegulatoryEffectObservation,
 )
+
+MIN_SIG = 1e-100
 
 
 def gen_qq_plot(analysis, analysis_dir):
@@ -40,7 +43,8 @@ def gen_qq_plot(analysis, analysis_dir):
 
     qq_data = {0: [], 1: []}
     for reo in reos:
-        p_val_log_10 = float(reo["reo_facets"][RegulatoryEffectObservation.Facet.LOG_SIGNIFICANCE.value])
+        raw_p_val = max(float(reo["reo_facets"][RegulatoryEffectObservation.Facet.RAW_P_VALUE.value]), MIN_SIG)
+        p_val_log_10 = -math.log10(raw_p_val)
 
         cat_facets = set(reo["cat_facets"])
         if cat_facets & non_ctrl:


### PR DESCRIPTION
[QQPlot data should be p values, not adjusted p values](https://github.com/ReddyLab/cegs-portal/commit/d875438e93768d2844e2fa6609c32530f260613b) 
Also p values are sometimes 0, so we need to set a floor for them because
log10(0) is not allowed.

[Add y=x line to vega-lite qq plot](https://github.com/ReddyLab/cegs-portal/commit/fcf75c9f91da80356ccd3c822b6c414f8a358bdc) 
This line is a helpful guide for folks using the qq plot
for QC purposes.

![Screenshot 2024-06-18 at 11 40 54 AM](https://github.com/ReddyLab/cegs-portal/assets/719958/916e44a8-00d4-4946-9f2f-0c7c69e723d4)


