### PR TITLE
Upgrade django to 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Moved to [settings](http://cookiecutter-django.readthedocs.io/en/latest/settings
 
 ## Set up Devlopment Environment
 
-First, clone this repository. This is a Django 4.x project that requires Python >= 3.9. Additionally you'll need at least Node.js 14.17 for CSS auto-reloading and compilation. The database, PostgreSQL, can [downloaded here](https://www.postgresql.org/download/) but the easiest way to set up the database is using Docker compose or, if you're on a Mac, [Postgres.app](https://postgresapp.com).
+First, clone this repository. This is a Django 5.1 project that requires Python >= 3.10. Additionally you'll need at least Node.js 14.17 for CSS auto-reloading and compilation. The database, PostgreSQL, can [downloaded here](https://www.postgresql.org/download/) but the easiest way to set up the database is using Docker compose or, if you're on a Mac, [Postgres.app](https://postgresapp.com).
 
 These instructions are for unix/linux systems. Windows users can follow along if they want to use WSL to run the portal.
 
 ### Pre-reqs
 
--   [python](https://www.python.org) >= 3.9
+-   [python](https://www.python.org) >= 3.10
 -   [docker](http://docker.com)
 -   [Node.js](https://nodejs.dev) >= 14.17
 -   [Rust](https://www.rust-lang.org)

--- a/cegs_portal/search/admin.py
+++ b/cegs_portal/search/admin.py
@@ -35,6 +35,14 @@ admin.site.register(DNAFeature, DNAFeatureAdmin)
 
 
 class FileForm(forms.ModelForm):
+    url = forms.URLField(
+        label="URL",
+        required=False,
+        max_length=200,
+        widget=forms.URLInput(attrs={"class": "vURLField"}),
+        assume_scheme="http",
+    )
+
     class Meta:
         model = File
         fields = (

--- a/cegs_portal/uploads/forms/__init__.py
+++ b/cegs_portal/uploads/forms/__init__.py
@@ -10,9 +10,9 @@ class UploadFileForm(forms.Form):
         label="Experiment Accession ID", max_length=17, validators=[validate_experiment_accession_id]
     )
     experiment_file = forms.FileField(label="Experiment File", required=False)
-    experiment_url = forms.URLField(label="Experiment URL", required=False)
+    experiment_url = forms.URLField(label="Experiment URL", required=False, assume_scheme="http")
     analysis_file = forms.FileField(label="Analysis File", required=False)
-    analysis_url = forms.URLField(label="Analysis URL", required=False)
+    analysis_url = forms.URLField(label="Analysis URL", required=False, assume_scheme="http")
 
     @property
     def helper(self):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -285,8 +285,8 @@ ACCOUNT_ADAPTER = "cegs_portal.users.adapters.AccountAdapter"
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 SOCIALACCOUNT_ADAPTER = "cegs_portal.users.adapters.SocialAccountAdapter"
 
-# https://docs.djangoproject.com/en/4.1/releases/4.1/#forms-4-1
-FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
+# https://docs.djangoproject.com/en/5.1/ref/forms/renderers/
+FORM_RENDERER = "django.forms.renderers.DjangoTemplates"
 
 # huey
 HUEY = {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ numpy==1.26.4  # https://numpy.org
 
 # Django
 # ------------------------------------------------------------------------------
-django==4.2.11  # pyup: < 4.1  # https://www.djangoproject.com/
+django==5.1  # pyup: < 4.1  # https://www.djangoproject.com/
 django-environ==0.9.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.2.0  # https://github.com/jazzband/django-model-utils
 django-allauth==0.52.0  # https://github.com/pennersr/django-allauth

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,7 +31,7 @@ pre-commit==2.13.0  # https://github.com/pre-commit/pre-commit
 # ------------------------------------------------------------------------------
 factory-boy==3.2.1  # https://github.com/FactoryBoy/factory_boy
 
-django-debug-toolbar==3.2.1  # https://github.com/jazzband/django-debug-toolbar
+django-debug-toolbar==4.4.6  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.1.3  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==2.0.0  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django


### PR DESCRIPTION
This upgrades django to 5.1, plus fixes all the deprecation warnings. They mainly had to do with the new "assume_schema" argument to URLField. the argument was added in Django 5.0 with a default of "http" and in 6.0 it will change to "https". I'm not sure we're ready for that to happen, so I explicitly set it to 'http".