### PR TITLE
Responsive dna_feature profile table

### DIFF
--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -68,9 +68,14 @@
     </div>
 
     <div class="content-container">
-        <div class="bg-gray-100 border-b flex flex-wrap text-center px-5">
+        <div class="bg-gray-100 border-b flex flex-wrap justify-center text-center px-5">
             <div class="flex flex-col items-start ml-3 py-4 flex-grow">
                 <div class="text-base font-bold text-gray-900">DNA Feature Aliases:</div>
+                {% comment %}
+                We want to line break wherever we can for narrow screens if the feature might have
+                a weird, long "name" like gRNAs and DHSs do -- basically anything that is a '"source type"
+                We can identify any of these "source types" because they (and only they) don't have ensembl ids
+                {% endcomment %}
                 <div class="text-base text-gray-700 font-light italic ml-0.5 {% if not feature.ensembl_id %} break-all{% endif %}">
                     {{ feature.name|default:feature.accession_id }}
                 </div>

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -69,40 +69,35 @@
 
     <div class="content-container">
         <div class="bg-gray-100 border-b flex flex-wrap text-center px-5">
-            <div class="flex items-center ml-3 py-4">
+            <div class="flex flex-col items-start ml-3 py-4 flex-grow">
                 <div class="text-base font-bold text-gray-900">DNA Feature Aliases:</div>
-                {% comment %}
-                We want to line break wherever we can for narrow screens if the feature might have
-                a weird, long "name" like gRNAs and DHSs do -- basically anything that is a '"source type"
-                We can identify any of these "source types" because they (and only they) don't have ensembl ids
-                {% endcomment %}
                 <div class="text-base text-gray-700 font-light italic ml-0.5 {% if not feature.ensembl_id %} break-all{% endif %}">
                     {{ feature.name|default:feature.accession_id }}
                 </div>
             </div>
-            <div class="flex items-center ml-3 py-4">
+            <div class="flex flex-col items-start ml-3 py-4 flex-grow">
                 <div class="text-base font-bold text-gray-900">Location:</div>
-                <div class="text-base text-gray-700 font-light italic ml-0.5 flex-wrap">
-                    <a href="{% url 'search:results' %}?query={{ feature.chrom_name }}:{{ feature.location.lower }}-{{ feature.location.upper|add:'-1' }}" class="text-blue-600 no-underline flex-wrap">
+                <div class="text-base text-gray-700 font-light italic ml-0.5">
+                    <a href="{% url 'search:results' %}?query={{ feature.chrom_name }}:{{ feature.location.lower }}-{{ feature.location.upper|add:'-1' }}" class="text-blue-600 no-underline">
                         <span>{{ feature.chrom_name }}</span>:
                         <span>{{ feature.location.lower|intcomma }} - {{ feature.location.upper|add:"-1"|intcomma }}:{{ feature.strand|if_strand }}</span>
                     </a>
                 </div>
             </div>
-            <div class="flex items-center ml-3 py-4">
+            <div class="flex flex-col items-start ml-3 py-4 flex-grow">
                 <div class="text-base font-bold text-gray-900">Reference Genome:</div>
                 <div class="text-base text-gray-700 font-light italic ml-0.5">
                     {{ feature.ref_genome }}
                 </div>
             </div>
-            <div class="flex items-center ml-3 py-4">
+            <div class="flex flex-col items-start ml-3 py-4 flex-grow">
                 <div class="text-base font-bold text-gray-900">Feature Type:</div>
                 <div class="text-base text-gray-700 font-light italic ml-0.5">
                     {{ feature.get_feature_type_display }}
                 </div>
             </div>
             {% if feature.feature_subtype %}
-            <div class="flex items-center ml-3 -mr-1 py-4">
+            <div class="flex flex-col items-start ml-3 py-4 flex-grow">
                 <div class="text-base font-bold text-gray-900">Feature Subtype:</div>
                 <div class="text-base text-gray-700 font-light italic ml-0.5">
                     {{ feature.feature_subtype|remove_underscores }}

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1158,10 +1158,6 @@ input[type="submit"], input[type="button"], button {
   margin-bottom: 1rem;
 }
 
-.-mr-1 {
-  margin-right: -0.25rem;
-}
-
 .mb-0 {
   margin-bottom: 0px;
 }


### PR DESCRIPTION
Reverted to the column structure to ensure all content fits on the same row within the container. Looks cleaner with more space.

![image](https://github.com/user-attachments/assets/c2d21105-cb34-4020-b686-f2c6bc30e37b)
![image](https://github.com/user-attachments/assets/bbec3587-a32e-4744-85dc-2c6d15c42382)

