### PR TITLE
Text changes for clarity

### DIFF
--- a/cegs_portal/search/templates/search/v1/partials/_search_feature_counts.html
+++ b/cegs_portal/search/templates/search/v1/partials/_search_feature_counts.html
@@ -1,6 +1,6 @@
 {% load humanize %}
 
-<div class="text-xl font-bold">Results for {{ region.chromo }}: {{ region.range.lower|intcomma }} - {{ region.range.upper|intcomma }}</div>
+<div class="text-xl font-bold">Summary Results for {{ region.chromo }}: {{ region.range.lower|intcomma }} - {{ region.range.upper|intcomma }}</div>
 <div class="flex flex-wrap md:flex-row md:flex-nowrap mt-3 sm:mt-1 gap-5">
     {% for feature, count, sig_count in feature_counts %}
     <div class="justify-self-start">{{ feature }}s: <span class="font-bold">{{ count }}</span>

--- a/cegs_portal/search/templates/search/v1/partials/_search_feature_counts.html
+++ b/cegs_portal/search/templates/search/v1/partials/_search_feature_counts.html
@@ -1,6 +1,6 @@
 {% load humanize %}
 
-<div class="text-xl font-bold">DNA Feature Counts for {{ region.chromo }}: {{ region.range.lower|intcomma }} - {{ region.range.upper|intcomma }}</div>
+<div class="text-xl font-bold">Results for {{ region.chromo }}: {{ region.range.lower|intcomma }} - {{ region.range.upper|intcomma }}</div>
 <div class="flex flex-wrap md:flex-row md:flex-nowrap mt-3 sm:mt-1 gap-5">
     {% for feature, count, sig_count in feature_counts %}
     <div class="justify-self-start">{{ feature }}s: <span class="font-bold">{{ count }}</span>

--- a/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects.html
+++ b/cegs_portal/search/templates/search/v1/partials/_sig_reg_effects.html
@@ -1,5 +1,5 @@
 {% if sig_reg_effects|length > 0 %}
-<div class="text-xl font-bold">Most Significant Reg Effect Observations</div>
+<div class="text-xl font-bold">Top Significant Reg Effect Observations</div>
 {% include "search/v1/partials/_sig_reg_effects_table.html" with sig_reg_effects=sig_reg_effects %}
 {% else %}
 No Relevant Reg Effect Observations Found

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -301,7 +301,7 @@
                                 aria-expanded="true"
                                 aria-controls="experimentFiltersCollapse">
                                 <div class="flex justify-center items-center">
-                                    <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Facets</div>
+                                    <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Region</div>
                                 </div>
                                 <div class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 rotate-180">

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -616,7 +616,7 @@ def test_sigdata(reg_effects, client: Client):
         r"\s+",
         " ",
         f"""
-    <div class="text-xl font-bold">Most Significant Reg Effect Observations</div>
+    <div class="text-xl font-bold">Top Significant Reg Effect Observations</div>
 
     <div class="overflow-x-auto">
     <table class="data-table no-hover">


### PR DESCRIPTION
The ‘Show results for a genomic region’ card on the homepage matches the ‘Results’ for chr11: 33,858,576 - 33,892,076 (region) text shown on the search results page. Describing it as ‘Top significant effect observation’ might be more descriptive of what we are showing the user. Additionally, using ‘Filter Region’ could bring more clarity. Our goal is to make the portal as intuitive as possible.

![image](https://github.com/user-attachments/assets/50cf5f59-08ac-4797-85c8-419ae39c8bb7)
![image](https://github.com/user-attachments/assets/4699ed88-4c0c-482b-9051-49ab1abec01f)


