### PR TITLE
Fix search view model tests

### DIFF
--- a/cegs_portal/search/view_models/v1/tests/test_search.py
+++ b/cegs_portal/search/view_models/v1/tests/test_search.py
@@ -4,7 +4,7 @@ from cegs_portal.search.models import ChromosomeLocation
 from cegs_portal.search.view_models.v1.search import Search
 from cegs_portal.users.models import UserType
 
-pytestmark = pytest.mark.django_db(transaction=True)
+pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.usefixtures("reg_effects")
@@ -12,11 +12,11 @@ def test_sig_reo_loc_search():
     result = Search.sig_reo_loc_search(ChromosomeLocation("chr1", "1", "1000000"))
 
     assert len(result) == 1
-    assert len(result[0][1]) == 2
+    assert len(result[0][1]) == 1
 
 
 def test_private_sig_reo_loc_search(private_reg_effects):
-    _, _, _, _, _, _, experiment = private_reg_effects
+    _, _, _, _, _, experiment = private_reg_effects
     result = Search.sig_reo_loc_search(ChromosomeLocation("chr1", "1", "1000000"))
 
     assert len(result) == 0
@@ -26,17 +26,17 @@ def test_private_sig_reo_loc_search(private_reg_effects):
     )
 
     assert len(result) == 1
-    assert len(result[0][1]) == 2
+    assert len(result[0][1]) == 1
 
 
 @pytest.mark.usefixtures("reg_effects")
 def test_feature_sig_reos():
     result = Search.feature_sig_reos(ChromosomeLocation("chr1", "1", "1000000"), "hg38", [])
-    assert len(result) == 2
+    assert len(result) == 1
 
 
 def test_private_feature_sig_reos(private_reg_effects):
-    _, _, _, _, _, _, experiment = private_reg_effects
+    _, _, _, _, _, experiment = private_reg_effects
 
     result = Search.feature_sig_reos(ChromosomeLocation("chr1", "1", "1000000"), "hg38", [])
     assert len(result) == 0
@@ -48,7 +48,7 @@ def test_private_feature_sig_reos(private_reg_effects):
         user_type=UserType.LOGGED_IN,
         private_experiments=[experiment.accession_id],
     )
-    assert len(result) == 2
+    assert len(result) == 1
 
 
 @pytest.mark.usefixtures("private_reg_effects")
@@ -57,4 +57,4 @@ def test_admin_feature_sig_reos():
     assert len(result) == 0
 
     result = Search.feature_sig_reos(ChromosomeLocation("chr1", "1", "1000000"), "hg38", [], user_type=UserType.ADMIN)
-    assert len(result) == 2
+    assert len(result) == 1


### PR DESCRIPTION
These tests were in a file that wasn't discovered by pytest due to the name not starting with "test_". We rename this file so pytest picks it up.

Since it hadn't been run due to the aformentioned issue when "target only" reg effects were removed from the reg_effects fixture the tests broke but hadn't been fixed.