### PR TITLE
Experiment page css

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/ui.js
+++ b/cegs_portal/search/static/search/js/exp_viz/ui.js
@@ -30,7 +30,7 @@ export function categoricalFilterControls(facets, default_facets) {
                                 : e("input", {type: "checkbox", id: entry[0], name: facet.name}, []),
                             e("label", {for: entry[0]}, entry[1]),
                         ]);
-                    })
+                    }),
                 ),
             ]);
         });
@@ -88,14 +88,19 @@ export function numericFilterControls(state, facets) {
             sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
         });
 
-        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", sliderLabel), sliderNode]));
+        filterNodes.push(
+            e("div", {class: "h-24 min-w-[12rem]"}, [
+                e("div", sliderLabel),
+                e("div", {class: "px-4 sm:px-0"}, sliderNode),
+            ]),
+        );
     }
 
     sliderNodes.forEach((sliderNode) => {
         sliderNode.noUiSlider.on("slide", function (values, handle) {
             state.u(
                 STATE_NUMERIC_FACET_VALUES,
-                sliderNodes.map((n) => n.noUiSlider.get(true))
+                sliderNodes.map((n) => n.noUiSlider.get(true)),
             );
         });
     });
@@ -146,14 +151,16 @@ export function countFilterControls(state) {
             sliderNode.noUiSlider.updateOptions({tooltips: [false, false]});
         });
 
-        filterNodes.push(e("div", {class: "h-24 w-72"}, [e("div", name), sliderNode]));
+        filterNodes.push(
+            e("div", {class: "h-24 min-w-[12rem]"}, [e("div", name), e("div", {class: "px-4 sm:px-0"}, sliderNode)]),
+        );
     }
 
     sliderNodes.forEach((sliderNode) => {
         sliderNode.noUiSlider.on("slide", function (values, handle) {
             state.u(
                 STATE_COUNT_FILTER_VALUES,
-                sliderNodes.map((n) => n.noUiSlider.get(true))
+                sliderNodes.map((n) => n.noUiSlider.get(true)),
             );
         });
     });

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -168,23 +168,6 @@
     .analysis-button:hover {
          background-color: rgb(229 231 235) !important;
     }
-
-    .responsive-container {
-        background: #ffffff;
-        -webkit-box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
-                box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
-        padding: 20px 30px;
-        border-radius: 10px;
-        margin-bottom: 20px;
-    }
-
-    /* .container {
-        margin-left: -20px;
-        margin-right: -200px;
-    } */
-
-
-
 </style>
 {% endblock %}
 
@@ -201,7 +184,7 @@
 
 {% block content %}
 <div class="flex flex-column justify-center min-w-full">
-    <div class="container min-w-fit max-w-fit sm:w-auto -mx-7 sm:mx-0">
+    <div class="content-container min-w-fit max-w-fit">
         <div class="bg-white border-b">
             <div class="text-2xl font-bold flex items-center justify-center" style="color: rgb(71 85 105);">
                 <span><i class="fa-solid fa-flask-vial mr-1"></i>{{ experiment.name }}
@@ -258,7 +241,7 @@
     </div>
 </div>
 
-<div class="min-w-full">
+<div class="min-w-full max-w-full">
     <div class="flex flex-column justify-center">
         <ul
             class="mb-5 flex list-none flex-col flex-wrap border-b-0 pl-0 md:flex-row tab-bar"
@@ -340,10 +323,10 @@
         aria-labelledby="tabs-overview-tab"
         data-te-tab-active
     >
-        <div class="flex flex-col md:flex-row mx-auto">
+        <div class="flex flex-row gap-x-10">
             <div id="chrom-data-filters" class="basis-1/4">
                 <!-- content section container for facet side bar -->
-                <div class="facet-content-section responsive-container sm:w-auto -mx-7 sm:mx-0">
+                <div class="facet-content-section content-container sm:w-auto -mx-7 sm:mx-0">
                     <div class="text-slate-500 flex justify-center">
                         <span id="chrom-data-header" class="text-xl font-bold"></span
                         ><span class="bi bi-layers-half ml-2"></span>
