### PR TITLE
Responsive UI tweaks

### DIFF
--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -1,4 +1,7 @@
-let browserWidth = () => Math.max(500, window.innerWidth - 50);
+// 100 is larger than the sum of the margins we use. By shrinking
+// the width by that much it ensures the browser won't "overflow"
+// it's container until the window is very narrow.
+let browserWidth = () => Math.max(500, window.innerWidth - 100);
 
 CEGSGenoverse = Genoverse.extend({
     // debug: true,

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -24,7 +24,7 @@
 
 {% block content %}
 <!-- HEADER -->
-<div>
+<div class="min-w-full max-w-full">
     <div class="title-separator"></div>
         <div class="flex justify-between md:ps-10">
             <span class="page-header-w-icon">

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -26,7 +26,7 @@
 <!-- HEADER -->
 <div>
     <div class="title-separator"></div>
-        <div class="flex justify-between">
+        <div class="flex justify-between md:ps-10">
             <span class="page-header-w-icon">
                 <div class="flex flex-wrap">
                 {% comment %}

--- a/cegs_portal/search/templates/search/v1/dna_features.html
+++ b/cegs_portal/search/templates/search/v1/dna_features.html
@@ -18,7 +18,7 @@
 {% block content %}
 <div>
     <div class="title-separator"></div>
-    <div class="flex justify-center items-center">
+    <div class="flex justify-center items-center md:ps-10 ">
         <span class="page-header-w-icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-icon mr-2">
                 <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->

--- a/cegs_portal/search/templates/search/v1/dna_features.html
+++ b/cegs_portal/search/templates/search/v1/dna_features.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content %}
-<div>
+<div class="max-w-full">
     <div class="title-separator"></div>
     <div class="flex justify-center items-center md:ps-10 ">
         <span class="page-header-w-icon">

--- a/cegs_portal/search/templates/search/v1/dna_features.html
+++ b/cegs_portal/search/templates/search/v1/dna_features.html
@@ -33,45 +33,45 @@
         </select>
     </div>
     <div>
-    <div class="title-separator"></div>
-    <div class="flex flex-row justify-center" id="genoverse-container">
-        <div id="genoverse"></div>
-    </div>
-    <div class="title-separator"></div>
-    <div class="container centered-container min-w-full">
-        <a name="near_features"></a>
-        <div class="table-title table-container-header">
-            <div class="table-container-title">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-icon h-4 w-4 mr-2">
-                    <path d="M3.9 54.9C10.5 40.9 24.5 32 40 32H472c15.5 0 29.5 8.9 36.1 22.9s4.6 30.5-5.2 42.5L320 320.9V448c0 12.1-6.8 23.2-17.7 28.6s-23.8 4.3-33.5-3l-64-48c-8.1-6-12.8-15.5-12.8-25.6V320.9L9 97.3C-.7 85.4-2.8 68.8 3.9 54.9z"/>
-                </svg>
-                Filter DNA Features
-            </div>
+        <div class="title-separator"></div>
+        <div class="justify-center overflow-x-auto" id="genoverse-container">
+            <div id="genoverse"></div>
         </div>
-        <form hx-get="{% url 'search:dna_feature_loc' loc.chr loc.start loc.end %}" hx-trigger="submit" hx-indicator="#spinner" hx-swap="innerHTML" hx-target="#features-table" class="text-center">
-            <div class="title-separator min-w-full"></div>
-            <fieldset name="facetfield">
-                <legend class="flex flex-row group font-bold min-w-full" id="facetHeader{{ forloop.counter }}"><div>{{ facet.name }}</div>
-                </legend>
-                <div class="flex flex-row flex-wrap gap-1"
-                    aria-labelledby="facetHeader{{ forloop.counter }}">
-                    {% for feature_type in dna_feature_types %}
-                    <div class="checkbox-divider">
-                        <input type="checkbox" id="{{ feature_type }}" name="feature_type" value="{{ feature_type }}"></input>
-                        <label for="{{ feature_type }}">{{ feature_type }}</label>
-                    </div>
-                    {% endfor %}
+        <div class="title-separator"></div>
+        <div class="content-container centered-container min-w-full">
+            <a name="near_features"></a>
+            <div class="table-title table-container-header">
+                <div class="table-container-title">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="svg-icon h-4 w-4 mr-2">
+                        <path d="M3.9 54.9C10.5 40.9 24.5 32 40 32H472c15.5 0 29.5 8.9 36.1 22.9s4.6 30.5-5.2 42.5L320 320.9V448c0 12.1-6.8 23.2-17.7 28.6s-23.8 4.3-33.5-3l-64-48c-8.1-6-12.8-15.5-12.8-25.6V320.9L9 97.3C-.7 85.4-2.8 68.8 3.9 54.9z"/>
+                    </svg>
+                    Filter DNA Features
                 </div>
-            </fieldset>
-            <div class="title-separator min-w-full"></div>
-            <input
-                type="submit"
-                class="global-button border-2 border-gray-300 h-10 text-sm"
-                value="Filter Features"
-            />
-            <i class='fas fa-spinner fa-spin htmx-indicator' id="spinner"></i>
-        </form>
-    </div>
+            </div>
+            <form hx-get="{% url 'search:dna_feature_loc' loc.chr loc.start loc.end %}" hx-trigger="submit" hx-indicator="#spinner" hx-swap="innerHTML" hx-target="#features-table" class="text-center">
+                <div class="title-separator min-w-full"></div>
+                <fieldset name="facetfield">
+                    <legend class="flex flex-row group font-bold min-w-full" id="facetHeader{{ forloop.counter }}"><div>{{ facet.name }}</div>
+                    </legend>
+                    <div class="flex flex-row flex-wrap gap-1"
+                        aria-labelledby="facetHeader{{ forloop.counter }}">
+                        {% for feature_type in dna_feature_types %}
+                        <div class="checkbox-divider">
+                            <input type="checkbox" id="{{ feature_type }}" name="feature_type" value="{{ feature_type }}"></input>
+                            <label for="{{ feature_type }}">{{ feature_type }}</label>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </fieldset>
+                <div class="title-separator min-w-full"></div>
+                <input
+                    type="submit"
+                    class="global-button border-2 border-gray-300 h-10 text-sm"
+                    value="Filter Features"
+                />
+                <i class='fas fa-spinner fa-spin htmx-indicator' id="spinner"></i>
+            </form>
+        </div>
         <div id="features-table">
         {% include "search/v1/partials/_features.html" with data=features no_data="No DNA Features Found" %}
         </div>

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -267,10 +267,10 @@
               </fieldset>
           </div>
         </div>
-        <div class="md:order-2 md:w-3/4 mx-auto" id="experiment-list">
+        <div class="md:order-2 lg:w-3/4 lg:mx-auto" id="experiment-list">
             {% for experiment in experiments %}
             <a href="{% url 'search:experiment' experiment.accession_id %}" class="exp-list-content-container-link experiment-summary" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">
-                <div class="container items-center">
+                <div class="content-container items-center">
                     <div class="flex justify-between">
                         <div class="exp-name">{{ experiment.name }}</div>
                         <div class="select-experiment font-bold text-2xl" title="Select Experiment" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">＋</div>

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="min-w-full">
     <div class="title-separator"></div>
-    <div style="display: flex; justify-content: space-between; align-items: center">
+    <div class="md:ps-10" style="display: flex; justify-content: space-between; align-items: center">
         <span class="page-header-w-icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" class="svg-icon mr-2">
                 <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->

--- a/cegs_portal/search/templates/search/v1/non_targeting_reos.html
+++ b/cegs_portal/search/templates/search/v1/non_targeting_reos.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div>
 <div class="title-separator"></div>
-    <div style="display: flex; justify-content: space-between">
+    <div class="md:ps-10" style="display: flex; justify-content: space-between">
         <span class="page-header-w-icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="svg-icon mr-2">
                 <!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. -->

--- a/cegs_portal/search/templates/search/v1/partials/_features.html
+++ b/cegs_portal/search/templates/search/v1/partials/_features.html
@@ -1,9 +1,9 @@
 {% load custom_helpers %}
 {% load humanize %}
 
-{% if features|length > 0 %}
-    <div class="content-container min-w-full max-w-sm">
-        <div class="table-title flex flex-col sm:flex-row max-w-full min-w-full justify-between items-center">
+{% if not features.empty %}
+    <div class="content-container min-w-full max-w-full">
+        <div class="table-title flex flex-col sm:flex-row justify-between items-center">
             <div class="flex-1">
                 <!-- This empty div takes up space on the left for centering and for responsive design-->
             </div>

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -174,6 +174,7 @@
 <script type="text/javascript" src="{% static 'search/js/genoverse.js' %}"></script>
 {% endblock %}
 {% block content %}
+<div class="max-w-full">
     <div class="grow flex flex-col items-center min-w-full grow-0">
         <div class="flex flex-row min-w-full justify-around">
             {% if region %}
@@ -435,7 +436,7 @@
             </div>
         </div>
     </div>
-
+</div>
 {% endblock %}
 {% block inline_javascript %}
     <script type="module">

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -837,7 +837,6 @@ h2 {
   color: #094474;
   text-shadow: 2px 2px #e3f2fd;
   margin-bottom: 10px;
-  margin-left: 40px;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -3062,6 +3061,11 @@ fieldset legend {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .md\:ps-10 {
+    -webkit-padding-start: 2.5rem;
+            padding-inline-start: 2.5rem;
+  }
 }
 
 @media (min-width: 1024px) {
@@ -3069,6 +3073,11 @@ fieldset legend {
     -webkit-box-ordinal-group: 2;
         -ms-flex-order: 1;
             order: 1;
+  }
+
+  .lg\:mx-auto {
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .lg\:mt-0 {
@@ -3095,6 +3104,10 @@ fieldset legend {
 
   .lg\:w-1\/4 {
     width: 25%;
+  }
+
+  .lg\:w-3\/4 {
+    width: 75%;
   }
 
   .lg\:w-auto {

--- a/cegs_portal/static/css/project.css.tw
+++ b/cegs_portal/static/css/project.css.tw
@@ -146,7 +146,6 @@ fieldset legend {
     color: #094474;
     text-shadow: 2px 2px #e3f2fd;
     margin-bottom: 10px;
-    margin-left: 40px;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
* The genoverse browser was a little too wide for its container.
The containers horizontal scroll bar was always showing and genoverse
went off the right edge.


![Screenshot 2024-09-16 at 10 09 31 AM](https://github.com/user-attachments/assets/65349b93-db62-4428-8cf8-ef65ce6deacd)
![Screenshot 2024-09-16 at 10 17 50 AM](https://github.com/user-attachments/assets/c568c0a4-3f2d-4496-a0b5-de019985a5e9)


* Adjusts how .page-header-w-icon works, so the left margin isn't
built in. This lets us remove the margin when the screen is narrow.

![Screenshot 2024-09-16 at 10 10 27 AM](https://github.com/user-attachments/assets/f01042ff-8874-4ef4-8f8b-619bb84d73a6)
![Screenshot 2024-09-16 at 10 18 23 AM](https://github.com/user-attachments/assets/d7c494e9-84cc-4907-b5ff-a0e555109304)


* Keeps the feature table width within the horizontal bounds
of the screen.

![Screenshot 2024-09-16 at 10 14 06 AM](https://github.com/user-attachments/assets/e1bce413-2147-4e75-ad1f-b70739295100)
![Screenshot 2024-09-16 at 10 19 29 AM](https://github.com/user-attachments/assets/6ff1d473-9d50-40ad-9ab6-113ce136b208)


* Updates the experiment list so that the experiment boxes are the
full width of the screen when the screen is narrow.

![Screenshot 2024-09-16 at 10 14 57 AM](https://github.com/user-attachments/assets/8f6abefe-45f5-4a26-8976-12d3b485675e)
![Screenshot 2024-09-16 at 10 20 19 AM](https://github.com/user-attachments/assets/a9d7c724-5351-421b-96cb-74bbddcd5d3b)

* The genoverse container on the dna_features page didn't overflow
so when the screen was narrow it would go off the edge.

![Screenshot 2024-09-16 at 10 16 24 AM](https://github.com/user-attachments/assets/01bc1343-50e1-4c90-be59-132343c92891)
![Screenshot 2024-09-16 at 10 16 56 AM](https://github.com/user-attachments/assets/69273196-83f0-4955-ace9-9d446da6140a)



