### PR TITLE
Coverage track

### DIFF
--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -88,7 +88,7 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
     return cast(FeatureJson, result)
 
 
-def reg_effect(re_obj: RegulatoryEffectObservation, options: Optional[dict[str, Any]] = None):
+def reg_effect(re_obj: RegulatoryEffectObservation, options: dict[str, Any]):
     result = {
         "accession_id": re_obj.accession_id,
         "effect_size": re_obj.effect_size,
@@ -99,7 +99,7 @@ def reg_effect(re_obj: RegulatoryEffectObservation, options: Optional[dict[str, 
         "targets": [{"name": feature.name, "ensembl_id": feature.ensembl_id} for feature in re_obj.targets.all()],
     }
 
-    if options is not None and options.get("json_format", None) == "genoverse":
+    if options.get("json_format", None) == "genoverse":
         genoversify(result)
 
     return result

--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -2,6 +2,7 @@ from typing import Any, Iterable, Optional, TypedDict, Union, cast
 
 from cegs_portal.search.json_templates import genoversify
 from cegs_portal.search.models import DNAFeature, RegulatoryEffectObservation
+from cegs_portal.search.view_models.v1.dna_features import LocSearchProperties
 from cegs_portal.utils.pagination_types import Pageable, PageableJson
 
 FeatureJson = TypedDict(
@@ -58,8 +59,6 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
         "type": feature_obj.get_feature_type_display(),
         "subtype": feature_obj.feature_subtype,
         "parent_accession_id": feature_obj.parent_accession_id,
-        "parent_ensembl_id": feature_obj.parent.ensembl_id if feature_obj.parent else None,
-        "parent": feature_obj.parent.name if feature_obj.parent else None,
         "name": feature_obj.name,
         "ids": feature_obj.ids,
         "misc": feature_obj.misc,
@@ -67,21 +66,23 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
     }
 
     if options is not None:
-        feature_properties = set(options.get("feature_properties", []))
-        if "regeffects" in feature_properties:
-            result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
-            result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
-
-        if "effect_directions" in feature_properties:
-            result["effect_directions"] = feature_obj.effect_directions
-
         if options.get("json_format", None) == "genoverse":
             genoversify(result)
 
-        if "screen_ccre" in feature_properties:
+        feature_properties = set(options.get("feature_properties", []))
+        if LocSearchProperties.REG_EFFECTS in feature_properties:
+            result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
+            result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
+
+        if LocSearchProperties.EFFECT_DIRECTIONS in feature_properties:
+            result["effect_directions"] = feature_obj.effect_directions
+
+        if LocSearchProperties.SCREEN_CCRE in feature_properties:
             result["ccre_type"] = feature_obj.ccre_type
 
-        if "parent_subtype" in feature_properties:
+        if LocSearchProperties.PARENT_INFO in feature_properties:
+            result["parent"] = (feature_obj.parent.name if feature_obj.parent else None,)
+            result["parent_ensembl_id"] = (feature_obj.parent.ensembl_id if feature_obj.parent else None,)
             result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None
 
     return cast(FeatureJson, result)

--- a/cegs_portal/search/json_templates/v1/dna_features.py
+++ b/cegs_portal/search/json_templates/v1/dna_features.py
@@ -2,7 +2,7 @@ from typing import Any, Iterable, Optional, TypedDict, Union, cast
 
 from cegs_portal.search.json_templates import genoversify
 from cegs_portal.search.models import DNAFeature, RegulatoryEffectObservation
-from cegs_portal.search.view_models.v1.dna_features import LocSearchProperties
+from cegs_portal.search.view_models.v1.dna_features import LocSearchProperty
 from cegs_portal.utils.pagination_types import Pageable, PageableJson
 
 FeatureJson = TypedDict(
@@ -70,17 +70,17 @@ def feature(feature_obj: DNAFeature, options: Optional[dict[str, Any]] = None) -
             genoversify(result)
 
         feature_properties = set(options.get("feature_properties", []))
-        if LocSearchProperties.REG_EFFECTS in feature_properties:
+        if LocSearchProperty.REG_EFFECTS in feature_properties:
             result["source_for"] = [reg_effect(r, options) for r in feature_obj.source_for.all()]
             result["target_of"] = [reg_effect(r, options) for r in feature_obj.target_of.all()]
 
-        if LocSearchProperties.EFFECT_DIRECTIONS in feature_properties:
+        if LocSearchProperty.EFFECT_DIRECTIONS in feature_properties:
             result["effect_directions"] = feature_obj.effect_directions
 
-        if LocSearchProperties.SCREEN_CCRE in feature_properties:
+        if LocSearchProperty.SCREEN_CCRE in feature_properties:
             result["ccre_type"] = feature_obj.ccre_type
 
-        if LocSearchProperties.PARENT_INFO in feature_properties:
+        if LocSearchProperty.PARENT_INFO in feature_properties:
             result["parent"] = (feature_obj.parent.name if feature_obj.parent else None,)
             result["parent_ensembl_id"] = (feature_obj.parent.ensembl_id if feature_obj.parent else None,)
             result["parent_subtype"] = feature_obj.parent.feature_subtype if feature_obj.parent else None

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -36,9 +36,7 @@ def test_feature(feature: DNAFeature, effect_dir_feature: DNAFeature):
         "type": feature.get_feature_type_display(),
         "subtype": feature.feature_subtype,
         "ref_genome": feature.ref_genome,
-        "parent": feature.parent if feature.parent is not None else None,
         "parent_accession_id": feature.parent_accession_id if feature.parent is not None else None,
-        "parent_ensembl_id": feature.parent_ensembl_id if feature.parent is not None else None,
         "misc": feature.misc,
     }
     if feature.closest_gene is not None:
@@ -58,7 +56,9 @@ def test_feature(feature: DNAFeature, effect_dir_feature: DNAFeature):
     f_dict = f_json(effect_dir_feature, {"feature_properties": ["effect_directions"]})
     assert "effect_directions" in f_dict
 
-    f_dict = f_json(effect_dir_feature, {"feature_properties": ["parent_subtype"]})
+    f_dict = f_json(effect_dir_feature, {"feature_properties": ["parent_info"]})
+    assert "parent" in f_dict
+    assert "parent_ensembl_id" in f_dict
     assert "parent_subtype" in f_dict
 
     result["id"] = result["accession_id"]

--- a/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_dna_features.py
@@ -77,6 +77,6 @@ def test_reg_effect(reg_effect: RegulatoryEffectObservation):
         "targets": [{"name": feature.name, "ensembl_id": feature.ensembl_id} for feature in reg_effect.targets.all()],
     }
 
-    assert re_json(reg_effect) == result
+    assert re_json(reg_effect, {}) == result
     result["id"] = result["accession_id"]
     assert re_json(reg_effect, {"json_format": "genoverse"}) == result

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -174,7 +174,7 @@ Genoverse.Track.Model.DHS = Genoverse.Track.Model.extend({
 });
 
 Genoverse.Track.View.DHS = Genoverse.Track.View.extend({
-    featureHeight: 10,
+    featureHeight: 15,
     labels: true,
     repeatLabels: true,
     bump: true,
@@ -374,6 +374,7 @@ Genoverse.Track.Model.Gene.Portal = Genoverse.Track.Model.Gene.extend({
 });
 
 Genoverse.Track.View.Gene.Portal = Genoverse.Track.View.Gene.extend({
+    featureHeight: 13,
     setFeatureColor: function (feature) {
         if (feature.subtype === "Protein Coding") {
             feature.color = "#A00000";
@@ -465,6 +466,7 @@ Genoverse.Track.Model.Transcript.Portal = Genoverse.Track.Model.Transcript.exten
 });
 
 Genoverse.Track.View.Transcript.Portal = Genoverse.Track.View.Transcript.extend({
+    featureHeight: 13,
     setFeatureColor: function (feature) {
         var processedTranscript = {
             "sense intronic": 1,
@@ -725,12 +727,12 @@ Genoverse.Track.DHS.Effects = Genoverse.Track.DHS.extend({
     configSettings: {
         squish: {
             true: {
-                featureHeight: 2,
+                featureHeight: 7,
                 featureMargin: {top: 1, right: 1, bottom: 1, left: 0},
                 labels: false,
             },
             false: {
-                featureHeight: 6,
+                featureHeight: 15,
                 featureMargin: {top: 2, right: 2, bottom: 2, left: 0},
                 labels: true,
             },

--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -153,6 +153,21 @@ Genoverse.Track.View.cCRE = Genoverse.Track.View.extend({
     },
 });
 
+Genoverse.Track.Model.Coverage = Genoverse.Track.Model.extend({
+    url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&search_type=overlap&accept=application/json&format=genoverse&property=reo_source",
+    dataRequestLimit: 5000000,
+});
+
+Genoverse.Track.View.Coverage = Genoverse.Track.View.extend({
+    featureHeight: 15,
+    labels: false,
+    repeatLabels: true,
+    bump: false,
+    setFeatureColor: function (feature) {
+        feature.color = "#502050";
+    },
+});
+
 Genoverse.Track.Model.DHS = Genoverse.Track.Model.extend({
     url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&search_type=overlap&accept=application/json&format=genoverse&feature_type=DHS&feature_type=cCRE&feature_type=gRNA&feature_type=Chromatin%20Accessible%20Region&property=effect_directions&property=significant",
     dataRequestLimit: 5000000,
@@ -377,7 +392,7 @@ Genoverse.Track.View.Gene.Portal = Genoverse.Track.View.Gene.extend({
 });
 
 Genoverse.Track.Model.Transcript.Portal = Genoverse.Track.Model.Transcript.extend({
-    url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&accept=application/json&format=genoverse&feature_type=Transcript&feature_type=Exon&property=parent_subtype",
+    url: "/search/featureloc/__CHR__/__START__/__END__?assembly=__ASSEMBLY__&accept=application/json&format=genoverse&feature_type=Transcript&feature_type=Exon&property=parent_info",
     dataRequestLimit: 5000000, // As per e! REST API restrictions
 
     setDefaults: function () {
@@ -518,6 +533,57 @@ Genoverse.Track.cCRE = Genoverse.Track.extend({
 
                 this.container
                     .attr("title", f.ccre_type)
+                    .tipsy({trigger: "manual", container: "body", offset: -15})
+                    .tipsy("show")
+                    .data("tipsy")
+                    .$tip.css("left", function () {
+                        return e.clientX - Genoverse.jQuery(this).width() / 2;
+                    });
+            } else {
+                this.container.tipsy("hide");
+            }
+        }
+    },
+    addUserEventHandlers: function () {
+        var track = this;
+
+        this.base();
+
+        this.container.on(
+            {
+                mousemove: function (e) {
+                    track.click(e);
+                },
+                mouseout: function (e) {
+                    track.container.tipsy("hide");
+                },
+            },
+            ".gv-image-container",
+        );
+    },
+});
+
+Genoverse.Track.Coverage = Genoverse.Track.extend({
+    id: "coverage",
+    name: "Coverage",
+    resizable: false,
+    model: Genoverse.Track.Model.Coverage,
+    view: Genoverse.Track.View.Coverage,
+    border: false,
+    controls: "off",
+    click: function (e) {
+        var target = Genoverse.jQuery(e.target);
+        var x = e.pageX - this.container.parent().offset().left + this.browser.scaledStart;
+        var y = e.pageY - target.offset().top;
+
+        if (e.type === "mousemove") {
+            var f = this.getClickedFeatures(x, 3, target)[0];
+
+            if (f) {
+                this.container.tipsy("hide");
+
+                this.container
+                    .attr("title", f.type)
                     .tipsy({trigger: "manual", container: "body", offset: -15})
                     .tipsy("show")
                     .data("tipsy")

--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -460,6 +460,7 @@
                 Genoverse.Track.Scaleline.extend({ strand: false }),
                 Genoverse.Track.Scalebar,
                 Genoverse.Track.cCRE,
+                Genoverse.Track.Coverage,
                 Genoverse.Track.DHS.Effects,
                 Genoverse.Track.Gene,
             ]

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -642,7 +642,7 @@
             window.addEventListener("resize", (event) => {
                 let currentWidth = window.innerWidth;
                 if (currentWidth != previousWidth) {
-                    checkWidthToCollapse(currendWidth);
+                    checkWidthToCollapse(currentWidth);
                     previousWidth = currentWidth;
                 }
             });

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -598,6 +598,7 @@
                 Genoverse.Track.Scaleline.extend({ strand: false }),
                 Genoverse.Track.Scalebar,
                 Genoverse.Track.cCRE,
+                Genoverse.Track.Coverage,
                 Genoverse.Track.DHS.Effects,
                 Genoverse.Track.Gene,
             ]

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -27,7 +27,7 @@ class LocSearchType(Enum):
     OVERLAP = "overlap"
 
 
-class LocSearchProperties(StrEnum):
+class LocSearchProperty(StrEnum):
     EFFECT_DIRECTIONS = "effect_directions"
     PARENT_INFO = "parent_info"
     REG_EFFECTS = "regeffects"
@@ -240,7 +240,7 @@ class DNAFeatureSearch:
 
         prefetch_values = ["parent", "parent_accession"]
 
-        if LocSearchProperties.SCREEN_CCRE in feature_properties:
+        if LocSearchProperty.SCREEN_CCRE in feature_properties:
             ccre_facet_id = Facet.objects.get(name="cCRE Category").id
             ccre_facet_values = FacetValue.objects.filter(facet_id=ccre_facet_id).values_list("id", flat=True)
             facets += ccre_facet_values
@@ -249,7 +249,7 @@ class DNAFeatureSearch:
             filters["facet_values__id__in"] = facets
             prefetch_values.extend(["facet_values", "facet_values__facet"])
 
-        if LocSearchProperties.REG_EFFECTS in feature_properties:
+        if LocSearchProperty.REG_EFFECTS in feature_properties:
             # The facet presets are used when getting the "direction" property
             # of a RegulatoryEffectObservation. This is done in the _reg_effect.html partial
             # and the reg_effect function of the dna_features.py json template.
@@ -271,16 +271,16 @@ class DNAFeatureSearch:
         features = DNAFeature.objects
 
         reo_count_properties = {
-            LocSearchProperties.EFFECT_DIRECTIONS,
-            LocSearchProperties.SIGNIFICANT,
-            LocSearchProperties.REO_SOURCE,
+            LocSearchProperty.EFFECT_DIRECTIONS,
+            LocSearchProperty.SIGNIFICANT,
+            LocSearchProperty.REO_SOURCE,
         }
         if any(p in reo_count_properties for p in feature_properties):
             # skip any feature that are not the sources for any REOs
             features = features.annotate(reo_count=Count("source_for"))
             filters["reo_count__gt"] = 0
 
-        if LocSearchProperties.EFFECT_DIRECTIONS in feature_properties:
+        if LocSearchProperty.EFFECT_DIRECTIONS in feature_properties:
             features = features.annotate(
                 effect_directions=ArrayAgg(
                     "source_for__facet_values__value",
@@ -289,7 +289,7 @@ class DNAFeatureSearch:
                 )
             )
 
-        if LocSearchProperties.SIGNIFICANT in feature_properties:
+        if LocSearchProperty.SIGNIFICANT in feature_properties:
             features = features.annotate(
                 sig_count=Count(
                     "source_for__facet_values__value",
@@ -298,7 +298,7 @@ class DNAFeatureSearch:
             )
             filters["sig_count__gt"] = 0
 
-        if LocSearchProperties.SCREEN_CCRE in feature_properties:
+        if LocSearchProperty.SCREEN_CCRE in feature_properties:
             features = features.annotate(
                 ccre_type=Subquery(FacetValue.objects.filter(id__in=OuterRef("facet_values__id")).values("value"))
             )

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -31,6 +31,7 @@ class LocSearchProperties(StrEnum):
     EFFECT_DIRECTIONS = "effect_directions"
     PARENT_INFO = "parent_info"
     REG_EFFECTS = "regeffects"
+    REO_SOURCE = "reo_source"
     SCREEN_CCRE = "screen_ccre"
     SIGNIFICANT = "significant"
 
@@ -272,6 +273,7 @@ class DNAFeatureSearch:
         reo_count_properties = {
             LocSearchProperties.EFFECT_DIRECTIONS,
             LocSearchProperties.SIGNIFICANT,
+            LocSearchProperties.REO_SOURCE,
         }
         if any(p in reo_count_properties for p in feature_properties):
             # skip any feature that are not the sources for any REOs

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, Optional, cast
 
 from django.contrib.postgres.aggregates import ArrayAgg
@@ -25,6 +25,14 @@ class LocSearchType(Enum):
     CLOSEST = "closest"
     EXACT = "exact"
     OVERLAP = "overlap"
+
+
+class LocSearchProperties(StrEnum):
+    EFFECT_DIRECTIONS = "effect_directions"
+    PARENT_INFO = "parent_info"
+    REG_EFFECTS = "regeffects"
+    SCREEN_CCRE = "screen_ccre"
+    SIGNIFICANT = "significant"
 
 
 def join_fields(*field_names):
@@ -231,7 +239,7 @@ class DNAFeatureSearch:
 
         prefetch_values = ["parent", "parent_accession"]
 
-        if "screen_ccre" in feature_properties:
+        if LocSearchProperties.SCREEN_CCRE in feature_properties:
             ccre_facet_id = Facet.objects.get(name="cCRE Category").id
             ccre_facet_values = FacetValue.objects.filter(facet_id=ccre_facet_id).values_list("id", flat=True)
             facets += ccre_facet_values
@@ -240,7 +248,7 @@ class DNAFeatureSearch:
             filters["facet_values__id__in"] = facets
             prefetch_values.extend(["facet_values", "facet_values__facet"])
 
-        if "regeffects" in feature_properties:
+        if LocSearchProperties.REG_EFFECTS in feature_properties:
             # The facet presets are used when getting the "direction" property
             # of a RegulatoryEffectObservation. This is done in the _reg_effect.html partial
             # and the reg_effect function of the dna_features.py json template.
@@ -261,12 +269,16 @@ class DNAFeatureSearch:
 
         features = DNAFeature.objects
 
-        if any(p in {"effect_directions", "significant"} for p in feature_properties):
+        reo_count_properties = {
+            LocSearchProperties.EFFECT_DIRECTIONS,
+            LocSearchProperties.SIGNIFICANT,
+        }
+        if any(p in reo_count_properties for p in feature_properties):
             # skip any feature that are not the sources for any REOs
             features = features.annotate(reo_count=Count("source_for"))
             filters["reo_count__gt"] = 0
 
-        if "effect_directions" in feature_properties:
+        if LocSearchProperties.EFFECT_DIRECTIONS in feature_properties:
             features = features.annotate(
                 effect_directions=ArrayAgg(
                     "source_for__facet_values__value",
@@ -275,7 +287,7 @@ class DNAFeatureSearch:
                 )
             )
 
-        if "significant" in feature_properties:
+        if LocSearchProperties.SIGNIFICANT in feature_properties:
             features = features.annotate(
                 sig_count=Count(
                     "source_for__facet_values__value",
@@ -284,15 +296,13 @@ class DNAFeatureSearch:
             )
             filters["sig_count__gt"] = 0
 
-        if "screen_ccre" in feature_properties:
+        if LocSearchProperties.SCREEN_CCRE in feature_properties:
             features = features.annotate(
                 ccre_type=Subquery(FacetValue.objects.filter(id__in=OuterRef("facet_values__id")).values("value"))
             )
 
-        features = features.filter(**filters).prefetch_related(*prefetch_values)
+        features = features.filter(**filters).prefetch_related(*prefetch_values).select_related("parent")
 
-        if "parent_subtype" in feature_properties:
-            features = features.select_related("parent")
         return features.order_by("location")
 
     @classmethod

--- a/cegs_portal/search/views/v1/dna_features.py
+++ b/cegs_portal/search/views/v1/dna_features.py
@@ -13,19 +13,13 @@ from cegs_portal.search.views.custom_views import (
     ExperimentAccessMixin,
     MultiResponseFormatView,
 )
+from cegs_portal.utils import truthy_to_bool
 from cegs_portal.utils.http_exceptions import Http400
 
 DEFAULT_TABLE_LENGTH = 20
 HG19 = "hg19"
 HG38 = "hg38"
 ALL_ASSEMBLIES = [HG38, HG19]  # Ordered by descending "importance"
-
-
-def get_sig_only(value):
-    if value == "0" or value == "false" or value == "False":
-        return False
-    else:
-        return True
 
 
 def normalize_assembly(value):
@@ -85,8 +79,7 @@ class DNAFeatureId(ExperimentAccessMixin, MultiResponseFormatView):
         options["assembly"] = normalize_assembly(request.GET.get("assembly", None))
         options["feature_properties"] = request.GET.getlist("property", [])
         options["json_format"] = request.GET.get("format", None)
-        sig_only = request.GET.get("sig_only", True)
-        options["sig_only"] = get_sig_only(sig_only)
+        options["sig_only"] = truthy_to_bool(request.GET.get("sig_only", True))
         return options
 
     def get(self, request, options, data, id_type, feature_id):
@@ -227,6 +220,7 @@ class DNAFeatureLoc(MultiResponseFormatView):
         options["facets"] = [int(facet) for facet in request.GET.getlist("facet", [])]
         options["page"] = int(request.GET.get("page", 1))
         options["per_page"] = int(request.GET.get("per_page", 20))
+        options["paginate"] = truthy_to_bool(request.GET.get("paginate", False))
         options["json_format"] = request.GET.get("format", None)
         options["dist"] = int(request.GET.get("dist", 0))
         options["tsv_format"] = request.GET.get("tsv_format", None)

--- a/cegs_portal/search/views/v1/dna_features.py
+++ b/cegs_portal/search/views/v1/dna_features.py
@@ -202,7 +202,12 @@ class DNAFeatureLoc(MultiResponseFormatView):
             format
                 * "genoverse" - only relevant for json
             property (multiple)
+                Be careful combining these, their effects are no necessarily orthogonal
                 * "regeffects" - preload associated reg effects
+                * "screen_ccre" - include screen cCRE type
+                * "effect_directions" - include effect directions of associated REOs
+                * "significant" - include only feature that are the source of significant REOs
+                * "reo_source" - include features that are the source for an REO
             search_type
                 * "exact" - match location exactly
                 * "overlap" - match any overlapping feature

--- a/cegs_portal/search/views/v1/non_targeting_reos.py
+++ b/cegs_portal/search/views/v1/non_targeting_reos.py
@@ -16,6 +16,7 @@ from cegs_portal.search.views.custom_views import (
     ExperimentAccessMixin,
     MultiResponseFormatView,
 )
+from cegs_portal.utils import truthy_to_bool
 from cegs_portal.utils.pagination_types import Pageable
 
 
@@ -61,17 +62,10 @@ class NonTargetRegEffectsView(ExperimentAccessMixin, MultiResponseFormatView):
                 * whether or not to include only significant observations
         """
 
-        def get_sig_only(value):
-            if value == "0" or value == "false" or value == "False":
-                return False
-            else:
-                return True
-
         options = super().request_options(request)
         options["page"] = int(request.GET.get("page", 1))
         options["per_page"] = int(request.GET.get("per_page", 20))
-        sig_only = request.GET.get("sig_only", True)
-        options["sig_only"] = get_sig_only(sig_only)
+        options["sig_only"] = truthy_to_bool(request.GET.get("sig_only", True))
         options["tsv_format"] = request.GET.get("tsv_format", None)
 
         return options

--- a/cegs_portal/search/views/v1/reg_effects.py
+++ b/cegs_portal/search/views/v1/reg_effects.py
@@ -18,6 +18,7 @@ from cegs_portal.search.views.custom_views import (
     ExperimentAccessMixin,
     MultiResponseFormatView,
 )
+from cegs_portal.utils import truthy_to_bool
 
 
 class RegEffectView(ExperimentAccessMixin, MultiResponseFormatView):
@@ -168,17 +169,10 @@ class FeatureEffectsView(ExperimentAccessMixin, MultiResponseFormatView):
                 * whether or not to include only significant observations
         """
 
-        def get_sig_only(value):
-            if value == "0" or value == "false" or value == "False":
-                return False
-            else:
-                return True
-
         options = super().request_options(request)
         options["page"] = int(request.GET.get("page", 1))
         options["per_page"] = int(request.GET.get("per_page", 20))
-        sig_only = request.GET.get("sig_only", True)
-        options["sig_only"] = get_sig_only(sig_only)
+        options["sig_only"] = truthy_to_bool(request.GET.get("sig_only", True))
         options["tsv_format"] = request.GET.get("tsv_format", None)
 
         return options

--- a/cegs_portal/task_status/views.py
+++ b/cegs_portal/task_status/views.py
@@ -3,16 +3,10 @@ from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 
 from cegs_portal.search.views.custom_views import MultiResponseFormatView
+from cegs_portal.utils import truthy_to_bool
 
 from .json_templates.task_status import task_status, task_statuses
 from .view_models import get_status
-
-
-def get_bool_param(value):
-    if value == "0" or value == "false" or value == "False":
-        return False
-    else:
-        return True
 
 
 class TaskStatusView(UserPassesTestMixin, MultiResponseFormatView):
@@ -60,7 +54,7 @@ class TaskStatusListView(UserPassesTestMixin, MultiResponseFormatView):
         options = super().request_options(request)
         options["page"] = int(request.GET.get("page", 1))
         options["per_page"] = int(request.GET.get("per_page", 20))
-        options["paginate"] = get_bool_param(request.GET.get("paginate", True))
+        options["paginate"] = truthy_to_bool(request.GET.get("paginate", True))
         return options
 
     def get(self, request, options, data, username):

--- a/cegs_portal/utils/__init__.py
+++ b/cegs_portal/utils/__init__.py
@@ -1,0 +1,8 @@
+def truthy_to_bool(value):
+    if isinstance(value, bool):
+        return value
+
+    if value == "0" or value == "false" or value == "False":
+        return False
+    else:
+        return True


### PR DESCRIPTION
New Coverage track:
![Screenshot 2024-10-03 at 1 42 34 PM](https://github.com/user-attachments/assets/50877f68-e93f-4900-a31e-d530829a8141)

This track shows all the features that are sources for REOs.

A new `feature_property` was added to the featureloc endpoint. Since there were so many `feature_properties` this got cleaned up a little by replacing all the strings with a StrEnum containing the feature_properties. This will help us keep straight what properties exist and avoid typos, since python will complain if we try to use a non-existent LocSearchProperties.

Random "leave it better than you found it"s:
* a feature's parent is always used (the parent.name property is always accessed) so we always select_related("parent")
* other parent properties are only used when the parent_info feature property is sent, so those are hidden behind that `feature_property` query
* Gene, Tested Element, and Transcript heights were increased in Genovese
* a typo on search_results was fixed
* the options dict for the `reg_effect` function in dna_features.py json template will always exist in practice, so it's no longer optional.

