### PR TITLE
Reduce Genoverse whitespace

### DIFF
--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -82,6 +82,7 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
 
         if "screen_ccre" in options.get("feature_properties", []):
             result["ccre_type"] = feature_obj.ccre_type
+        result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None
 
     return cast(FeatureJson, result)
 

--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -67,22 +67,25 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
     }
 
     if options is not None:
-        if "regeffects" in options.get("feature_properties", []):
+        feature_properties = set(options.get("feature_properties", []))
+        if "regeffects" in feature_properties:
             result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
             result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
 
-        if "effect_directions" in options.get("feature_properties", []):
+        if "effect_directions" in feature_properties:
             result["effect_directions"] = feature_obj.effect_directions
 
-        if "effect_targets" in options.get("feature_properties", []):
+        if "effect_targets" in feature_properties:
             result["effect_targets"] = feature_obj.effect_targets
 
         if options.get("json_format", None) == "genoverse":
             genoversify(result)
 
-        if "screen_ccre" in options.get("feature_properties", []):
+        if "screen_ccre" in feature_properties:
             result["ccre_type"] = feature_obj.ccre_type
-    result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None
+
+        if "parent_subtype" in feature_properties:
+            result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None
 
     return cast(FeatureJson, result)
 

--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -82,7 +82,7 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
 
         if "screen_ccre" in options.get("feature_properties", []):
             result["ccre_type"] = feature_obj.ccre_type
-        result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None
+    result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None
 
     return cast(FeatureJson, result)
 

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -39,7 +39,6 @@ def test_feature(feature: DNAFeature, effect_dir_feature: DNAFeature):
         "parent": feature.parent if feature.parent is not None else None,
         "parent_accession_id": feature.parent_accession_id if feature.parent is not None else None,
         "parent_ensembl_id": feature.parent_ensembl_id if feature.parent is not None else None,
-        "parent_subtype": feature.parent.subtype if feature.parent is not None else None,
         "misc": feature.misc,
     }
     if feature.closest_gene is not None:
@@ -58,6 +57,9 @@ def test_feature(feature: DNAFeature, effect_dir_feature: DNAFeature):
 
     f_dict = f_json(effect_dir_feature, {"feature_properties": ["effect_directions"]})
     assert "effect_directions" in f_dict
+
+    f_dict = f_json(effect_dir_feature, {"feature_properties": ["parent_subtype"]})
+    assert "parent_subtype" in f_dict
 
     result["id"] = result["accession_id"]
     result["chr"] = feature.chrom_name.removeprefix("chr")

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -39,6 +39,7 @@ def test_feature(feature: DNAFeature, effect_dir_feature: DNAFeature):
         "parent": feature.parent if feature.parent is not None else None,
         "parent_accession_id": feature.parent_accession_id if feature.parent is not None else None,
         "parent_ensembl_id": feature.parent_ensembl_id if feature.parent is not None else None,
+        "parent_subtype": feature.parent.subtype if feature.parent is not None else None,
         "misc": feature.misc,
     }
     if feature.closest_gene is not None:

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -3,6 +3,63 @@
 // it's container until the window is very narrow.
 let browserWidth = () => Math.max(500, window.innerWidth - 100);
 
