### PR TITLE
Fix mobile dropdown issue

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -299,53 +299,8 @@
     addSelectListeners();
 </script>
 <script>
-    window.addEventListener("DOMContentLoaded", (event) => {
-    let previousWidth = window.innerWidth;
-
-    function handleResize() {
-        const currentWidth = window.innerWidth;
-
-        if (currentWidth <= 1020 && previousWidth > 1020) {
-            document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "false");
-            document.querySelector("#combinedExperimentsHeader").setAttribute("data-te-collapse-collapsed", "");
-            document.querySelector("#combinedExperimentsCollapse").classList.add("hidden");
-            document.querySelector("#combinedExperimentsCollapse").removeAttribute("data-te-collapse-show");
-            document.querySelector("#experimentFiltersHeader").setAttribute("aria-expanded", "false");
-            document.querySelector("#experimentFiltersHeader").setAttribute("data-te-collapse-collapsed", "");
-            document.querySelector("#experimentFiltersCollapse").classList.add("hidden");
-            document.querySelector("#experimentFiltersCollapse").removeAttribute("data-te-collapse-show");
-            document.querySelector("#selectExperiments button").setAttribute("aria-expanded", "false");
-            document.querySelector("#analyzeExperiments button").setAttribute("aria-expanded", "false");
-            document.querySelector("#selectExperiments button").setAttribute("data-te-collapse-collapsed", "");
-            document.querySelector("#analyzeExperiments button").setAttribute("data-te-collapse-collapsed", "");
-            document.querySelector("#selectExperimentsCollapse").classList.add("hidden");
-            document.querySelector("#analyzeExperimentsCollapse").classList.add("hidden");
-            document.querySelector("#selectExperimentsCollapse").removeAttribute("data-te-collapse-show");
-            document.querySelector("#analyzeExperimentsCollapse").removeAttribute("data-te-collapse-show");
-        } else if (currentWidth > 1020 && previousWidth <= 1020) {
-            document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "true");
-            document.querySelector("#combinedExperimentsHeader").removeAttribute("data-te-collapse-collapsed");
-            document.querySelector("#combinedExperimentsCollapse").classList.remove("hidden");
-            document.querySelector("#combinedExperimentsCollapse").setAttribute("data-te-collapse-show", "");
-            document.querySelector("#experimentFiltersHeader").setAttribute("aria-expanded", "true");
-            document.querySelector("#experimentFiltersHeader").removeAttribute("data-te-collapse-collapsed");
-            document.querySelector("#experimentFiltersCollapse").classList.remove("hidden");
-            document.querySelector("#experimentFiltersCollapse").setAttribute("data-te-collapse-show", "");
-            document.querySelector("#selectExperiments button").setAttribute("aria-expanded", "true");
-            document.querySelector("#analyzeExperiments button").setAttribute("aria-expanded", "true");
-            document.querySelector("#selectExperiments button").removeAttribute("data-te-collapse-collapsed");
-            document.querySelector("#analyzeExperiments button").removeAttribute("data-te-collapse-collapsed");
-            document.querySelector("#selectExperimentsCollapse").classList.remove("hidden");
-            document.querySelector("#analyzeExperimentsCollapse").classList.remove("hidden");
-            document.querySelector("#selectExperimentsCollapse").setAttribute("data-te-collapse-show", "");
-            document.querySelector("#analyzeExperimentsCollapse").setAttribute("data-te-collapse-show", "");
-        }
-
-        previousWidth = currentWidth;
-    }
-
-    // First screen sizing check
-    if (window.innerWidth <= 1020) {
+function checkWidthToCollapse(currentWidth) {
+    if (currentWidth <= 1020) {
         document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "false");
         document.querySelector("#combinedExperimentsHeader").setAttribute("data-te-collapse-collapsed", "");
         document.querySelector("#combinedExperimentsCollapse").classList.add("hidden");
@@ -380,8 +335,20 @@
         document.querySelector("#selectExperimentsCollapse").setAttribute("data-te-collapse-show", "");
         document.querySelector("#analyzeExperimentsCollapse").setAttribute("data-te-collapse-show", "");
     }
+}
 
