### PR TITLE
Update docker image to fix CVEs

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11.2-slim-bullseye
+ARG PYTHON_VERSION=3.11.9-slim-bullseye
 ARG RUST_VERSION=1.77-bullseye
 
 # define an alias for the specfic python version used in this file.

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11.2-slim-bullseye
+ARG PYTHON_VERSION=3.11.9-slim-bullseye
 ARG RUST_VERSION=1.77-bullseye
 
 # define an alias for the specfic python version used in this file.


### PR DESCRIPTION
CI Scan was failing due to some security vulnerabilities in OS-level libraries, so we have to update the base image.