### PR TITLE
Adds more gunicorn works, script to restart gunicorn

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,5 +7,6 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput -i "*.ecd" -i "*.fd"
 
-
-/usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
+# Gunicorn recommends setting (2 * $(num_cores) + 1) workers. Our containers have access to 16 cores, which
+# would be 33 workers. This is probably overkill, so we'll go with 8 for now.
+/usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -w 8 -k uvicorn.workers.UvicornWorker

--- a/scripts/refresh_static_files.sh
+++ b/scripts/refresh_static_files.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${PROD_CEGSPTL_POSTGRESQL_SVC_SERVICE_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+python /app/manage.py collectstatic --noinput -i "*.ecd" -i "*.fd"
+kill -s SIGHUP 9 # Maybe the root gunicorn process is always 9? If not, you can find it by checking /proc


### PR DESCRIPTION
After data is uploaded gunicorn needs to be reset because the whitenoise middleware we use to serve static files doesn't automatically pick up new files. It only checks for new files at load.