@@ -354,7 +337,7 @@
                     <div id="chrom-data-counts"></div>
                 </div>
 
-                <div class="facet-content-section responsive-container sm:w-auto -mx-7 sm:mx-0">
+                <div class="facet-content-section content-container sm:w-auto -mx-7 sm:mx-0">
                     <form name="regionUploadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="regionFile">Highlight Regions</label>
@@ -366,7 +349,7 @@
                 </div>
 
                 {% if logged_in %}
-                <div class="facet-content-section responsive-container sm:w-auto -mx-7 sm:mx-0">
+                <div class="facet-content-section content-container sm:w-auto -mx-7 sm:mx-0">
                     <form name="dataDownloadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="dataDlAll">Download All Selected Data*</label>
@@ -387,8 +370,8 @@
                 {% endif %}
             </div>
 
-            <div class="basis-3/4 container bg-transparent border-none shadow-none lg:w-auto pt-0 pb-0 mt-0 mb-0">
-                <div class="responsive-container sm:w-auto -mx-14 sm:mx-0 overflow-x-auto">
+            <div class="content-container basis-3/4">
+                <div class="sm:w-auto sm:mx-0 overflow-x-auto">
                 <!-- content section container for ChromCov -->
                     <div class="flex flex-row sm:flex-wrap gap-x-4 items-center">
                         <div id="chrom-data-legend"></div>
@@ -412,59 +395,57 @@
         </div>
     </div>
     <div
-        class="hidden opacity-0 transition-opacity duration-150 ease-linear data-[te-tab-active]:block"
+        class="hidden opacity-0 transition-opacity duration-150 ease-linear sm:w-auto data-[te-tab-active]:block"
         id="tabs-details"
         role="tabpanel"
         aria-labelledby="tabs-details-tab"
     >
-        <div class="flex justify-center">
-            <div class="container min-w-fit max-w-fit sm:w-auto -mx-7 sm:mx-0">
-                <div class="min-w-full">
-                    <div class="bg-white border-b">
-                        <div class="text-xl text-slate-500 font-bold px-6 py-4 text-left">Description</div>
-                        <div class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-                            {{ experiment.description }}
-                        </div>
+        <div class="content-container min-w-fit max-w-fit  flex justify-center">
+            <div class="min-w-full">
+                <div class="bg-white border-b">
+                    <div class="text-xl text-slate-500 font-bold mb-4 text-left">Description</div>
+                    <div class="text-sm font-medium text-gray-900 mb-4 text-left">
+                        {{ experiment.description }}
                     </div>
-                    <div class="bg-gray-100 border-b flex items-center">
-                        <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Assay</div>
-                        <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
-                            {{ experiment.experiment_type }}
-                        </div>
+                </div>
+                <div class="bg-gray-100 border-b flex items-center">
+                    <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Assay</div>
+                    <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
+                        {{ experiment.experiment_type }}
                     </div>
-                    <div class="bg-white border-b flex items-center">
-                        <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Cell Lines</div>
-                        <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
-                            {{ experiment.cell_lines|join:", " }}
-                        </div>
+                </div>
+                <div class="bg-white border-b flex items-center">
+                    <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Cell Lines</div>
+                    <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
+                        {{ experiment.cell_lines|join:", " }}
                     </div>
-                    <div class="bg-gray-100 border-b flex items-center">
-                        <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Tissue Type</div>
-                        <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
-                            {{ experiment.tissue_types|join:", " }}
-                        </div>
+                </div>
+                <div class="bg-gray-100 border-b flex items-center">
+                    <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Tissue Type</div>
+                    <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
+                        {{ experiment.tissue_types|join:", " }}
                     </div>
