### PR TITLE
Speed up exp coll view tests

### DIFF
--- a/cegs_portal/conftest.py
+++ b/cegs_portal/conftest.py
@@ -1,9 +1,122 @@
+import json
 from typing import Optional
 
 import pytest
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import AnonymousUser, Permission
 from django.db.models import Model
-from django.test import Client
+from django.test import Client, RequestFactory
+
+
+class Response:
+    def __init__(self, response):
+        self.resp = response
+
+    def json(self):
+        return json.loads(self.resp.content)
+
+    def __getattr__(self, method_name):
+        return self.resp.__getattribute__(method_name)
+
+
+class Request:
+    def __init__(self, request):
+        self.req = request
+
+    def request(self, view, *args, **kwargs):
+        return Response(view(self.req, *args, **kwargs))
+
+
+class RequestBuilder:
+    def __init__(
+        self,
+        user_model: Optional[Model] = None,
+        group_model: Optional[Model] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        is_portal_admin: bool = False,
+        permissions: Optional[list[str]] = None,
+    ):
+        self.request_factory = RequestFactory()
+        self.username = username
+        self.password = password
+
+        if user_model is not None and username is not None and password is not None:
+            self.user = user_model.objects.create_user(username=username, password=password)
+            self.user.is_portal_admin = is_portal_admin
+            self.user.save()
+        else:
+            self.user = AnonymousUser()
+
+        if permissions is not None and self.user is not None:
+            perm_objs = list(Permission.objects.filter(codename__in=permissions).all())
+            self.user.user_permissions.add(*perm_objs)
+
+        if group_model is not None:
+            assert not isinstance(self.user, AnonymousUser)
+            self.group = group_model
+            self.user.groups.add(group_model.group)
+        else:
+            self.group = None
+
+    def get(self, *args, **kwargs):
+        request = self.request_factory.get(*args, **kwargs)
+        request.user = self.user
+
+        return Request(request)
+
+    def post(self, *args, **kwargs):
+        request = self.request_factory.post(*args, **kwargs)
+        request.user = self.user
+
+        return Request(request)
+
+    def set_user_experiments(self, experiment_list: list[str]):
+        if isinstance(self.user, AnonymousUser):
+            return
+
+        self.user.experiments = experiment_list
+        self.user.save()
+
+    def set_group_experiments(self, experiment_list: list[str]):
+        if self.group is None:
+            return
+
+        self.group.experiments = experiment_list
+        self.group.save()
+
+    def add_user_experiment_collection(self, experiment_collection: str):
+        if isinstance(self.user, AnonymousUser):
+            return
+
+        self.user.experiment_collections.append(experiment_collection)
+        self.user.save()
+
+    def add_group_experiment_collection(self, experiment_collection: str):
+        if self.group is None:
+            return
+
+        self.group.experiment_collections.append(experiment_collection)
+        self.group.save()
+
+
+@pytest.fixture
+def public_test_client():
+    return RequestBuilder()
+
+
+@pytest.fixture
+def login_test_client(django_user_model):
+    return RequestBuilder(user_model=django_user_model, username="user2", password="bar")
+
+
+@pytest.fixture
+def portal_admin_test_client(django_user_model):
+    return RequestBuilder(user_model=django_user_model, username="user2", password="bar", is_portal_admin=True)
+
+
+@pytest.fixture
+def group_login_test_client(django_user_model, group_extension):  # noqa: F811
+    return RequestBuilder(user_model=django_user_model, group_model=group_extension, username="user3", password="bar")
 
 
 class SearchClient:

--- a/cegs_portal/search/views/v1/tests/test_experiment_collection.py
+++ b/cegs_portal/search/views/v1/tests/test_experiment_collection.py
@@ -1,10 +1,17 @@
 import pytest
-from django.test import Client
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
 
-from cegs_portal.conftest import SearchClient
+from cegs_portal.conftest import RequestBuilder, SearchClient
 from cegs_portal.search.models import ExperimentCollection
+from cegs_portal.search.views.v1.experiment_collection import ExperimentCollectionView
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def view():
+    return ExperimentCollectionView.as_view()
 
 
 def check_experiment_collection(collection: ExperimentCollection, response_json):
