### PR TITLE
Add cCRE track to genoverse

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -11,6 +11,7 @@ from cegs_portal.get_expr_data.conftest import (  # noqa: F401
 from cegs_portal.search.json_templates.v1.search_results import SearchResults
 from cegs_portal.search.models import (
     Biosample,
+    CCRECategoryType,
     DNAFeature,
     DNAFeatureType,
     EffectObservationDirectionType,
@@ -552,6 +553,11 @@ def genoverse_dhs_features():
     length = 10_000
     gap = 1_000
     ref_genome = "hg38"
+
+    screen_facet = FacetFactory(description="", name=DNAFeature.Facet.CCRE_CATEGORIES.value)
+    pels = FacetValueFactory(facet=screen_facet, value=CCRECategoryType.PELS.value)
+    dels = FacetValueFactory(facet=screen_facet, value=CCRECategoryType.DELS.value)
+
     f1 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
@@ -563,12 +569,14 @@ def genoverse_dhs_features():
         chrom_name=chrom,
         location=NumericRange(start + length + gap, start + length * 2 + gap),
         feature_type=DNAFeatureType.CCRE,
+        facet_values=(pels,),
     )
     f3 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
         location=NumericRange(start + length * 2 + gap * 2, start + length * 3 + gap * 2),
         feature_type=DNAFeatureType.CCRE,
+        facet_values=(dels,),
     )
     f4 = DNAFeatureFactory(
         ref_genome=ref_genome,

--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -66,18 +66,22 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
         "ref_genome": feature_obj.ref_genome,
     }
 
-    if options is not None and "regeffects" in options.get("feature_properties", []):
-        result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
-        result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
+    if options is not None:
+        if "regeffects" in options.get("feature_properties", []):
+            result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
+            result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
 
-    if options is not None and "effect_directions" in options.get("feature_properties", []):
-        result["effect_directions"] = feature_obj.effect_directions
+        if "effect_directions" in options.get("feature_properties", []):
+            result["effect_directions"] = feature_obj.effect_directions
 
-    if options is not None and "effect_targets" in options.get("feature_properties", []):
-        result["effect_targets"] = feature_obj.effect_targets
+        if "effect_targets" in options.get("feature_properties", []):
+            result["effect_targets"] = feature_obj.effect_targets
 
-    if options is not None and options.get("json_format", None) == "genoverse":
-        genoversify(result)
+        if options.get("json_format", None) == "genoverse":
+            genoversify(result)
+
+        if "screen_ccre" in options.get("feature_properties", []):
+            result["ccre_type"] = feature_obj.ccre_type
 
     return cast(FeatureJson, result)
 

--- a/cegs_portal/search/models/__init__.py
+++ b/cegs_portal/search/models/__init__.py
@@ -1,6 +1,6 @@
 from . import signals
 from .accession import Accessioned, AccessionIdLog, AccessionIds