-                    <div class="bg-white border-b flex items-center">
-                        <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Assembly</div>
-                        <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
-                            {{ experiment.genome_assembly }}
-                        </div>
+                </div>
+                <div class="bg-white border-b flex items-center">
+                    <div class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 w-1/4">Assembly</div>
+                    <div class="text-sm text-gray-500 font-light px-6 py-4 whitespace-nowrap italic ml-4 w-3/4">
+                        {{ experiment.genome_assembly }}
                     </div>
                 </div>
             </div>
-            </div>
         </div>
+    </div>
     <div
         class="hidden opacity-0 transition-opacity duration-150 ease-linear data-[te-tab-active]:block"
         id="tabs-files"
         role="tabpanel"
         aria-labelledby="tabs-files-tab"
     >
-    <div class="container bg-transparent border-none shadow-none mx-auto mb-0 mt-0 p-0">
-        <div class="responsive-container overflow-x-auto sm:w-auto -mx-14 sm:mx-0 mt-0">
+        <div class="content-container mx-auto">
             <div class="text-xl font-bold" style="color: rgb(100 116 139);">
                 Data Files <i class="bi bi-folder-symlink-fill"></i>
             </div>
+            <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-400" id="dataFilesTable">
                 <thead class="bg-gray-700">
                     <tr>
@@ -499,15 +480,15 @@
                 </tbody>
                 {% endfor %} {% endif %}
             </table>
+            </div>
         </div>
-    </div>
 
-    <div class="container bg-transparent border-none shadow-none mx-auto mb-0 mt-0 p-0">
-        <div class="responsive-container overflow-x-auto sm:w-auto -mx-14 sm:mx-0">
+        <div class="content-container mx-auto overflow-x-auto ">
+            <div class="text-xl font-bold" style="color: rgb(100 116 139);">
+                Other Files <i class="bi bi-folder-symlink-fill"></i>
+            </div>
+            <div class="overflow-x-auto">
             <table class="divide-y divide-gray-300" id="otherFilesTable">
-                <div class="text-xl font-bold" style="color: rgb(100 116 139);">
-                    Other Files <i class="bi bi-folder-symlink-fill"></i>
-                </div>
                 <thead class="bg-gray-700">
                     <tr>
                         <th class="px-6 py-2 text-xs text-white">File Name</th>
@@ -547,8 +528,8 @@
                 </tbody>
                 {% endfor %} {% endif %}
             </table>
+            </div>
         </div>
-    </div>
     </div>
     <div
         class="hidden opacity-0 transition-opacity duration-150 ease-linear data-[te-tab-active]:block"
@@ -557,18 +538,14 @@
         aria-labelledby="tabs-qc-graphs-tab"
     >
         <div
-            class="container text-xl font-bold mx-auto bg-transparent border-none shadow-none p-0"
+            class="content-container mx-auto text-xl font-bold max-w-fit"
             style="color: rgb(100 116 139);"
         >
-            <div class="responsive-container sm:w-auto -mx-14 sm:mx-0">
             QC Graphs <i class="bi bi-file-bar-graph-fill"></i>
             <div class="title-separator my-3.5"></div>
-            <div class="flex justify-center">
-                <div class="flex flex-nowrap my-3.5 w-full overflow-x-auto">
-                    <div id="ncells_histogram" class="mr-4"></div>
-                    <div id="ngrna_histogram"></div>
-                </div>
-            </div>
+            <div class="flex flex-nowrap my-3.5 max-w-fit overflow-x-auto">
+                <div id="ncells_histogram" class="mr-4"></div>
+                <div id="ngrna_histogram"></div>
             </div>
         </div>
     </div>
@@ -578,18 +555,15 @@
         role="tabpanel"
         aria-labelledby="tabs-analysis"
     >
-    <div
-        class="container text-xl font-bold mx-auto bg-transparent border-none shadow-none p-0"
-        style="color: rgb(100 116 139);"
-    >
-        <div class="responsive-container sm:w-auto -mx-14 sm:mx-0">
+        <div
+            class="content-container mx-auto text-xl font-bold max-w-fit"
+            style="color: rgb(100 116 139);"
+        >
             Analysis <i class="bi bi-pie-chart-fill"></i>
             <div class="title-separator my-3.5"></div>