@@ -13,99 +20,138 @@ def check_experiment_collection(collection: ExperimentCollection, response_json)
     assert collection.description == response_json["description"]
 
 
-def test_experiment_collection_with_anonymous_client(experiment_collection: ExperimentCollection, client: Client):
-    response = client.get(f"/search/experiment_collection/{experiment_collection.accession_id}")
+def test_experiment_collection_with_public_client(
+    experiment_collection: ExperimentCollection, view, public_test_client: RequestBuilder
+):
+    response = public_test_client.get(f"/search/experiment_collection/{experiment_collection.accession_id}").request(
+        view, expcol_id=experiment_collection.accession_id
+    )
     assert response.status_code == 200
 
-    response = client.get(f"/search/experiment_collection/{experiment_collection.accession_id}?accept=application/json")
+    response = public_test_client.get(
+        f"/search/experiment_collection/{experiment_collection.accession_id}?accept=application/json",
+    ).request(view, expcol_id=experiment_collection.accession_id)
     assert response.status_code == 200
 
     check_experiment_collection(experiment_collection, response.json())
 
 
-def test_fake_experiment_collection_with_anonymous_client(client: Client):
-    response = client.get("/search/experiment_collection/DCPEXCLFFFFFFFFFF")
+def test_experiment_collection_with_public_client_e2e(
+    experiment_collection: ExperimentCollection, public_client: SearchClient
+):
+    response = public_client.get(f"/search/experiment_collection/{experiment_collection.accession_id}")
+    assert response.status_code == 200
+
+    response = public_client.get(
+        f"/search/experiment_collection/{experiment_collection.accession_id}?accept=application/json",
+    )
+    assert response.status_code == 200
+
+    check_experiment_collection(experiment_collection, response.json())
+
+    response = public_client.get("/search/experiment_collection/DCPEXCLFFFFFFFFFF")
+    assert response.status_code == 404
+
+    response = public_client.get("/search/experiment_collection/lkasjdfjsdf")
     assert response.status_code == 404
 
 
+def test_fake_experiment_collection_with_anonymous_client(view, public_test_client: RequestBuilder):
+    faux_id = "DCPEXCLFFFFFFFFFF"
+
+    with pytest.raises(Http404):
+        public_test_client.get(f"/search/experiment_collection/{faux_id}").request(view, expcol_id=faux_id)
+
+
 def test_private_experiment_collection_with_anonymous_client(
-    private_experiment_collection: ExperimentCollection, client: Client
+    private_experiment_collection: ExperimentCollection, view, public_test_client: RequestBuilder
 ):
-    response = client.get(f"/search/experiment_collection/{private_experiment_collection.accession_id}")
+    response = public_test_client.get(
+        f"/search/experiment_collection/{private_experiment_collection.accession_id}"
+    ).request(view, expcol_id=private_experiment_collection.accession_id)
     assert response.status_code == 302
 
 
 def test_private_experiment_collection_with_login_client(
-    private_experiment_collection: ExperimentCollection, login_client: SearchClient
+    private_experiment_collection: ExperimentCollection, view, login_test_client: RequestBuilder
 ):
-    response = login_client.get(f"/search/experiment_collection/{private_experiment_collection.accession_id}")
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        login_test_client.get(f"/search/experiment_collection/{private_experiment_collection.accession_id}").request(
+            view, expcol_id=private_experiment_collection.accession_id
+        )
 
 
 def test_private_experiment_collection_with_private_login_client(
-    private_experiment_collection: ExperimentCollection, login_client: SearchClient
+    private_experiment_collection: ExperimentCollection, view, login_test_client: RequestBuilder
 ):
-    login_client.add_user_experiment_collection(private_experiment_collection.accession_id)
+    login_test_client.add_user_experiment_collection(private_experiment_collection.accession_id)
 
-    response = login_client.get(f"/search/experiment_collection/{private_experiment_collection.accession_id}")
+    response = login_test_client.get(
+        f"/search/experiment_collection/{private_experiment_collection.accession_id}"
+    ).request(view, expcol_id=private_experiment_collection.accession_id)
     assert response.status_code == 200
 
 
 def test_private_experiment_collection_with_private_login_client_no_experiments(
-    private_experiment_collection: ExperimentCollection, login_client: SearchClient
+    private_experiment_collection: ExperimentCollection, view, login_test_client: RequestBuilder
 ):
