### PR TITLE
Makes #card-container full width of page

### DIFF
--- a/cegs_portal/search/templates/search/index.html
+++ b/cegs_portal/search/templates/search/index.html
@@ -88,10 +88,14 @@
     }
 
     #card-container {
-        width: min(calc(100%), 1380px);
-        /* display: grid;
-        grid-template-columns: repeat(auto-fill, 415px);
-        place-content: center; */
+        width: min(calc(100% + .5rem), 1380px); /* The container padding is .25rem on each side */
+    }
+
+    /* Tailwind breakpoint "sm" */
+    @media (min-width: 640px) {
+      #card-container {
+          width: min(calc(100% + 5rem), 1380px); /* The container padding is 2.5rem on each side */
+      }
     }
 
     .card {


### PR DESCRIPTION
This increases the screen width before the cards on the index page wrap. It resets it what we want, after a recent change changed the behavior.

Before:
<img width="1285" alt="Screenshot 2024-09-20 at 4 10 53 PM" src="https://github.com/user-attachments/assets/cc1deddb-babe-4cac-a13c-3b487bff9cfa">

After:
<img width="1285" alt="Screenshot 2024-09-20 at 4 10 38 PM" src="https://github.com/user-attachments/assets/62597c28-b644-40d7-a59d-25f45a40e33b">