-            <div class="flex justify-center">
-                <div class="flex flex-nowrap my-3.5 overflow-x-auto">
-                    <div id="volcano" class="mr-4"></div>
-                    <div id="uniform_qqplot" class="mr-4"></div>
-                </div>
+            <div class="flex flex-nowrap my-3.5 max-w-fit overflow-x-auto">
+                <div id="volcano" class="mr-4"></div>
+                <div id="uniform_qqplot" class="mr-4"></div>
             </div>
         </div>
         </div>

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -388,16 +388,14 @@
                         </select>
                     </div>
                 </div>
-                <div class="max-w-full">
-                    <div class="overflow-x-auto">
-                        <div id="chrom-data" class="min-w-[768px] md:min-w-0"></div>
-                    </div>
+                <div class="overflow-x-auto">
+                    <div id="chrom-data" class="min-w-[768px] md:min-w-0"></div>
                 </div>
             </div>
         </div>
     </div>
     <div
-        class="hidden opacity-0 transition-opacity duration-150 ease-linear sm:w-auto data-[te-tab-active]:block"
+        class="hidden opacity-0 transition-opacity duration-150 ease-linear data-[te-tab-active]:block"
         id="tabs-details"
         role="tabpanel"
         aria-labelledby="tabs-details-tab"

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -323,10 +323,10 @@
         aria-labelledby="tabs-overview-tab"
         data-te-tab-active
     >
-        <div class="flex flex-row gap-x-10">
+        <div class="flex flex-col md:flex-row max-w-full gap-x-10">
             <div id="chrom-data-filters" class="basis-1/4">
                 <!-- content section container for facet side bar -->
-                <div class="facet-content-section content-container sm:w-auto -mx-7 sm:mx-0">
+                <div class="facet-content-section content-container">
                     <div class="text-slate-500 flex justify-center">
                         <span id="chrom-data-header" class="text-xl font-bold"></span
                         ><span class="bi bi-layers-half ml-2"></span>
@@ -337,7 +337,7 @@
                     <div id="chrom-data-counts"></div>
                 </div>
 
-                <div class="facet-content-section content-container sm:w-auto -mx-7 sm:mx-0">
+                <div class="facet-content-section content-container">
                     <form name="regionUploadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="regionFile">Highlight Regions</label>
@@ -349,7 +349,7 @@
                 </div>
 
                 {% if logged_in %}
-                <div class="facet-content-section content-container sm:w-auto -mx-7 sm:mx-0">
+                <div class="facet-content-section content-container">
                     <form name="dataDownloadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="dataDlAll">Download All Selected Data*</label>
@@ -371,25 +371,27 @@
             </div>
 
             <div class="content-container basis-3/4">
-                <div class="sm:w-auto sm:mx-0 overflow-x-auto">
                 <!-- content section container for ChromCov -->
-                    <div class="flex flex-row sm:flex-wrap gap-x-4 items-center">
-                        <div id="chrom-data-legend"></div>
-                        <div class="flex flex-col">
-                            <div id="reo-count"></div>
-                            <div id="source-count"></div>
-                            <div id="target-count"></div>
-                        </div>
-                        <div>
-                            <label for="covSelect">View:</label>
-                            <select class="global-button border-2 p-2 h-10 text-sm" name="views" id="covSelect">
-                                <option value="sig">Largest Significance</option>
-                                <option value="effect">Greatest Effect Size</option>
-                                <option value="count">{{ experiment.get_source_type_display }}/Gene Count</option>
-                            </select>
-                        </div>
+                <div class="flex flex-row flex-wrap gap-x-4 items-center">
+                    <div id="chrom-data-legend"></div>
+                    <div class="flex flex-col">
+                        <div id="reo-count"></div>
+                        <div id="source-count"></div>
+                        <div id="target-count"></div>
                     </div>