-    window.addEventListener("resize", handleResize);
+window.addEventListener("DOMContentLoaded", (event) => {
+    checkWidthToCollapse(window.innerWidth);
+
+    let previousWidth = window.innerWidth;
+
+    window.addEventListener("resize", (event) => {
+        let currentWidth = window.innerWidth;
+        if (currentWidth != previousWidth) {
+            checkWidthToCollapse(currendWidth);
+            previousWidth = currentWidth;
+        }
+    });
 });
 </script>
 {% if logged_in %}

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -299,45 +299,90 @@
     addSelectListeners();
 </script>
 <script>
-  window.addEventListener('DOMContentLoaded', (event) => {
-      window.addEventListener('resize', function() {
-          if (window.innerWidth <= 1020) {
-              document.querySelector('#combinedExperimentsHeader').setAttribute('aria-expanded', 'false');
-              document.querySelector('#combinedExperimentsHeader').setAttribute('data-te-collapse-collapsed', '');
-              document.querySelector('#combinedExperimentsCollapse').classList.add('hidden');
-              document.querySelector('#combinedExperimentsCollapse').removeAttribute('data-te-collapse-show');
-              document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'false');
-              document.querySelector('#experimentFiltersHeader').setAttribute('data-te-collapse-collapsed', '');
-              document.querySelector('#experimentFiltersCollapse').classList.add('hidden');
-              document.querySelector('#experimentFiltersCollapse').removeAttribute('data-te-collapse-show');
-              document.querySelector('#selectExperiments button').setAttribute('aria-expanded', 'false');
-              document.querySelector('#analyzeExperiments button').setAttribute('aria-expanded', 'false');
-              document.querySelector('#selectExperiments button').setAttribute('data-te-collapse-collapsed', '');
-              document.querySelector('#analyzeExperiments button').setAttribute('data-te-collapse-collapsed', '');
-              document.querySelector('#selectExperimentsCollapse').classList.add('hidden');
-              document.querySelector('#analyzeExperimentsCollapse').classList.add('hidden');
-              document.querySelector('#selectExperimentsCollapse').removeAttribute('data-te-collapse-show');
-              document.querySelector('#analyzeExperimentsCollapse').removeAttribute('data-te-collapse-show');
-          } else {
-              document.querySelector('#combinedExperimentsHeader').setAttribute('aria-expanded', 'true');
-              document.querySelector('#combinedExperimentsHeader').removeAttribute('data-te-collapse-collapsed');
-              document.querySelector('#combinedExperimentsCollapse').classList.remove('hidden');
-              document.querySelector('#combinedExperimentsCollapse').setAttribute('data-te-collapse-show', '');
-              document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'true');
-              document.querySelector('#experimentFiltersHeader').removeAttribute('data-te-collapse-collapsed');
-              document.querySelector('#experimentFiltersCollapse').classList.remove('hidden');
-              document.querySelector('#experimentFiltersCollapse').setAttribute('data-te-collapse-show', '');
-              document.querySelector('#selectExperiments button').setAttribute('aria-expanded', 'true');
-              document.querySelector('#analyzeExperiments button').setAttribute('aria-expanded', 'true');
-              document.querySelector('#selectExperiments button').removeAttribute('data-te-collapse-collapsed');
-              document.querySelector('#analyzeExperiments button').removeAttribute('data-te-collapse-collapsed');
-              document.querySelector('#selectExperimentsCollapse').classList.remove('hidden');
-              document.querySelector('#analyzeExperimentsCollapse').classList.remove('hidden');
-              document.querySelector('#selectExperimentsCollapse').setAttribute('data-te-collapse-show', '');
-              document.querySelector('#analyzeExperimentsCollapse').setAttribute('data-te-collapse-show', '');
-          }
-      });
-  });
+    window.addEventListener("DOMContentLoaded", (event) => {
+    let previousWidth = window.innerWidth;
+
+    function handleResize() {
+        const currentWidth = window.innerWidth;
+
+        if (currentWidth <= 1020 && previousWidth > 1020) {
+            document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "false");
+            document.querySelector("#combinedExperimentsHeader").setAttribute("data-te-collapse-collapsed", "");
+            document.querySelector("#combinedExperimentsCollapse").classList.add("hidden");
+            document.querySelector("#combinedExperimentsCollapse").removeAttribute("data-te-collapse-show");
+            document.querySelector("#experimentFiltersHeader").setAttribute("aria-expanded", "false");
+            document.querySelector("#experimentFiltersHeader").setAttribute("data-te-collapse-collapsed", "");
+            document.querySelector("#experimentFiltersCollapse").classList.add("hidden");
+            document.querySelector("#experimentFiltersCollapse").removeAttribute("data-te-collapse-show");
+            document.querySelector("#selectExperiments button").setAttribute("aria-expanded", "false");
+            document.querySelector("#analyzeExperiments button").setAttribute("aria-expanded", "false");
+            document.querySelector("#selectExperiments button").setAttribute("data-te-collapse-collapsed", "");
+            document.querySelector("#analyzeExperiments button").setAttribute("data-te-collapse-collapsed", "");
+            document.querySelector("#selectExperimentsCollapse").classList.add("hidden");
+            document.querySelector("#analyzeExperimentsCollapse").classList.add("hidden");
+            document.querySelector("#selectExperimentsCollapse").removeAttribute("data-te-collapse-show");
+            document.querySelector("#analyzeExperimentsCollapse").removeAttribute("data-te-collapse-show");
+        } else if (currentWidth > 1020 && previousWidth <= 1020) {
+            document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "true");
+            document.querySelector("#combinedExperimentsHeader").removeAttribute("data-te-collapse-collapsed");
+            document.querySelector("#combinedExperimentsCollapse").classList.remove("hidden");
+            document.querySelector("#combinedExperimentsCollapse").setAttribute("data-te-collapse-show", "");
+            document.querySelector("#experimentFiltersHeader").setAttribute("aria-expanded", "true");
+            document.querySelector("#experimentFiltersHeader").removeAttribute("data-te-collapse-collapsed");
+            document.querySelector("#experimentFiltersCollapse").classList.remove("hidden");
+            document.querySelector("#experimentFiltersCollapse").setAttribute("data-te-collapse-show", "");
+            document.querySelector("#selectExperiments button").setAttribute("aria-expanded", "true");
+            document.querySelector("#analyzeExperiments button").setAttribute("aria-expanded", "true");
+            document.querySelector("#selectExperiments button").removeAttribute("data-te-collapse-collapsed");
+            document.querySelector("#analyzeExperiments button").removeAttribute("data-te-collapse-collapsed");
+            document.querySelector("#selectExperimentsCollapse").classList.remove("hidden");
+            document.querySelector("#analyzeExperimentsCollapse").classList.remove("hidden");
+            document.querySelector("#selectExperimentsCollapse").setAttribute("data-te-collapse-show", "");
+            document.querySelector("#analyzeExperimentsCollapse").setAttribute("data-te-collapse-show", "");
+        }
+
+        previousWidth = currentWidth;
+    }
+
+    // First screen sizing check
+    if (window.innerWidth <= 1020) {
+        document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "false");
+        document.querySelector("#combinedExperimentsHeader").setAttribute("data-te-collapse-collapsed", "");
+        document.querySelector("#combinedExperimentsCollapse").classList.add("hidden");
+        document.querySelector("#combinedExperimentsCollapse").removeAttribute("data-te-collapse-show");
+        document.querySelector("#experimentFiltersHeader").setAttribute("aria-expanded", "false");
+        document.querySelector("#experimentFiltersHeader").setAttribute("data-te-collapse-collapsed", "");
+        document.querySelector("#experimentFiltersCollapse").classList.add("hidden");
+        document.querySelector("#experimentFiltersCollapse").removeAttribute("data-te-collapse-show");
+        document.querySelector("#selectExperiments button").setAttribute("aria-expanded", "false");
+        document.querySelector("#analyzeExperiments button").setAttribute("aria-expanded", "false");
+        document.querySelector("#selectExperiments button").setAttribute("data-te-collapse-collapsed", "");
+        document.querySelector("#analyzeExperiments button").setAttribute("data-te-collapse-collapsed", "");
+        document.querySelector("#selectExperimentsCollapse").classList.add("hidden");
+        document.querySelector("#analyzeExperimentsCollapse").classList.add("hidden");
+        document.querySelector("#selectExperimentsCollapse").removeAttribute("data-te-collapse-show");
+        document.querySelector("#analyzeExperimentsCollapse").removeAttribute("data-te-collapse-show");
+    } else {
+        document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "true");
+        document.querySelector("#combinedExperimentsHeader").removeAttribute("data-te-collapse-collapsed");
+        document.querySelector("#combinedExperimentsCollapse").classList.remove("hidden");
+        document.querySelector("#combinedExperimentsCollapse").setAttribute("data-te-collapse-show", "");
+        document.querySelector("#experimentFiltersHeader").setAttribute("aria-expanded", "true");
+        document.querySelector("#experimentFiltersHeader").removeAttribute("data-te-collapse-collapsed");
+        document.querySelector("#experimentFiltersCollapse").classList.remove("hidden");
+        document.querySelector("#experimentFiltersCollapse").setAttribute("data-te-collapse-show", "");
+        document.querySelector("#selectExperiments button").setAttribute("aria-expanded", "true");
+        document.querySelector("#analyzeExperiments button").setAttribute("aria-expanded", "true");
+        document.querySelector("#selectExperiments button").removeAttribute("data-te-collapse-collapsed");
+        document.querySelector("#analyzeExperiments button").removeAttribute("data-te-collapse-collapsed");
+        document.querySelector("#selectExperimentsCollapse").classList.remove("hidden");
+        document.querySelector("#analyzeExperimentsCollapse").classList.remove("hidden");
+        document.querySelector("#selectExperimentsCollapse").setAttribute("data-te-collapse-show", "");
+        document.querySelector("#analyzeExperimentsCollapse").setAttribute("data-te-collapse-show", "");
+    }
+
+    window.addEventListener("resize", handleResize);
+});
 </script>
 {% if logged_in %}
 <script type="module">

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -299,8 +299,8 @@
     addSelectListeners();
 </script>
 <script>
