### PR TITLE
Make genoverse better match window width

### DIFF
--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -1,3 +1,5 @@
+let browserWidth = () => Math.max(500, window.innerWidth - 50);
+
 CEGSGenoverse = Genoverse.extend({
     // debug: true,
     _sharedState: {
@@ -37,11 +39,18 @@ CEGSGenoverse = Genoverse.extend({
             config.assembly = "grch37";
         }
 
+        config.width = browserWidth();
+
         this.base(config);
     },
     init: function () {
         this.base();
         this.updateSharedState("region", {chr: this.chr, start: this.start, end: this.end});
+
+        let browser = this;
+        window.addEventListener("resize", function () {
+            browser.setWidth(browserWidth());
+        });
     },
     updateURL: function () {
         this.base();


### PR DESCRIPTION
This sets the initial browser with to most of the window width (matching the padding of the page). Additionally, it makes genoverse resize when the window resizes, to a minimum of 500px. That's just a guess at the smallest size that could still be useful.

![Screenshot 2024-09-11 at 11-10-40 Region Search Results](https://github.com/user-attachments/assets/b1aa0902-b5fb-400d-a593-5e6d77ea8040)
![Screenshot 2024-09-11 at 11-10-50 Region Search Results](https://github.com/user-attachments/assets/723dc25e-c55d-4568-9468-7e14a4ba43d0)
