### PR TITLE
Adds ability to union experiment results together

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -31,6 +31,7 @@ import {
     STATE_COVERAGE_TYPE,
     STATE_LEGEND_INTERVALS,
     STATE_FEATURE_FILTER_TYPE,
+    STATE_COMBO_SET_OP,
 } from "./consts.js";
 import {
     numericFilterControls,
@@ -170,7 +171,8 @@ function build_state(manifests, genomeRenderer, accessionIDs, sourceType) {
             source: legendIntervalFunc(coverageData, "source_intervals"),
             target: legendIntervalFunc(coverageData, "target_intervals"),
         },
-        [STATE_FEATURE_FILTER_TYPE]: "sources",
+        [STATE_FEATURE_FILTER_TYPE]: g("feature-select").value,
+        [STATE_COMBO_SET_OP]: g("set-op-select").value,
     });
 
     return state;
@@ -269,10 +271,13 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         state.u(STATE_SCALE_X, zoomed ? 30 : 1);
         state.u(STATE_SCALE_Y, zoomed ? 15 : 1);
 
-        let body = getFilterBody(state, genome, manifests[0].chromosomes, [
-            state.g(STATE_CATEGORICAL_FACET_VALUES),
-            state.g(STATE_NUMERIC_FACET_VALUES),
-        ]);
+        let body = getFilterBody(
+            state,
+            genome,
+            manifests[0].chromosomes,
+            [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
+            state.g(STATE_COMBO_SET_OP)
+        );
 
         postJson("/search/combined_experiment_coverage", JSON.stringify(body)).then((response_json) => {
             state.u(STATE_COVERAGE_DATA, mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes));
@@ -284,7 +289,13 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
     });
 
     function get_all_data() {
-        let body = getFilterBody(state, genome, manifests[0].chromosomes, [state.g(STATE_CATEGORICAL_FACET_VALUES)]);
+        let body = getFilterBody(
+            state,
+            genome,
+            manifests[0].chromosomes,
+            [state.g(STATE_CATEGORICAL_FACET_VALUES)],
+            state.g(STATE_COMBO_SET_OP)
+        );
 
         postJson("/search/combined_experiment_coverage", JSON.stringify(body)).then((response_json) => {
             state.u(STATE_COVERAGE_DATA, mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes));
@@ -313,10 +324,13 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         STATE_NUMERIC_FACET_VALUES,
         debounce((s, key) => {
             // Send facet data to server to get filtered data and updated numeric facets
-            let body = getFilterBody(state, genome, manifests[0].chromosomes, [
-                state.g(STATE_CATEGORICAL_FACET_VALUES),
-                state.g(STATE_NUMERIC_FACET_VALUES),
-            ]);
+            let body = getFilterBody(
+                state,
+                genome,
+                manifests[0].chromosomes,
+                [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
+                state.g(STATE_COMBO_SET_OP)
+            );
 
             postJson("/search/combined_experiment_coverage", JSON.stringify(body)).then((response_json) => {
                 state.u(
@@ -454,7 +468,6 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
     // Feature Filter Selector
     //
     let featureFilterSelector = g("feature-select");
-    featureFilterSelector.value = "sources";
     featureFilterSelector.addEventListener(
         "change",
         () => {
@@ -464,6 +477,22 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
     );
 
     state.ac(STATE_FEATURE_FILTER_TYPE, (s, key) => {
+        get_all_data();
+    });
+
+    //
+    // Experiment Combination Set Operator Selector
+    //
+    let setOpSelector = g("set-op-select");
+    setOpSelector.addEventListener(
+        "change",
+        () => {
+            state.u(STATE_COMBO_SET_OP, setOpSelector.value);
+        },
+        false
+    );
+
+    state.ac(STATE_COMBO_SET_OP, (s, key) => {
         get_all_data();
     });
 }

--- a/cegs_portal/search/static/search/js/exp_viz/consts.js
+++ b/cegs_portal/search/static/search/js/exp_viz/consts.js
@@ -21,6 +21,7 @@ export const STATE_ANALYSIS = "state-analysis";
 export const STATE_COVERAGE_TYPE = "state-coverage-type";
 export const STATE_FEATURE_FILTER_TYPE = "state-feature-filter-type";
 export const STATE_LEGEND_INTERVALS = "state-legend-intervals";
+export const STATE_COMBO_SET_OP = "state-combo-set-op";
 
 export const COVERAGE_TYPE_COUNT = "coverage-type-count";
 export const COVERAGE_TYPE_SIG = "coverage-type-sig";

--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -178,10 +178,13 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
         state.u(STATE_SCALE_X, zoomed ? 30 : 1);
         state.u(STATE_SCALE_Y, zoomed ? 15 : 1);
 
-        let body = getFilterBody(state, genome, manifest.chromosomes, [
-            state.g(STATE_CATEGORICAL_FACET_VALUES),
-            state.g(STATE_NUMERIC_FACET_VALUES),
-        ]);
+        let body = getFilterBody(
+            state,
+            genome,
+            manifest.chromosomes,
+            [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
+            null
+        );
 
         postJson(`/search/experiment_coverage?${experimentQuery(state)}`, JSON.stringify(body)).then(
             (response_json) => {
@@ -201,7 +204,13 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
         STATE_CATEGORICAL_FACET_VALUES,
         debounce((s, key) => {
             // Send facet data to server to get filtered data and updated numeric facets
-            let body = getFilterBody(state, genome, manifest.chromosomes, [state.g(STATE_CATEGORICAL_FACET_VALUES)]);
+            let body = getFilterBody(
+                state,
+                genome,
+                manifest.chromosomes,
+                [state.g(STATE_CATEGORICAL_FACET_VALUES)],
+                null
+            );
 
             postJson(`/search/experiment_coverage?${experimentQuery(state)}`, JSON.stringify(body)).then(
                 (response_json) => {
@@ -229,10 +238,13 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
         STATE_NUMERIC_FACET_VALUES,
         debounce((s, key) => {
             // Send facet data to server to get filtered data and updated numeric facets
-            let body = getFilterBody(state, genome, manifest.chromosomes, [
-                state.g(STATE_CATEGORICAL_FACET_VALUES),
-                state.g(STATE_NUMERIC_FACET_VALUES),
-            ]);
+            let body = getFilterBody(
+                state,
+                genome,
+                manifest.chromosomes,
+                [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
+                null
+            );
 
             postJson(`/search/experiment_coverage?${experimentQuery(state)}`, JSON.stringify(body)).then(
                 (response_json) => {

--- a/cegs_portal/search/static/search/js/exp_viz/ui.js
+++ b/cegs_portal/search/static/search/js/exp_viz/ui.js
@@ -161,7 +161,7 @@ export function countFilterControls(state) {
     return filterNodes;
 }
 
-export function getFilterBody(state, genome, chroms, filter_values) {
+export function getFilterBody(state, genome, chroms, filter_values, combo_op) {
     let filters = {
         filters: filter_values,
         chromosomes: genome.map((c) => c.chrom),
@@ -172,7 +172,7 @@ export function getFilterBody(state, genome, chroms, filter_values) {
     }
     try {
         let combinations = state.g(STATE_SELECTED_EXPERIMENTS).map((exp) => exp.join("/"));
-        filters.combinations = combinations.concat(combinations.slice(1).map((_) => "i"));
+        filters.combinations = combinations.concat(combinations.slice(1).map((_) => combo_op));
         filters.combination_features = state.g(STATE_FEATURE_FILTER_TYPE);
     } catch (e) {
         // An "Invalid State Key" exception is expected when this is called from

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -181,7 +181,10 @@
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="svg-icon mr-2"><!--! Font Awesome Free 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M175 389.4c-9.8 16-15 34.3-15 53.1c-10 3.5-20.8 5.5-32 5.5c-53 0-96-43-96-96V64C14.3 64 0 49.7 0 32S14.3 0 32 0H96h64 64c17.7 0 32 14.3 32 32s-14.3 32-32 32V309.9l-49 79.6zM96 64v96h64V64H96zM352 0H480h32c17.7 0 32 14.3 32 32s-14.3 32-32 32V214.9L629.7 406.2c6.7 10.9 10.3 23.5 10.3 36.4c0 38.3-31.1 69.4-69.4 69.4H261.4c-38.3 0-69.4-31.1-69.4-69.4c0-12.8 3.6-25.4 10.3-36.4L320 214.9V64c-17.7 0-32-14.3-32-32s14.3-32 32-32h32zm32 64V224c0 5.9-1.6 11.7-4.7 16.8L330.5 320h171l-48.8-79.2c-3.1-5-4.7-10.8-4.7-16.8V64H384z"/>
             </svg> Multi-Experiment Coverage Information
         </div>
-        <div class="mt-2 italic">The coverage data from the following experiments have been intersected based on their
+        <div class="mt-2 italic">The coverage data from the following experiments have been <select class="intersect-button border-2 p-2 h-10 text-sm" name="set ops" id="set-op-select">
+            <option value="i" selected>intersected</option>
+            <option value="u">unioned</option>
+        </select> based on their
             <select class="intersect-button border-2 p-2 h-10 text-sm" name="views" id="feature-select">
                 <option value="sources">Tested Elements</option>
                 <option value="targets">Genes</option>


### PR DESCRIPTION
Adds a dropdown to the multi-experiment page that allows users to select between unioning and intersecting the experiment coverage data for multiple experiments.

![Screenshot 2024-06-25 at 1 44 26 PM](https://github.com/ReddyLab/cegs-portal/assets/719958/c7ed8938-5830-43bd-a396-44873fb75c77)
![Screenshot 2024-06-25 at 1 44 20 PM](https://github.com/ReddyLab/cegs-portal/assets/719958/8c3c9885-37b0-40d1-a291-9066272b56e8)