+/*
+ * Title Caps
+ *
+ * Ported to JavaScript By John Resig - http://ejohn.org/ - 21 May 2008
+ * Original by John Gruber - http://daringfireball.net/ - 10 May 2008
+ * License: http://www.opensource.org/licenses/mit-license.php
+ */
+
+(function () {
+    var small = "(a|an|and|as|at|but|by|en|for|if|in|of|on|or|the|to|v[.]?|via|vs[.]?)";
+    var punct = "([!\"#$%&'()*+,./:;<=>?@[\\\\\\]^_`{|}~-]*)";
+
+    this.titleCaps = function (title) {
+        var parts = [],
+            split = /[:.;?!] |(?: |^)["Ò]/g,
+            index = 0;
+
+        while (true) {
+            var m = split.exec(title);
+
+            parts.push(
+                title
+                    .substring(index, m ? m.index : title.length)
+                    .replace(/\b([A-Za-z][a-z.'Õ]*)\b/g, function (all) {
+                        return /[A-Za-z]\.[A-Za-z]/.test(all) ? all : upper(all);
+                    })
+                    .replace(RegExp("\\b" + small + "\\b", "ig"), lower)
+                    .replace(RegExp("^" + punct + small + "\\b", "ig"), function (all, punct, word) {
+                        return punct + upper(word);
+                    })
+                    .replace(RegExp("\\b" + small + punct + "$", "ig"), upper),
+            );
+
+            index = split.lastIndex;
+
+            if (m) parts.push(m[0]);
+            else break;
+        }
+
+        return parts
+            .join("")
+            .replace(/ V(s?)\. /gi, " v$1. ")
+            .replace(/(['Õ])S\b/gi, "$1s")
+            .replace(/\b(AT&T|Q&A)\b/gi, function (all) {
+                return all.toUpperCase();
+            });
+    };
+
+    function lower(word) {
+        return word.toLowerCase();
+    }
+
+    function upper(word) {
+        return word.substr(0, 1).toUpperCase() + word.substr(1);
+    }
+})();
+
 CEGSGenoverse = Genoverse.extend({
     // debug: true,
     _sharedState: {

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -587,15 +587,59 @@ Genoverse.Track.DHS = Genoverse.Track.extend({
 
         return menu;
     },
+    click: function (e) {
+        var target = $(e.target);
+        var x = e.pageX - this.container.parent().offset().left + this.browser.scaledStart;
+        var y = e.pageY - target.offset().top;
+
+        if (e.type === "mouseup") {
+            this.browser.makeMenu(this.getClickedFeatures(x, y, target), e, this.track);
+            return;
+        } else if (e.type === "mousemove") {
+            var f = this.getClickedFeatures(x, y, target)[0];
+            if (f && f.type) {
+                this.container.tipsy("hide");
+
+                this.container
+                    .attr("title", f.type)
+                    .tipsy({trigger: "manual", container: "body", offset: -15})
+                    .tipsy("show")
+                    .data("tipsy")
+                    .$tip.css("left", function () {
+                        return e.clientX - $(this).width() / 2;
+                    })
+                    .css("top", function () {
+                        return e.pageY + 10;
+                    });
+            } else {
+                this.container.tipsy("hide");
+            }
+        }
+    },
+    addUserEventHandlers: function () {
+        var track = this;
+
+        this.base();
+
+        this.container.on(
+            {
+                mousemove: function (e) {
+                    track.click(e);
+                },
+                mouseout: function (e) {
+                    track.container.tipsy("hide");
+                },
+            },
+            ".gv-image-container",
+        );
+    },
 });
 
 Genoverse.Track.DHS.Effects = Genoverse.Track.DHS.extend({
     id: "dhs-effects",
     name: "Experimentally Tested Elements",
     labels: false,
-    legend: Genoverse.Track.Legend.extend({
-        name: "Element Types",
-    }),
+    legend: false,
     model: Genoverse.Track.Model.DHS.Effects,
     controls: [
         $('<a title="Change feature height">Squish</a>').on("click", function () {

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -368,7 +368,7 @@ Genoverse.Track.View.Gene.Portal = Genoverse.Track.View.Gene.extend({
 });
 
 Genoverse.Track.Model.Transcript.Portal = Genoverse.Track.Model.Transcript.extend({
-    url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&accept=application/json&format=genoverse&feature_type=Transcript&feature_type=Exon",
+    url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&accept=application/json&format=genoverse&feature_type=Transcript&feature_type=Exon&property=parent_subtype",
     dataRequestLimit: 5000000, // As per e! REST API restrictions
 
     setDefaults: function () {
@@ -676,6 +676,7 @@ Genoverse.Track.Gene = Genoverse.Track.extend({
     model: Genoverse.Track.Model.Gene.Portal,
     view: Genoverse.Track.View.Gene.Portal,
     legend: false,
+    controls: "off",
     populateMenu: function (feature) {
         if (["Gene", "Exon", "Transcript"].includes(feature.type)) {
             var url = `/search/feature/accession/${feature.accession_id}`;

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -113,6 +113,7 @@ def test_genoverse_track_model_gene_portal(client: Client, genoverse_gene_featur
         assert feature.get("strand", None) is not None
         assert feature.get("name", None) is not None
         assert feature.get("ensembl_id", None) is not None
+        assert feature["parent_subtype"] is None
 
 
 def test_genoverse_track_model_transcript_portal(client: Client, genoverse_transcript_features):
@@ -146,6 +147,7 @@ def test_genoverse_track_model_transcript_portal(client: Client, genoverse_trans
         assert transcript.get("parent", None) is not None
         assert transcript.get("parent_accession_id", None) is not None
         assert transcript.get("parent_ensembl_id", None) is not None
+        assert transcript["parent_subtype"] is not None
 
     for exon in exons:
         assert exon.get("parent_accession_id", None) is not None

--- a/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
+++ b/cegs_portal/search/static/search/js/test/test_genoverse_standin.py
@@ -113,7 +113,6 @@ def test_genoverse_track_model_gene_portal(client: Client, genoverse_gene_featur
         assert feature.get("strand", None) is not None
         assert feature.get("name", None) is not None
         assert feature.get("ensembl_id", None) is not None
-        assert feature["parent_subtype"] is None
 
 
 def test_genoverse_track_model_transcript_portal(client: Client, genoverse_transcript_features):
@@ -124,7 +123,7 @@ def test_genoverse_track_model_transcript_portal(client: Client, genoverse_trans
     features = genoverse_transcript_features["features"]
 
     response = client.get(
-        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&accept=application/json&format=genoverse&feature_type=Transcript&feature_type=Exon"  # noqa: E501
+        f"/search/featureloc/{chrom}/{start + 100}/{end - 100}?assembly={assembly}&accept=application/json&format=genoverse&feature_type=Transcript&feature_type=Exon&property=parent_subtype"  # noqa: E501
     )
 
     assert response.status_code == 200

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -60,7 +60,7 @@
     <div class="title-separator"></div>
 
     <div class="flex justify-center min-w-full max-w-sm" id="genoverse-container">
-        <div class="overflow-x-auto">
+        <div class="overflow-x-auto sm:overflow-x-visible">
             <div id="genoverse"></div>
         </div>
     </div>

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -292,7 +292,9 @@ class DNAFeatureSearch:
                 ccre_type=Subquery(FacetValue.objects.filter(id__in=OuterRef("facet_values__id")).values("value"))
             )
 
-        return features.filter(**filters).prefetch_related(*prefetch_values).order_by("location")
+        return (
+            features.filter(**filters).prefetch_related(*prefetch_values).select_related("parent").order_by("location")
+        )
 
     @classmethod
     def loc_search_public(cls, *args, **kwargs):

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -262,7 +262,7 @@ class DNAFeatureSearch:
         features = DNAFeature.objects
 
         if any(p in {"effect_directions", "effect_targets", "significant"} for p in feature_properties):
-            # skip any feature that not the sources for any REOs
+            # skip any feature that are not the sources for any REOs
             features = features.annotate(reo_count=Count("source_for"))
             filters["reo_count__gt"] = 0
 
@@ -292,9 +292,11 @@ class DNAFeatureSearch:
                 ccre_type=Subquery(FacetValue.objects.filter(id__in=OuterRef("facet_values__id")).values("value"))
             )
 
-        return (
-            features.filter(**filters).prefetch_related(*prefetch_values).select_related("parent").order_by("location")
-        )
+        features = features.filter(**filters).prefetch_related(*prefetch_values)
+
+        if "parent_subtype" in feature_properties:
+            features = features.select_related("parent")
+        return features.order_by("location")
 
     @classmethod
     def loc_search_public(cls, *args, **kwargs):

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -2980,6 +2980,10 @@ fieldset legend {
             flex-direction: row;
   }
 
+  .sm\:overflow-x-visible {
+    overflow-x: visible;
+  }
+
   .sm\:p-8 {
     padding: 2rem;
   }


### PR DESCRIPTION
Reduces "whitespace" in Genoverse browser mainly by replacing legends with tooltips. It also fixes a couple of inconsistencies and bugs.

* The colors for the two gene "zoom levels" didn't match -- a gene would have one color when the exons were visible and another when they weren't.
* This is related to the second bug -- the gene types weren't always correct. When the exons were visible we were actually using the transcript type, which isn't the same as the gene type.
* Also a small issue with menus and CSS overflow is fixed

Before:
![Screenshot 2024-09-19 at 10 27 07 AM](https://github.com/user-attachments/assets/f4a1f33c-96d1-441d-b73d-02f7b51ab5f1)

After:
![Screenshot 2024-09-19 at 10 23 06 AM](https://github.com/user-attachments/assets/1ae39ff7-da00-46d5-a409-bf1fe4ffb9bf)

More After:
![Screenshot 2024-09-19 at 10 22 21 AM](https://github.com/user-attachments/assets/3b3b63c3-88a2-4111-a0ca-df2baf60bc3f)
![Screenshot 2024-09-19 at 10 22 32 AM](https://github.com/user-attachments/assets/24b1b91b-099f-4dbe-9230-753df6ef79ac)
![Screenshot 2024-09-19 at 10 22 42 AM](https://github.com/user-attachments/assets/3597d028-7a97-46da-a679-d9367ec1a312)

