### PR TITLE
Allow users to upload data from compressed archives

### DIFF
--- a/cegs_portal/search/models/dna_feature.py
+++ b/cegs_portal/search/models/dna_feature.py
@@ -53,6 +53,7 @@ class DNAFeature(Accessioned, Faceted, AccessControlled):
         (str(DNAFeatureType.DHS), DNAFeatureType.DHS.value),
         (str(DNAFeatureType.GRNA), DNAFeatureType.GRNA.value),
         (str(DNAFeatureType.CAR), DNAFeatureType.CAR.value),
+        (str(DNAFeatureType.CRE), DNAFeatureType.CRE.value),
     )
 
     cell_line = models.CharField(max_length=50, null=True, blank=True)

--- a/cegs_portal/uploads/data_loading/analysis.py
+++ b/cegs_portal/uploads/data_loading/analysis.py
@@ -75,11 +75,16 @@ class Analysis:
             facet.value: facet.id for facet in FacetValue.objects.filter(facet_id=dir_facet.id).all()
         }
 
-    def load(self):
+    def load(self, results_file_location=None):
         source_type = FeatureType(self.metadata.source_type)
 
         results_file = self.metadata.results
-        results_tsv = InternetFile(results_file.file_location).file
+
+        if results_file_location is None:
+            results_tsv = InternetFile(results_file.file_location).file
+        else:
+            results_tsv = InternetFile(results_file_location).file
+
         reader = csv.DictReader(results_tsv, delimiter=results_file.delimiter(), quoting=csv.QUOTE_NONE)
         observations: list[ObservationRow] = []
         for line in reader:

--- a/cegs_portal/uploads/data_loading/compressed.py
+++ b/cegs_portal/uploads/data_loading/compressed.py
@@ -8,20 +8,17 @@ from .experiment_metadata import AnalysisMetadata, ExperimentMetadata
 
 
 def load(compressed_file, experiment_accession_id):
-    with tarfile.open(fileobj=compressed_file, mode="r:gz") as data_files:
-        data_files.list()
+    with tarfile.open(fileobj=compressed_file, mode="r:gz") as data_files, tempfile.TemporaryDirectory() as dir_name:
+        data_files.extractall(dir_name)
 
-        with tempfile.TemporaryDirectory() as dir_name:
-            data_files.extractall(dir_name)
+        experiment_filename = os.path.join(dir_name, "experiment.json")
+        expr_data_filename = os.path.join(dir_name, "tested_elements.tsv")
+        analysis_filename = os.path.join(dir_name, "analysis001.json")
+        analysis_data_filename = os.path.join(dir_name, "observations.tsv")
 
-            experiment_filename = os.path.join(dir_name, "experiment.json")
-            expr_data_filename = os.path.join(dir_name, "tested_elements.tsv")
-            analysis_filename = os.path.join(dir_name, "analysis001.json")
-            analysis_data_filename = os.path.join(dir_name, "observations.tsv")
+        metadata = ExperimentMetadata.load(experiment_filename, experiment_accession_id)
+        Experiment(metadata).load(expr_data_filename).save()
 
-            metadata = ExperimentMetadata.load(experiment_filename, experiment_accession_id)
-            Experiment(metadata).load(expr_data_filename).save()
-
-            metadata = AnalysisMetadata.load(analysis_filename, experiment_accession_id)
-            analysis = Analysis(metadata).load(analysis_data_filename).save()
-            return analysis.accession_id
+        metadata = AnalysisMetadata.load(analysis_filename, experiment_accession_id)
+        analysis = Analysis(metadata).load(analysis_data_filename).save()
+        return analysis.accession_id

--- a/cegs_portal/uploads/data_loading/compressed.py
+++ b/cegs_portal/uploads/data_loading/compressed.py
@@ -1,0 +1,27 @@
+import os.path
+import tarfile
+import tempfile
+
+from .analysis import Analysis
+from .experiment import Experiment
+from .experiment_metadata import AnalysisMetadata, ExperimentMetadata
+
+
+def load(compressed_file, experiment_accession_id):
+    with tarfile.open(fileobj=compressed_file, mode="r:gz") as data_files:
+        data_files.list()
+
+        with tempfile.TemporaryDirectory() as dir_name:
+            data_files.extractall(dir_name)
+
+            experiment_filename = os.path.join(dir_name, "experiment.json")
+            expr_data_filename = os.path.join(dir_name, "tested_elements.tsv")
+            analysis_filename = os.path.join(dir_name, "analysis001.json")
+            analysis_data_filename = os.path.join(dir_name, "observations.tsv")
+
+            metadata = ExperimentMetadata.load(experiment_filename, experiment_accession_id)
+            Experiment(metadata).load(expr_data_filename).save()
+
+            metadata = AnalysisMetadata.load(analysis_filename, experiment_accession_id)
+            analysis = Analysis(metadata).load(analysis_data_filename).save()
+            return analysis.accession_id