-                    <div id="chrom-data"></div>
+                    <div>
+                        <label for="covSelect">View:</label>
+                        <select class="global-button border-2 p-2 h-10 text-sm" name="views" id="covSelect">
+                            <option value="sig">Largest Significance</option>
+                            <option value="effect">Greatest Effect Size</option>
+                            <option value="count">{{ experiment.get_source_type_display }}/Gene Count</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="max-w-full">
+                    <div class="overflow-x-auto">
+                        <div id="chrom-data" class="min-w-[768px] md:min-w-0"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -400,7 +402,7 @@
         role="tabpanel"
         aria-labelledby="tabs-details-tab"
     >
-        <div class="content-container min-w-fit max-w-fit  flex justify-center">
+        <div class="content-container min-w-fit max-w-fit flex justify-center">
             <div class="min-w-full">
                 <div class="bg-white border-b">
                     <div class="text-xl text-slate-500 font-bold mb-4 text-left">Description</div>

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -768,6 +768,15 @@ a:visited {
   margin-bottom: 20px;
 }
 
+.content-container {
+  background: #ffffff;
+  -webkit-box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
+          box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
+  padding: 10px 10px;
+  border-radius: 10px;
+  margin-bottom: 20px;
+}
+
 .centered-container {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -1155,6 +1164,10 @@ input[type="submit"], input[type="button"], button {
   margin-bottom: 0.875rem;
 }
 
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
 .mb-5 {
   margin-bottom: 1.25rem;
 }
@@ -1193,10 +1206,6 @@ input[type="submit"], input[type="button"], button {
 
 .mr-4 {
   margin-right: 1rem;
-}
-
-.mt-0 {
-  margin-top: 0px;
 }
 
 .mt-1 {
@@ -1632,10 +1641,6 @@ input[type="submit"], input[type="button"], button {
   border-top-width: 0px;
 }
 
-.border-none {
-  border-style: none;
-}
-
 .border-blue-700 {
   --tw-border-opacity: 1;
   border-color: rgb(29 78 216 / var(--tw-border-opacity));
@@ -1670,10 +1675,6 @@ input[type="submit"], input[type="button"], button {
   background-color: rgb(241 245 249 / var(--tw-bg-opacity));
 }
 
-.bg-transparent {
-  background-color: transparent;
-}
-
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
@@ -1685,10 +1686,6 @@ input[type="submit"], input[type="button"], button {
 
 .fill-current {
   fill: currentColor;
-}
-
-.p-0 {
-  padding: 0px;
 }
 
 .p-2 {
@@ -1707,9 +1704,9 @@ input[type="submit"], input[type="button"], button {
   padding: 1.5rem;
 }
 
-.px-10 {
-  padding-left: 2.5rem;
-  padding-right: 2.5rem;
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 .px-2 {
@@ -1762,10 +1759,6 @@ input[type="submit"], input[type="button"], button {
   padding-bottom: 1rem;
 }
 
-.pb-0 {
-  padding-bottom: 0px;
-}
-
 .pb-3 {
   padding-bottom: 0.75rem;
 }
@@ -1796,10 +1789,6 @@ input[type="submit"], input[type="button"], button {
 
 .pr-8 {
   padding-right: 2rem;
-}
-
-.pt-0 {
-  padding-top: 0px;
 }
 
 .pt-3 {
@@ -1964,13 +1953,6 @@ input[type="submit"], input[type="button"], button {
 .shadow {
   --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
-  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-          box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.shadow-none {
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
   -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
           box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
@@ -2300,6 +2282,12 @@ fieldset legend {
             flex-grow: 0;
     padding: 0;
     overflow-y: visible;
+  }
+}
+
+@media (min-width: 640px) {
+  .content-container {
+    padding: 20px 30px;
   }
 }
 
@@ -2956,6 +2944,11 @@ fieldset legend {
 
   .sm\:p-8 {
     padding: 2rem;
+  }
+
+  .sm\:px-10 {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
   }
 }
 

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1099,16 +1099,6 @@ input[type="submit"], input[type="button"], button {
   top: 0px;
 }
 
-.-mx-14 {
-  margin-left: -3.5rem;
-  margin-right: -3.5rem;
-}
-
-.-mx-7 {
-  margin-left: -1.75rem;
-  margin-right: -1.75rem;
-}
-
 .mx-1 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
@@ -1326,10 +1316,6 @@ input[type="submit"], input[type="button"], button {
   width: 1.75rem;
 }
 
-.w-72 {
-  width: 18rem;
-}
-
 .w-\[100px\] {
   width: 100px;
 }
@@ -1344,6 +1330,14 @@ input[type="submit"], input[type="button"], button {
 
 .w-full {
   width: 100%;
+}
+
+.min-w-\[12rem\] {
+  min-width: 12rem;
+}
+
+.min-w-\[768px\] {
+  min-width: 768px;
 }
 
 .min-w-fit {
@@ -2285,6 +2279,8 @@ fieldset legend {
   }
 }
 
+/* Tailwind breakpoint "sm" */
+
 @media (min-width: 640px) {
   .content-container {
     padding: 20px 30px;
@@ -2924,11 +2920,6 @@ fieldset legend {
 }
 
 @media (min-width: 640px) {
-  .sm\:mx-0 {
-    margin-left: 0px;
-    margin-right: 0px;
-  }
-
   .sm\:w-auto {
     width: auto;
   }
@@ -2937,13 +2928,13 @@ fieldset legend {
     max-width: 28rem;
   }
 
-  .sm\:flex-wrap {
-    -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-  }
-
   .sm\:p-8 {
     padding: 2rem;
+  }
+
+  .sm\:px-0 {
+    padding-left: 0px;
+    padding-right: 0px;
   }
 
   .sm\:px-10 {
@@ -2955,6 +2946,10 @@ fieldset legend {
 @media (min-width: 768px) {
   .md\:mt-0 {
     margin-top: 0px;
+  }
+
+  .md\:min-w-0 {
+    min-width: 0px;
   }
 
   .md\:flex-row {

--- a/cegs_portal/static/css/project.css.tw
+++ b/cegs_portal/static/css/project.css.tw
@@ -110,10 +110,18 @@ fieldset legend {
     margin-bottom: 20px;
   }
 
+  .content-container {
+    background: #ffffff;
+    box-shadow: 0px 2px 5px 4px rgba(0, 0, 0, 0.1);
+    padding: 10px 10px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+  }
+
   .centered-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   h1 {
@@ -530,6 +538,12 @@ fieldset legend {
     flex-grow: 0;
     padding: 0;
     overflow-y: visible;
+  }
+}
+
+@media (min-width: 640px) {
+  .content-container {
+    padding: 20px 30px;
   }
 }
 

--- a/cegs_portal/static/css/project.css.tw
+++ b/cegs_portal/static/css/project.css.tw
@@ -541,6 +541,7 @@ fieldset legend {
   }
 }
 
+/* Tailwind breakpoint "sm" */
 @media (min-width: 640px) {
   .content-container {
     padding: 20px 30px;

--- a/cegs_portal/templates/base.html
+++ b/cegs_portal/templates/base.html
@@ -159,7 +159,7 @@
               </nav>
           </div>
 
-            <div class="grow flex flex-col items-center px-10">
+            <div class="grow flex flex-col items-center px-1 sm:px-10">
                 {% block content %}
                 <p>Use this document as a way to quick start any new project.</p>
                 {% endblock content %}


### PR DESCRIPTION
* Sliders expand to with of container
* body padding is 1 on small screens
* QC/Analysis graph boxes are centered and the width of the content on larger screens
* File tables still show container padding when overflowing their containers
* Description margins/padding is 0
* Container padding is 10x10 on small screens and 20x30 (or 30x20, whichever) on all other screens