### PR TITLE
Experiment list facet query

### DIFF
--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -2,63 +2,77 @@ import {e, g, rc} from "../dom.js";
 import {getJson} from "../files.js";
 import {addDragListeners, addSelectListeners} from "./drag_drop.js";
 
+let controller;
+
 export function facetFilterSetup() {
     let facetCheckboxes = g("categorical-facets").querySelectorAll("input[type=checkbox]");
     facetCheckboxes.forEach((checkbox) => {
         checkbox.addEventListener("change", (_event) => {
+            if (controller !== undefined) {
+                controller.abort();
+            }
+
             let facetQuery = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
                 .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
                 .map((i) => `facet=${i.id}`)
                 .join("&");
 
-            getJson(`/search/experiment?${facetQuery}&accept=application/json`).then((response_json) => {
-                let experimentListNode = g("experiment-list");
-                let experimentNodes = response_json["experiments"].map((expr) => {
-                    return e(
-                        "a",
-                        {
-                            href: `/search/experiment/${expr.accession_id}`,
-                            class: "exp-list-content-container-link experiment-summary",
-                            "data-accession": expr.accession_id,
-                            "data-name": expr.name,
-                        },
-                        e(
-                            "div",
-                            {
-                                class: "container",
-                            },
-                            [
-                                e("div", {class: "flex justify-between"}, [
-                                    e("div", {class: "exp-name"}, expr.name),
-                                    e(
-                                        "div",
-                                        {
-                                            class: "select-experiment font-bold text-2xl",
-                                            title: "Select Experiment",
-                                            "data-accession": expr.accession_id,
-                                            "data-name": expr.name,
-                                        },
-                                        "＋"
-                                    ),
-                                ]),
-                                e("div", expr.description),
-                                e("div", {class: "flex justify-between"}, [
-                                    e(
-                                        "div",
-                                        {class: "cell-lines"},
-                                        `Cell Lines: ${expr.biosamples.map((b) => b.cell_line).join(", ")}`
-                                    ),
-                                    e("div", {class: "accession-id"}, expr.accession_id),
-                                ]),
-                            ]
-                        )
-                    );
-                });
-                rc(experimentListNode, experimentNodes);
+            controller = new AbortController();
 
-                addDragListeners();
-                addSelectListeners();
-            });
+            getJson(`/search/experiment?${facetQuery}&accept=application/json`, controller.signal)
+                .then((response_json) => {
+                    let experimentListNode = g("experiment-list");
+                    let experimentNodes = response_json["experiments"].map((expr) => {
+                        return e(
+                            "a",
+                            {
+                                href: `/search/experiment/${expr.accession_id}`,
+                                class: "exp-list-content-container-link experiment-summary",
+                                "data-accession": expr.accession_id,
+                                "data-name": expr.name,
+                            },
+                            e(
+                                "div",
+                                {
+                                    class: "container",
+                                },
+                                [
+                                    e("div", {class: "flex justify-between"}, [
+                                        e("div", {class: "exp-name"}, expr.name),
+                                        e(
+                                            "div",
+                                            {
+                                                class: "select-experiment font-bold text-2xl",
+                                                title: "Select Experiment",
+                                                "data-accession": expr.accession_id,
+                                                "data-name": expr.name,
+                                            },
+                                            "＋",
+                                        ),
+                                    ]),
+                                    e("div", expr.description),
+                                    e("div", {class: "flex justify-between"}, [
+                                        e(
+                                            "div",
+                                            {class: "cell-lines"},
+                                            `Cell Lines: ${expr.biosamples.map((b) => b.cell_line).join(", ")}`,
+                                        ),
+                                        e("div", {class: "accession-id"}, expr.accession_id),
+                                    ]),
+                                ],
+                            ),
+                        );
+                    });
+                    rc(experimentListNode, experimentNodes);
+
+                    addDragListeners();
+                    addSelectListeners();
+                })
+                .catch((err) => {
+                    if (err.name != "AbortError") {
+                        console.error(err.message);
+                    }
+                });
         });
     });
 }

--- a/cegs_portal/search/static/search/js/files.js
+++ b/cegs_portal/search/static/search/js/files.js
@@ -1,10 +1,16 @@
 export function getJson(path) {
-    return fetch(path, {
+    let options = {
         credentials: "include",
         headers: {
             Accept: "application/json",
         },
-    }).then((response) => {
+    };
+
+    if (arguments.length == 2) {
+        options["signal"] = arguments[1];
+    }
+
+    return fetch(path, options).then((response) => {
         if (!response.ok) {
             throw new Error(`${path} fetch failed: ${response.status} ${response.statusText}`);
         }

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11.2-slim-bullseye
+ARG PYTHON_VERSION=3.11.9-slim-bullseye
 ARG RUST_VERSION=1.77-bullseye
 
 # define an alias for the specfic python version used in this file.

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11.2-slim-bullseye
+ARG PYTHON_VERSION=3.11.9-slim-bullseye
 ARG RUST_VERSION=1.77-bullseye
 
 # define an alias for the specfic python version used in this file.


### PR DESCRIPTION
Clicking around on the filter check boxes can cause multiple fetches to be "in flight"
at the same time. These may not necessarily return in the expected order (i.e. the most
resent "state" of the filter might finish before other states). This can result in an experiment
list that doesn't reflect the current state of the facet checkboxes.

This change adds a way to cancel getJson fetches and uses this to cancel previous
facet filter fetches when creating a new one so that only the most recent fetch finishes.