-    login_client.add_user_experiment_collection(private_experiment_collection.accession_id)
+    login_test_client.add_user_experiment_collection(private_experiment_collection.accession_id)
 
-    response = login_client.get(
+    response = login_test_client.get(
         f"/search/experiment_collection/{private_experiment_collection.accession_id}?accept=application/json"
-    )
+    ).request(view, expcol_id=private_experiment_collection.accession_id)
 
-    json = response.json()
-    assert len(json["experiments"]) == 0
+    assert len(response.json()["experiments"]) == 0
 
 
 def test_private_experiment_collection_with_private_login_client_experiments(
-    private_experiment_collection: ExperimentCollection, login_client: SearchClient
+    private_experiment_collection: ExperimentCollection, view, login_test_client: RequestBuilder
 ):
-    login_client.add_user_experiment_collection(private_experiment_collection.accession_id)
-    login_client.set_user_experiments([expr.accession_id for expr in private_experiment_collection.experiments.all()])
-
-    response = login_client.get(
-        f"/search/experiment_collection/{private_experiment_collection.accession_id}?accept=application/json"
+    login_test_client.add_user_experiment_collection(private_experiment_collection.accession_id)
+    login_test_client.set_user_experiments(
+        [expr.accession_id for expr in private_experiment_collection.experiments.all()]
     )
 
-    json = response.json()
-    assert len(json["experiments"]) == 3
+    response = login_test_client.get(
+        f"/search/experiment_collection/{private_experiment_collection.accession_id}?accept=application/json"
+    ).request(view, expcol_id=private_experiment_collection.accession_id)
+
+    assert len(response.json()["experiments"]) == 3
 
 
 def test_private_experiment_collection_with_admin_client(
-    private_experiment_collection: ExperimentCollection, portal_admin_client: SearchClient
+    private_experiment_collection: ExperimentCollection, view, portal_admin_test_client: RequestBuilder
 ):
-    response = portal_admin_client.get(
+    response = portal_admin_test_client.get(
         f"/search/experiment_collection/{private_experiment_collection.accession_id}?accept=application/json"
-    )
+    ).request(view, expcol_id=private_experiment_collection.accession_id)
     assert response.status_code == 200
 
-    json = response.json()
-    assert len(json["experiments"]) == 3
+    assert len(response.json()["experiments"]) == 3
 
 
 def test_archived_experiment_collection_with_anon_client(
-    archived_experiment_collection: ExperimentCollection, client: Client
+    archived_experiment_collection: ExperimentCollection, view, public_test_client: RequestBuilder
 ):
-    response = client.get(f"/search/experiment_collection/{archived_experiment_collection.accession_id}")
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        public_test_client.get(f"/search/experiment_collection/{archived_experiment_collection.accession_id}").request(
+            view, expcol_id=archived_experiment_collection.accession_id
+        )
 
 
 def test_archived_experiment_collection_with_login_client(
-    archived_experiment_collection: ExperimentCollection, login_client: SearchClient
+    archived_experiment_collection: ExperimentCollection, view, login_test_client: RequestBuilder
 ):
-    response = login_client.get(f"/search/experiment_collection/{archived_experiment_collection.accession_id}")
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        login_test_client.get(f"/search/experiment_collection/{archived_experiment_collection.accession_id}").request(
+            view, expcol_id=archived_experiment_collection.accession_id
+        )
 
 
 def test_archived_experiment_collection_with_admin_client(
-    archived_experiment_collection: ExperimentCollection, portal_admin_client: SearchClient
+    archived_experiment_collection: ExperimentCollection, view, portal_admin_test_client: RequestBuilder
 ):
-    response = portal_admin_client.get(f"/search/experiment_collection/{archived_experiment_collection.accession_id}")
+    response = portal_admin_test_client.get(
+        f"/search/experiment_collection/{archived_experiment_collection.accession_id}"
+    ).request(view, expcol_id=archived_experiment_collection.accession_id)
     assert response.status_code == 200


### PR DESCRIPTION
The "client" is quite slow-- it takes about 2s/test. By using RequestFactory/RequestBuilder we speed this up so all the same tests take about 1s total. That's not fast-fast, but it's much better.

We kept a "client" test to make sure the end-to-end still works.