### PR TITLE
Apply margins to only footer images

### DIFF
--- a/cegs_portal/templates/base.html
+++ b/cegs_portal/templates/base.html
@@ -22,7 +22,7 @@
         }
 
         @media (max-width: 600px) {
-            img {
+            footer img {
                 margin-bottom: 10px;
                 margin-top: 20px;
             }


### PR DESCRIPTION
This CSS is included in every page, and thus applies to every image. But it's really only for the footer images.

It was causing problems with the genoverse browser when the screen got too narrow.