### PR TITLE
Adds facets to upload experiment tests

### DIFF
--- a/cegs_portal/search/models/__init__.py
+++ b/cegs_portal/search/models/__init__.py
@@ -6,9 +6,11 @@ from .experiment import (
     Analysis,
     Biosample,
     CellLine,
+    CRISPRModulationType,
     Experiment,
     ExperimentCollection,
     ExperimentDataFile,
+    GenomeAssemblyType,
     Pipeline,
     TissueType,
 )

--- a/cegs_portal/search/models/experiment.py
+++ b/cegs_portal/search/models/experiment.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 
 from django.contrib.postgres.fields import DateRangeField
 from django.db import models
@@ -41,6 +41,16 @@ class Biosample(Accessioned):
         return f"{self.name} ({self.cell_line_name})"
 
 
+class CRISPRModulationType(StrEnum):
+    CRISPRA = "CRISPRa"
+    CRISPRI = "CRISPRi"
+
+
+class GenomeAssemblyType(StrEnum):
+    HG19 = "hg19"
+    HG38 = "hg38"
+
+
 class Experiment(Accessioned, Faceted, AccessControlled):
     class Meta(Accessioned.Meta):
         indexes = [
@@ -52,8 +62,8 @@ class Experiment(Accessioned, Faceted, AccessControlled):
         SOURCE_TYPES = "Experiment Source Type"
         CELL_LINE = "Cell Line"
         TISSUE_TYPE = "Tissue Type"
-        GENOME_ASSEMBLY = "Genome Assembly"
-        CRISPR_MODULATION = "CRISPR Modulation"
+        GENOME_ASSEMBLY = "Genome Assembly"  # GenomeAssemblyType
+        CRISPR_MODULATION = "CRISPR Modulation"  # CRISPRModulationType
 
     description = models.CharField(max_length=4096, null=True, blank=True)
     experiment_type = models.CharField(max_length=100, null=True, blank=True)

--- a/cegs_portal/uploads/views/tests/conftest.py
+++ b/cegs_portal/uploads/views/tests/conftest.py
@@ -3,11 +3,13 @@ from psycopg2.extras import NumericRange
 
 from cegs_portal.conftest import SearchClient
 from cegs_portal.search.models import (
+    CRISPRModulationType,
     DNAFeature,
     DNAFeatureType,
     EffectObservationDirectionType,
     Experiment,
     Facet,
+    GenomeAssemblyType,
     GrnaType,
     PromoterType,
     RegulatoryEffectObservation,
@@ -27,7 +29,7 @@ class MockExperimentMetadata:
 
     def __init__(self):
         self.experiment = ExperimentFactory()
-        self.assay = "scCERES"
+        self.assay = "Perturb-Seq"
         self.accession_id = self.experiment.accession_id
         self.tested_elements_file = FileMetadata(
             {
@@ -117,6 +119,22 @@ def facets() -> list[Facet]:
     _ = FacetValueFactory(facet=tissue_type_facet, value="Stem")
     _ = FacetValueFactory(facet=tissue_type_facet, value="Bone Marrow")
     _ = FacetValueFactory(facet=tissue_type_facet, value="T Cell")
+
+    # The reason there's a check to see if the crispr and assembly facets already exist is because
+    # they are created when pytest is run with --create-db but deleted at the end of the run. So
+    # we don't want to create them when pytest is run with --create-db, but do want to create them
+    # otherwise.
+    crispr = Facet.objects.filter(name=Experiment.Facet.CRISPR_MODULATION.value).first()
+    if crispr is None:
+        crispr_facet = FacetFactory(description="", name=Experiment.Facet.CRISPR_MODULATION.value)
+        _ = FacetValueFactory(facet=crispr_facet, value=CRISPRModulationType.CRISPRA)
+        _ = FacetValueFactory(facet=crispr_facet, value=CRISPRModulationType.CRISPRI)
+
+    assembly = Facet.objects.filter(name=Experiment.Facet.GENOME_ASSEMBLY.value).first()
+    if assembly is None:
+        assembly_facet = FacetFactory(description="", name=Experiment.Facet.GENOME_ASSEMBLY.value)
+        _ = FacetValueFactory(facet=assembly_facet, value=GenomeAssemblyType.HG19)
+        _ = FacetValueFactory(facet=assembly_facet, value=GenomeAssemblyType.HG38)
 
     return [
         direction_facet,


### PR DESCRIPTION
Without these facets these tests fail. The reason there's a check to see if the facets already exist is because they are created when pytest created the DB (i.e. `pytest --create-db` is run) but are deleted when pytest is done. So the shouldn't be created when pytest is run with --create-db but they should otherwise.