### PR TITLE
Remove download/upload buttons on smaller screens

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -337,7 +337,7 @@
                     <div id="chrom-data-counts"></div>
                 </div>
 
-                <div class="facet-content-section content-container">
+                <div class="facet-content-section content-container hidden md:block">
                     <form name="regionUploadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="regionFile">Highlight Regions</label>
@@ -349,7 +349,7 @@
                 </div>
 
                 {% if logged_in %}
-                <div class="facet-content-section content-container">
+                <div class="facet-content-section content-container hidden md:block">
                     <form name="dataDownloadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="dataDlAll">Download All Selected Data*</label>

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -214,7 +214,7 @@
                     </div>
                     {% if logged_in %}
                     <div
-                      class="bg-white">
+                      class="bg-white hidden md:block">
                       <h2 class="accordion-header mb-0" id="downloadData">
                         <button
                           class="remove-lr-margin data-[twe-collapse-collapsed] group relative flex w-full items-center border-0 bg-white py-4 text-left text-base text-neutral-800 transition [overflow-anchor:none] hover:z-[2] focus:z-[3] focus:outline-none data-[twe-collapse-collapsed]:rounded-b-lg"

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -237,7 +237,7 @@
                     <div id="chrom-data-counts"></div>
                 </div>
 
-                <div class="facet-content-section content-container mx-auto">
+                <div class="facet-content-section content-container mx-auto hidden md:block">
                     <form name="regionUploadForm">
                             <label class="font-bold flex justify-center" for="regionFile">Highlight Regions</label>
                             <input class="hidden" id="regionUploadInput" type="file" accept=".bed" name="regionFile"/>
@@ -247,7 +247,7 @@
                 </div>
 
                 {% if logged_in %}
-                <div class="facet-content-section content-container mx-auto">
+                <div class="facet-content-section content-container mx-auto hidden md:block">
                     <form name="dataDownloadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="dataDlAll">Download All Selected Data*</label>

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -349,7 +349,7 @@
                     </div>
 
                     {% if logged_in %}
-                    <div class="content-container">
+                    <div class="content-container hidden md:block">
                         <form name="dataDownloadForm">
                             <div>
                                 <label class="font-bold flex justify-center" for="dataDlAll">Download Region Data*</label>

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -3015,6 +3015,10 @@ fieldset legend {
     display: block;
   }
 
+  .md\:hidden {
+    display: none;
+  }
+
   .md\:w-1\/4 {
     width: 25%;
   }

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -3015,10 +3015,6 @@ fieldset legend {
     display: block;
   }
 
-  .md\:hidden {
-    display: none;
-  }
-
   .md\:w-1\/4 {
     width: 25%;
   }


### PR DESCRIPTION
When users log in, certain buttons alter the intuitive layout design on smaller screens. Additionally, users on smaller devices are less likely to download or upload data.

![image](https://github.com/user-attachments/assets/8fa0e274-6741-4c3e-9b45-948d6b31eaf2)

Highlight regions button removed:
![image](https://github.com/user-attachments/assets/ea6dce13-0386-49d2-b052-f6ceb53dd61b)

![image](https://github.com/user-attachments/assets/fd0e9290-76f7-42ea-abcb-965f76f8cb8a)

Highlight regions and download buttons removed:
![image](https://github.com/user-attachments/assets/a0c5706f-ab44-47f5-a932-5342adf46312)
![image](https://github.com/user-attachments/assets/fdfcc7c9-e111-4958-845e-428a13c663c4)


Download Region Data button removed:
![image](https://github.com/user-attachments/assets/b5910a0c-62f8-4514-9d70-7eb085645064)


![image](https://github.com/user-attachments/assets/30d437f6-94f0-4679-8f3b-72a43288c37e)

Download data from selected experiments button removed:
![image](https://github.com/user-attachments/assets/a7de337f-a4a4-484d-ab67-4437169ad056)