-function checkWidthToCollapse(currentWidth) {
-    if (currentWidth <= 1020) {
+function checkWidthToCollapse(width) {
+    if (width <= 1020) {
         document.querySelector("#combinedExperimentsHeader").setAttribute("aria-expanded", "false");
         document.querySelector("#combinedExperimentsHeader").setAttribute("data-te-collapse-collapsed", "");
         document.querySelector("#combinedExperimentsCollapse").classList.add("hidden");

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -619,8 +619,8 @@
         }
     </script>
     <script>
-        function checkWidthToCollapse() {
-            if (currentWidth <= 1020) {
+        function checkWidthToCollapse(width) {
+            if (width <= 1020) {
                 document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'false');
                 document.querySelector('#experimentFiltersHeader').setAttribute('data-te-collapse-collapsed', '');
                 document.querySelector('#experimentFiltersCollapse').classList.add('hidden');
@@ -642,7 +642,7 @@
                 let currentWidth = window.innerWidth;
                 if (currentWidth != previousWidth) {
                     checkWidthToCollapse(currendWidth);
-                      previousWidth = currentWidth;
+                    previousWidth = currentWidth;
                 }
             });
         });

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -619,29 +619,8 @@
         }
     </script>
     <script>
-        window.addEventListener('DOMContentLoaded', (event) => {
-            let previousWidth = window.innerWidth;
-
-            function checkWidthToCollapse() {
-                const currentWidth = window.innerWidth;
-
-                if (currentWidth <= 1020 && previousWidth > 1020) {
-                    document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'false');
-                    document.querySelector('#experimentFiltersHeader').setAttribute('data-te-collapse-collapsed', '');
-                    document.querySelector('#experimentFiltersCollapse').classList.add('hidden');
-                    document.querySelector('#experimentFiltersCollapse').removeAttribute('data-te-collapse-show');
-                } else if (currentWidth > 1020 && previousWidth <= 1020) {
-                    document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'true');
-                    document.querySelector('#experimentFiltersHeader').removeAttribute('data-te-collapse-collapsed');
-                    document.querySelector('#experimentFiltersCollapse').classList.remove('hidden');
-                    document.querySelector('#experimentFiltersCollapse').setAttribute('data-te-collapse-show', '');
-                }
-
-                previousWidth = currentWidth;
-            }
-
-            //First screen sizing check
-            if (window.innerWidth <= 1020) {
+        function checkWidthToCollapse() {
+            if (currentWidth <= 1020) {
                 document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'false');
                 document.querySelector('#experimentFiltersHeader').setAttribute('data-te-collapse-collapsed', '');
                 document.querySelector('#experimentFiltersCollapse').classList.add('hidden');
@@ -652,8 +631,20 @@
                 document.querySelector('#experimentFiltersCollapse').classList.remove('hidden');
                 document.querySelector('#experimentFiltersCollapse').setAttribute('data-te-collapse-show', '');
             }
+        }
 
-            window.addEventListener('resize', checkWidthToCollapse);
+        window.addEventListener('DOMContentLoaded', (event) => {
+            checkWidthToCollapse(window.innerWidth);
+
+            let previousWidth = window.innerWidth;
+
+            window.addEventListener("resize", (event) => {
+                let currentWidth = window.innerWidth;
+                if (currentWidth != previousWidth) {
+                    checkWidthToCollapse(currendWidth);
+                      previousWidth = currentWidth;
+                }
+            });
         });
     </script>
 {% endblock %}

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -619,7 +619,28 @@
         }
     </script>
     <script>