-from .dna_feature import DNAFeature, GrnaType, PromoterType
+from .dna_feature import CCRECategoryType, DNAFeature, GrnaType, PromoterType
 from .dna_feature_type import DNAFeatureSourceType, DNAFeatureType
 from .experiment import (
     Analysis,

--- a/cegs_portal/search/models/dna_feature.py
+++ b/cegs_portal/search/models/dna_feature.py
@@ -26,6 +26,15 @@ class PromoterType(Enum):
     NON_PROMOTER = "Non-promoter"
 
 
+class CCRECategoryType(Enum):
+    PLS = "PLS"
+    PELS = "pELS"
+    DELS = "dELS"
+    DNASE = "DNase-H3K4me3"
+    CTCF_ONLY = "CTCF-only"
+    CTCF_BOUND = "CTCF-bound"
+
+
 class DNAFeature(Accessioned, Faceted, AccessControlled):
     class Meta(Accessioned.Meta):
         indexes = [

--- a/cegs_portal/search/models/tests/dna_feature_factory.py
+++ b/cegs_portal/search/models/tests/dna_feature_factory.py
@@ -1,7 +1,7 @@
 import random
 
 import factory
-from factory import Faker
+from factory import Faker, post_generation
 from factory.django import DjangoModelFactory
 from faker import Faker as F
 from psycopg2.extras import NumericRange
@@ -83,3 +83,14 @@ class DNAFeatureFactory(DjangoModelFactory):
         if self.closest_gene:
             return random.randint(0, 10000)
         return None
+
+    @post_generation
+    def facet_values(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of groups were passed in, use them
+            for value in extracted:
+                self.facet_values.add(value)  # pylint: disable=no-member

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -71,7 +71,7 @@ Genoverse.Track.View.cCRE = Genoverse.Track.View.extend({
     labels: false,
     repeatLabels: true,
     bump: false,
-    ccreColor: {
+    color: {
         PLS: "#EB382A",
         pELS: "#F3A94C",
         dELS: "#F7CC63",
@@ -80,7 +80,7 @@ Genoverse.Track.View.cCRE = Genoverse.Track.View.extend({
         "CTCF-bound": "#4DB0E4",
     },
     setFeatureColor: function (feature) {
-        feature.color = this.ccreColor[feature.ccre_type];
+        feature.color = this.color[feature.ccre_type];
     },
 });
 
@@ -453,19 +453,57 @@ Genoverse.Track.cCRE = Genoverse.Track.extend({
     view: Genoverse.Track.View.cCRE,
     legend: false,
     border: false,
-    info: 'cCRE colors correspond to their <u><a target="_blank" href="https://screen.wenglab.org/assets/about/images/figure3.png">SCREEN meanings</a></u>',
+    controls: "off",
 
-    populateMenu: async function (feature) {
-        let url = `/search/feature/accession/${feature.accession_id}`;
-        let type = feature.type.toUpperCase();
-        let menu = {
-            title: `<a target="_blank" href="${url}">${type}: ${feature.accession_id}</a>`,
+    populateMenu: function (feature) {
+        return {
+            title: `<u><a target="_blank" href="https://screen.wenglab.org/assets/about/images/figure3.png">SCREEN cCRE (${feature.ccre_type})</a></u>`,
             Location: `chr${feature.chr}:${feature.start}-${feature.end}`,
             Assembly: feature.ref_genome,
             "Closest Gene": `<a target="_blank" href="/search/feature/ensembl/${feature.closest_gene_ensembl_id}">${feature.closest_gene_name} (${feature.closest_gene_ensembl_id})</a>`,
         };
+    },
+    click: function (e) {
+        var target = $(e.target);
+        var x = e.pageX - this.container.parent().offset().left + this.browser.scaledStart;
+        var y = e.pageY - target.offset().top;
 
-        return menu;
+        if (e.type === "mouseup") {
+            this.browser.makeMenu(this.getClickedFeatures(x, y, target), e, this.track);
+            return;
+        } else if (e.type === "mousemove") {
+            var f = this.getClickedFeatures(x, 3, target)[0];
+            if (f && f.ccre_type) {
+                this.container.tipsy("hide");
+
+                this.container
+                    .attr("title", f.ccre_type)
+                    .tipsy({trigger: "manual", container: "body", offset: -15})
+                    .tipsy("show")
+                    .data("tipsy")
+                    .$tip.css("left", function () {
+                        return e.clientX - $(this).width() / 2;
+                    });
+            }
+        }
+    },
+
+    addUserEventHandlers: function () {
+        var track = this;
+
+        this.base();
+
+        this.container.on(
+            {
+                mousemove: function (e) {
+                    track.click(e);
+                },
+                mouseout: function (e) {
+                    track.container.tipsy("hide");
+                },
+            },
+            ".gv-image-container",
+        );
     },
 });
 

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -484,10 +484,11 @@ Genoverse.Track.cCRE = Genoverse.Track.extend({
                     .$tip.css("left", function () {
                         return e.clientX - $(this).width() / 2;
                     });
+            } else {
+                this.container.tipsy("hide");
             }
         }
     },
-
     addUserEventHandlers: function () {
         var track = this;
 

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -61,6 +61,29 @@ CEGSGenoverse = Genoverse.extend({
     },
 });
 
+Genoverse.Track.Model.cCRE = Genoverse.Track.Model.extend({
+    url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&search_type=overlap&accept=application/json&format=genoverse&feature_type=cCRE&property=screen_ccre",
+    dataRequestLimit: 5000000,
+});
+
+Genoverse.Track.View.cCRE = Genoverse.Track.View.extend({
+    featureHeight: 15,
+    labels: false,
+    repeatLabels: true,
+    bump: false,
+    ccreColor: {
+        PLS: "#EB382A",
+        pELS: "#F3A94C",
+        dELS: "#F7CC63",
+        "DNase-H3K4me3": "#F3AEAD",
+        "CTCF-only": "#4DB0E4",
+        "CTCF-bound": "#4DB0E4",
+    },
+    setFeatureColor: function (feature) {
+        feature.color = this.ccreColor[feature.ccre_type];
+    },
+});
+
 Genoverse.Track.Model.DHS = Genoverse.Track.Model.extend({
     url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&feature_type=gRNA&feature_type=Chromatin%20Accessible%20Region&property=effect_directions&property=effect_targets&property=significant",
     dataRequestLimit: 5000000,
@@ -419,6 +442,30 @@ Genoverse.Track.View.Transcript.Portal = Genoverse.Track.View.Transcript.extend(
         }
 
         feature.labelColor = feature.labelColor || feature.color;
+    },
+});
+
+Genoverse.Track.cCRE = Genoverse.Track.extend({
+    id: "ccres",
+    name: "cCREs",
+    resizable: false,
+    model: Genoverse.Track.Model.cCRE,
+    view: Genoverse.Track.View.cCRE,
+    legend: false,
+    border: false,
+    info: 'cCRE colors correspond to their <u><a target="_blank" href="https://screen.wenglab.org/assets/about/images/figure3.png">SCREEN meanings</a></u>',
+
+    populateMenu: async function (feature) {
+        let url = `/search/feature/accession/${feature.accession_id}`;
+        let type = feature.type.toUpperCase();
+        let menu = {
+            title: `<a target="_blank" href="${url}">${type}: ${feature.accession_id}</a>`,
+            Location: `chr${feature.chr}:${feature.start}-${feature.end}`,
+            Assembly: feature.ref_genome,
+            "Closest Gene": `<a target="_blank" href="/search/feature/ensembl/${feature.closest_gene_ensembl_id}">${feature.closest_gene_name} (${feature.closest_gene_ensembl_id})</a>`,
+        };
+
+        return menu;
     },
 });
 

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -72,6 +72,26 @@ def test_genoverse_track_model_DHS_effects(client: Client, genoverse_dhs_feature
         assert "accession_id" in feature
 
 
+def test_genoverse_track_view_cCRE(client: Client, genoverse_dhs_features):
+    chrom = genoverse_dhs_features["chrom"]
+    assembly = genoverse_dhs_features["ref_genome"]
+    start = genoverse_dhs_features["start"]
+    end = genoverse_dhs_features["end"]
+
+    response = client.get(
+        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&search_type=overlap&accept=application/json&format=genoverse&feature_type=cCRE&property=screen_ccre"  # noqa: E501
+    )
+
+    assert response.status_code == 200
+
+    json_content = json.loads(response.content)
+    assert isinstance(json_content, list)
+    assert len(json_content) == 2
+    for feature in json_content:
+        assert feature["type"] == "cCRE"
+        assert feature.get("ccre_type", None) is not None
+
+
 def test_genoverse_track_model_gene_portal(client: Client, genoverse_gene_features):
     chrom = genoverse_gene_features["chrom"]
     assembly = genoverse_gene_features["ref_genome"]

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -457,6 +457,7 @@
             tracks    : [
                 Genoverse.Track.Scaleline.extend({ strand: false }),
                 Genoverse.Track.Scalebar,
+                Genoverse.Track.cCRE,
                 Genoverse.Track.DHS.Effects,
                 Genoverse.Track.Gene,
             ]

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -598,6 +598,7 @@
             tracks: [
                 Genoverse.Track.Scaleline.extend({ strand: false }),
                 Genoverse.Track.Scalebar,
+                Genoverse.Track.cCRE,
                 Genoverse.Track.DHS.Effects,
                 Genoverse.Track.Gene,
             ]


### PR DESCRIPTION
This track shows the location of SCREEN cCREs. They are color coded according to SCREEN category (pELS, dELS, etc.).

<img width="924" alt="Screenshot 2024-09-18 at 3 57 58 PM" src="https://github.com/user-attachments/assets/12bde35c-f3dd-4699-803d-6cfb0a41d9f7">