--- a/cegs_portal/uploads/data_loading/experiment_metadata.py
+++ b/cegs_portal/uploads/data_loading/experiment_metadata.py
@@ -50,17 +50,17 @@ class InternetFile:
         else:
             self.file = file
 
-    def _file_load(cls, file_path: str):
+    def _file_load(self, file_path: str):
         return open(file_path, "r")
 
-    def _http_load(cls, file_url: str):
+    def _http_load(self, file_url: str):
         with requests.get(file_url) as response:
             if not response.ok:
                 raise ValueError(f"Unable to download {file_url}: {response.status_code} {response.reason}")
 
             return StringIO(response.text)
 
-    def _s3_load(cls, file_url: str):
+    def _s3_load(self, file_url: str):
         return open(file_url, "r")
 
     def close(self):

--- a/cegs_portal/uploads/forms/__init__.py
+++ b/cegs_portal/uploads/forms/__init__.py
@@ -7,12 +7,14 @@ from cegs_portal.uploads.validators import validate_experiment_accession_id
 
 class UploadFileForm(forms.Form):
     experiment_accession = forms.CharField(
-        label="Experiment Accession ID", max_length=17, validators=[validate_experiment_accession_id]
+        label="Experiment Accession ID", max_length=17, validators=[validate_experiment_accession_id], required=False
     )
     experiment_file = forms.FileField(label="Experiment File", required=False)
     experiment_url = forms.URLField(label="Experiment URL", required=False, assume_scheme="http")
     analysis_file = forms.FileField(label="Analysis File", required=False)
     analysis_url = forms.URLField(label="Analysis URL", required=False, assume_scheme="http")
+    full_file = forms.FileField(label="Full Experiment Information File", required=False)
+    full_url = forms.URLField(label="Full Experiment Information URL", required=False, assume_scheme="http")
 
     @property
     def helper(self):
@@ -25,6 +27,13 @@ class UploadFileForm(forms.Form):
                 '<legend class="form-header-text">Upload Experiment and/or Analysis Metadata</legend>',
                 HTML('<div class="title-separator my-3.5"></div>'),
                 "experiment_accession",
+                HTML('<div class="title-separator my-3.5"></div>'),
+                Fieldset(
+                    '<div class="form-label">Compressed Full Experiment Information</div>',
+                    Field("full_url", wrapper_class="indent"),
+                    Field("full_file", wrapper_class="indent inline_url_field"),
+                ),
+                HTML('<div class="title-separator my-3.5"></div>'),
                 Fieldset(
                     '<div class="form-label">Experiment Metadata</div>',
                     Field("experiment_url", wrapper_class="indent"),

--- a/cegs_portal/uploads/validators.py
+++ b/cegs_portal/uploads/validators.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 
 
 def validate_experiment_accession_id(value):
-    if value is not None and fullmatch("DCPEXPR[0-9A-F]{10}", value) is None:
+    if value is None or fullmatch("DCPEXPR[0-9A-F]{10}", value) is None:
         raise ValidationError(
             f"""{value} is not of the form "DCPEXPRXXXXXXXX" where X is a hexadecimal digit (0-9, A-F)"""
         )

--- a/cegs_portal/uploads/view_models.py
+++ b/cegs_portal/uploads/view_models.py
@@ -1,3 +1,20 @@
+import re
+
+from cegs_portal.search.models import Experiment
+
+
+def next_accession(accession: str) -> str:
+    match = re.fullmatch(r"DCPEXPR([\da-fA-F]{10})", accession)
+    number = int(match.group(1), base=16) + 1
+
+    return f"DCPEXPR{number:010X}"
+
+
 def add_experiment_to_user(experiment_accession, user):
     user.experiments.append(experiment_accession)
     user.save()
+
+
+def get_next_experiment_accession() -> str:
+    largest_accession = Experiment.objects.all().values_list("accession_id", flat=True).order_by("-id").first()
+    return "DCPEXPR0000000000" if largest_accession is None else next_accession(largest_accession)


### PR DESCRIPTION
It's annoying to rely on 3rd party hosting to get data into the portal
all the time (especially when, as of the data of these commits, the lab
doesn't have any 3rd party hosting).

This code adds support for uploading a tar.gz file with the metadata AND
data included.

The backend untars the file and then loads the file as usual, more or less.