### PR TITLE
Update Twisted to newer version

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -2,10 +2,10 @@ ARG PYTHON_VERSION=3.11.9-slim-bullseye
 ARG RUST_VERSION=1.77-bullseye
 
 # define an alias for the specfic python version used in this file.
-FROM image-mirror-prod-registry.cloud.duke.edu/library/python:${PYTHON_VERSION} as python
+FROM image-mirror-prod-registry.cloud.duke.edu/library/python:${PYTHON_VERSION} AS python
 
 # Build the rust applications for generating coverage information
-FROM image-mirror-prod-registry.cloud.duke.edu/library/rust:${RUST_VERSION} as rust
+FROM image-mirror-prod-registry.cloud.duke.edu/library/rust:${RUST_VERSION} AS rust
 
 WORKDIR /build
 RUN git clone https://github.com/ReddyLab/ccgr_portal_cov_viz.git
@@ -24,7 +24,7 @@ COPY ./extensions/exp_viz .
 RUN maturin build -b pyo3 -i 3.11 --release
 
 # Python build stage
-FROM python as python-build-stage
+FROM python AS python-build-stage
 
 ARG BUILD_ENVIRONMENT=local
 
@@ -49,14 +49,14 @@ RUN python -m pip wheel --wheel-dir /usr/src/app/wheels -r ${BUILD_ENVIRONMENT}.
 
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM python AS python-run-stage
 
 ARG BUILD_ENVIRONMENT=local
 ARG APP_HOME=/app
 
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV BUILD_ENV ${BUILD_ENVIRONMENT}
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV BUILD_ENV=${BUILD_ENVIRONMENT}
 
 WORKDIR ${APP_HOME}
 

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -2,10 +2,10 @@ ARG PYTHON_VERSION=3.11.9-slim-bullseye
 ARG RUST_VERSION=1.77-bullseye
 
 # define an alias for the specfic python version used in this file.
-FROM image-mirror-prod-registry.cloud.duke.edu/library/python:${PYTHON_VERSION} as python
+FROM image-mirror-prod-registry.cloud.duke.edu/library/python:${PYTHON_VERSION} AS python
 
 # Build the rust applications for generating coverage information
-FROM image-mirror-prod-registry.cloud.duke.edu/library/rust:${RUST_VERSION} as rust
+FROM image-mirror-prod-registry.cloud.duke.edu/library/rust:${RUST_VERSION} AS rust
 
 WORKDIR /build
 RUN git clone https://github.com/ReddyLab/ccgr_portal_cov_viz.git
@@ -25,7 +25,7 @@ RUN maturin build -b pyo3 -i 3.11 --release
 RUN ls /exp_viz/target/wheels
 
 # Python build stage
-FROM python as python-build-stage
+FROM python AS python-build-stage
 
 ARG BUILD_ENVIRONMENT=production
 
@@ -49,14 +49,14 @@ COPY ./requirements .
 RUN python -m pip wheel --wheel-dir /usr/src/app/wheels -r ${BUILD_ENVIRONMENT}.txt
 
 # Python 'run' stage
-FROM python as python-run-stage
+FROM python AS python-run-stage
 
 ARG BUILD_ENVIRONMENT=production
 ARG APP_HOME=/app
 
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV BUILD_ENV ${BUILD_ENVIRONMENT}
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV BUILD_ENV=${BUILD_ENVIRONMENT}
 
 WORKDIR ${APP_HOME}
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,8 @@ redis==4.5.4  # https://github.com/andymccurdy/redis-py
 hiredis==2.2.2  # https://github.com/redis/hiredis-py
 uvicorn[standard]==0.26.0  # https://github.com/encode/uvicorn
 channels==4.0.0  # https://github.com/django/channels
-daphne==4.0.0  # https://github.com/django/daphne
+daphne==4.1.2  # https://github.com/django/daphne
+twisted[tls]>=24.3 # https://twisted.org
 requests==2.32.0  # https://docs.python-requests.org/en/master/
 maturin==0.14.8 # https://maturin.rs
 huey==2.4.5 # https://github.com/coleifer/huey/


### PR DESCRIPTION
The default version of Twisted that gets installed as a dependency of daphne relies on the 'cgi' module. This 'cgi' module will be removed in python 3.13, which will be released soon. This newer version of Twisted has removed usage of that module.