-        function checkWidthToCollapse() {
+        window.addEventListener('DOMContentLoaded', (event) => {
+            let previousWidth = window.innerWidth;
+
+            function checkWidthToCollapse() {
+                const currentWidth = window.innerWidth;
+
+                if (currentWidth <= 1020 && previousWidth > 1020) {
+                    document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'false');
+                    document.querySelector('#experimentFiltersHeader').setAttribute('data-te-collapse-collapsed', '');
+                    document.querySelector('#experimentFiltersCollapse').classList.add('hidden');
+                    document.querySelector('#experimentFiltersCollapse').removeAttribute('data-te-collapse-show');
+                } else if (currentWidth > 1020 && previousWidth <= 1020) {
+                    document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'true');
+                    document.querySelector('#experimentFiltersHeader').removeAttribute('data-te-collapse-collapsed');
+                    document.querySelector('#experimentFiltersCollapse').classList.remove('hidden');
+                    document.querySelector('#experimentFiltersCollapse').setAttribute('data-te-collapse-show', '');
+                }
+
+                previousWidth = currentWidth;
+            }
+
+            //First screen sizing check
             if (window.innerWidth <= 1020) {
                 document.querySelector('#experimentFiltersHeader').setAttribute('aria-expanded', 'false');
                 document.querySelector('#experimentFiltersHeader').setAttribute('data-te-collapse-collapsed', '');
@@ -631,10 +652,7 @@
                 document.querySelector('#experimentFiltersCollapse').classList.remove('hidden');
                 document.querySelector('#experimentFiltersCollapse').setAttribute('data-te-collapse-show', '');
             }
-        }
 
-        window.addEventListener('DOMContentLoaded', (event) => {
-            checkWidthToCollapse();
             window.addEventListener('resize', checkWidthToCollapse);
         });
     </script>


### PR DESCRIPTION
On mobile devices, scrolling can sometimes trigger a resize event, which might be causing the tabs to collapse unexpectedly. We are now comparing the current screen size with the previous one to determine if the tabs should collapse or not.

![image](https://github.com/user-attachments/assets/48136601-ba04-4788-aeec-ca711f40db81)
![image](https://github.com/user-attachments/assets/75dcdf8f-111e-466b-9a7e-f715eea45cc0)



