### PR TITLE
Update psycopg from 2 to 3

### DIFF
--- a/cegs_portal/get_expr_data/conftest.py
+++ b/cegs_portal/get_expr_data/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from django.core.files.storage import default_storage
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.get_expr_data.models import (
     EXPR_DATA_DIR,
@@ -45,21 +45,21 @@ def _reg_effects(public=True, archived=False) -> list[RegulatoryEffectObservatio
         DNAFeatureFactory(
             accession_id="DCPDHS0000000000",
             chrom_name="chr1",
-            location=NumericRange(10, 1_000),
+            location=Int4Range(10, 1_000),
             experiment_accession=None,
             feature_type=DNAFeatureType.GRNA,
         ),
         DNAFeatureFactory(
             accession_id="DCPDHS0000000001",
             chrom_name="chr1",
-            location=NumericRange(20_000, 111_000),
+            location=Int4Range(20_000, 111_000),
             experiment_accession=None,
             feature_type=DNAFeatureType.DHS,
         ),
         DNAFeatureFactory(
             accession_id="DCPDHS0000000002",
             chrom_name="chr2",
-            location=NumericRange(22_222, 33_333),
+            location=Int4Range(22_222, 33_333),
             experiment_accession=None,
             feature_type=DNAFeatureType.CAR,
         ),
@@ -81,13 +81,13 @@ def _reg_effects(public=True, archived=False) -> list[RegulatoryEffectObservatio
         sources=(
             DNAFeatureFactory(
                 chrom_name="chr1",
-                location=NumericRange(11, 1_001),
+                location=Int4Range(11, 1_001),
                 experiment_accession=None,
                 feature_type=DNAFeatureType.GRNA,
             ),
             DNAFeatureFactory(
                 chrom_name="chr2",
-                location=NumericRange(22_223, 33_334),
+                location=Int4Range(22_223, 33_334),
                 experiment_accession=None,
                 feature_type=DNAFeatureType.CAR,
             ),
@@ -97,7 +97,7 @@ def _reg_effects(public=True, archived=False) -> list[RegulatoryEffectObservatio
                 chrom_name="chr1",
                 name="XUEQ-1",
                 ensembl_id="ENSG01124619313",
-                location=NumericRange(35_001, 40_001),
+                location=Int4Range(35_001, 40_001),
                 experiment_accession=None,
                 feature_type=DNAFeatureType.GENE,
             ),

--- a/cegs_portal/get_expr_data/tests.py
+++ b/cegs_portal/get_expr_data/tests.py
@@ -101,9 +101,9 @@ def test_gen_output_filename(expr_accession_ids, an_accession_ids, valid):
 @pytest.mark.parametrize(
     "source_locs,result",
     [
-        ('{"(,)"}', []),
-        (r'{"(chr1,\"[11,1001)\")"}', ["chr1:11-1001"]),
-        (r'{"(chr1,\"[11,1001)\")","(chr2,\"[22223,33334)\")"}', ["chr1:11-1001", "chr2:22223-33334"]),
+        ([(None, None)], []),
+        ([("chr1", "[11,1001)")], ["chr1:11-1001"]),
+        ([("chr1", "[11,1001)"), ("chr2", "[22223,33334)")], ["chr1:11-1001", "chr2:22223-33334"]),
     ],
 )
 def test_parse_source_locs(source_locs, result):
@@ -113,10 +113,13 @@ def test_parse_source_locs(source_locs, result):
 @pytest.mark.parametrize(
     "target_info,result",
     [
-        ('{"(,,,)"}', []),
-        (r'{"(chr1,\"[35001,40001)\",GWSR-1,ENSG20717717659)"}', ["GWSR-1:ENSG20717717659"]),
+        ([(None, None, None, None)], []),
+        ([("chr1", "[35001,40001)", "GWSR-1", "ENSG20717717659")], ["GWSR-1:ENSG20717717659"]),
         (
-            r'{"(chr1,\"[35001,40001)\",GWSR-1,ENSG20717717659)","(chr1,\"[35000,40000)\",PKND-1,ENSG20717717659)"}',
+            [
+                ("chr1", "[35001,40001)", "GWSR-1", "ENSG20717717659"),
+                ("chr1", "[35000,40000)", "PKND-1", "ENSG20717717659"),
+            ],
             ["GWSR-1:ENSG20717717659", "PKND-1:ENSG20717717659"],
         ),
     ],

--- a/cegs_portal/get_expr_data/view_models.py
+++ b/cegs_portal/get_expr_data/view_models.py
@@ -11,7 +11,7 @@ from uuid import UUID, uuid4
 from django.core.files.storage import default_storage
 from django.db import connection
 from huey.contrib.djhuey import db_task
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range, NumericRange
 
 from cegs_portal.get_expr_data.models import ExperimentData, expr_data_base_path
 
@@ -262,21 +262,21 @@ def retrieve_experiment_data(
                             AND get_expr_data_reo_sources_targets.source_loc && %s)"""
             for i, (chrom, start, end) in zip(inputs, regions):
                 i.append(chrom)
-                i.append(NumericRange(start, end))
+                i.append(Int4Range(start, end))
         case ReoDataSource.TARGETS:
             where = f"""{where} AND (get_expr_data_reo_sources_targets.target_chrom = %s
                             AND get_expr_data_reo_sources_targets.target_loc && %s)"""
             for i, (chrom, start, end) in zip(inputs, regions):
                 i.append(chrom)
-                i.append(NumericRange(start, end))
+                i.append(Int4Range(start, end))
         case ReoDataSource.BOTH:
             where = f"""{where} AND ((get_expr_data_reo_sources_targets.source_chrom = %s AND get_expr_data_reo_sources_targets.source_loc && %s)
                             OR (get_expr_data_reo_sources_targets.target_chrom = %s AND get_expr_data_reo_sources_targets.target_loc && %s))"""
             for i, (chrom, start, end) in zip(inputs, regions):
                 i.append(chrom)
-                i.append(NumericRange(start, end))
+                i.append(Int4Range(start, end))
                 i.append(chrom)
-                i.append(NumericRange(start, end))
+                i.append(Int4Range(start, end))
         case ReoDataSource.EVERYTHING:
             pass
         case _:
@@ -369,9 +369,9 @@ def sig_reo_loc_search(
     inputs = [
         experiments,
         location[0],
-        NumericRange(location[1], location[2]),
+        Int4Range(location[1], location[2]),
         location[0],
-        NumericRange(location[1], location[2]),
+        Int4Range(location[1], location[2]),
     ]
 
     if assembly is not None:

--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 import pytest
 from django.db.models import Manager
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.get_expr_data.conftest import (  # noqa: F401
     private_reg_effects,
@@ -310,14 +310,14 @@ def nearby_feature_mix() -> tuple[DNAFeature, DNAFeature, DNAFeature]:
     private_feature = DNAFeatureFactory(
         feature_type=DNAFeatureType.CCRE,
         chrom_name=pub_feature.chrom_name,
-        location=NumericRange(pub_feature.location.lower + 1000, pub_feature.location.upper + 1000),
+        location=Int4Range(pub_feature.location.lower + 1000, pub_feature.location.upper + 1000),
         ref_genome="hg38",
         public=False,
     )
     archived_feature = DNAFeatureFactory(
         feature_type=DNAFeatureType.DHS,
         chrom_name=pub_feature.chrom_name,
-        location=NumericRange(private_feature.location.lower + 1000, private_feature.location.upper + 1000),
+        location=Int4Range(private_feature.location.lower + 1000, private_feature.location.upper + 1000),
         ref_genome="hg38",
         archived=True,
     )
@@ -561,33 +561,33 @@ def genoverse_dhs_features():
     f1 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start, start + length),
+        location=Int4Range(start, start + length),
         feature_type=DNAFeatureType.DHS,
     )
     f2 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + length + gap, start + length * 2 + gap),
+        location=Int4Range(start + length + gap, start + length * 2 + gap),
         feature_type=DNAFeatureType.CCRE,
         facet_values=(pels,),
     )
     f3 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + length * 2 + gap * 2, start + length * 3 + gap * 2),
+        location=Int4Range(start + length * 2 + gap * 2, start + length * 3 + gap * 2),
         feature_type=DNAFeatureType.CCRE,
         facet_values=(dels,),
     )
     f4 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + length * 3 + gap * 3, start + length * 4 + gap * 3),
+        location=Int4Range(start + length * 3 + gap * 3, start + length * 4 + gap * 3),
         feature_type=DNAFeatureType.DHS,
     )
     f5 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + length * 4 + gap * 4, start + length * 5 + gap * 4),
+        location=Int4Range(start + length * 4 + gap * 4, start + length * 5 + gap * 4),
         feature_type=DNAFeatureType.DHS,
     )
 
@@ -625,34 +625,34 @@ def genoverse_gene_features():
         ref_genome=ref_genome,
         chrom_name=chrom,
         strand="-",
-        location=NumericRange(start, start + length),
+        location=Int4Range(start, start + length),
         feature_type=DNAFeatureType.GENE,
     )
     f2 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
         strand="-",
-        location=NumericRange(start + length + gap, start + length * 2 + gap),
+        location=Int4Range(start + length + gap, start + length * 2 + gap),
         feature_type=DNAFeatureType.GENE,
     )
     f3 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
         strand="+",
-        location=NumericRange(start + length * 2 + gap * 2, start + length * 3 + gap * 2),
+        location=Int4Range(start + length * 2 + gap * 2, start + length * 3 + gap * 2),
         feature_type=DNAFeatureType.GENE,
     )
     f4 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
         strand="+",
-        location=NumericRange(start + length * 3 + gap * 3, start + length * 4 + gap * 3),
+        location=Int4Range(start + length * 3 + gap * 3, start + length * 4 + gap * 3),
         feature_type=DNAFeatureType.GENE,
     )
     f5 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + length * 4 + gap * 4, start + length * 5 + gap * 4),
+        location=Int4Range(start + length * 4 + gap * 4, start + length * 5 + gap * 4),
         strand="-",
         feature_type=DNAFeatureType.GENE,
     )
@@ -675,7 +675,7 @@ def genoverse_transcript_features():
     g1 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start, start + 40_000),
+        location=Int4Range(start, start + 40_000),
         strand="-",
         feature_type=DNAFeatureType.GENE,
     )
@@ -684,7 +684,7 @@ def genoverse_transcript_features():
         parent=g1,
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start, start + 40_000),
+        location=Int4Range(start, start + 40_000),
         strand="-",
         feature_type=DNAFeatureType.TRANSCRIPT,
     )
@@ -693,7 +693,7 @@ def genoverse_transcript_features():
         parent=g1_t1,
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start, start + 10_000),
+        location=Int4Range(start, start + 10_000),
         strand="-",
         feature_type=DNAFeatureType.EXON,
     )
@@ -701,7 +701,7 @@ def genoverse_transcript_features():
         parent=g1_t1,
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + 20_000, start + 40_000),
+        location=Int4Range(start + 20_000, start + 40_000),
         strand="-",
         feature_type=DNAFeatureType.EXON,
     )
@@ -709,7 +709,7 @@ def genoverse_transcript_features():
     g2 = DNAFeatureFactory(
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + 50_000, end),
+        location=Int4Range(start + 50_000, end),
         strand="+",
         feature_type=DNAFeatureType.GENE,
     )
@@ -718,7 +718,7 @@ def genoverse_transcript_features():
         parent=g2,
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + 50_000, end),
+        location=Int4Range(start + 50_000, end),
         strand="+",
         feature_type=DNAFeatureType.TRANSCRIPT,
     )
@@ -727,7 +727,7 @@ def genoverse_transcript_features():
         parent=g2_t1,
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + 50_000, start + 70_000),
+        location=Int4Range(start + 50_000, start + 70_000),
         strand="+",
         feature_type=DNAFeatureType.EXON,
     )
@@ -735,7 +735,7 @@ def genoverse_transcript_features():
         parent=g2_t1,
         ref_genome=ref_genome,
         chrom_name=chrom,
-        location=NumericRange(start + 80_000, end),
+        location=Int4Range(start + 80_000, end),
         strand="+",
         feature_type=DNAFeatureType.EXON,
     )

--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -200,8 +200,8 @@ def feature_pages() -> Pageable[DNAFeature]:
 @pytest.fixture
 def reo_source_target():
     return {
-        "source_locs": '{"(chr6,\\"[31577822,31578136)\\")"}',
-        "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
+        "source_locs": [("chr6", "[31577822,31578136)")],
+        "target_info": [("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366")],
         "reo_accession_id": "DCPREO0000000001",
         "effect_size": -1.2,
         "p_value": 0.005,
@@ -216,8 +216,8 @@ def reo_source_target():
 def reo_source_targets():
     return [
         {
-            "source_locs": '{"(chr6,\\"[31577822,31578136)\\",DCPDHS0000000001)"}',
-            "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
+            "source_locs": [("chr6", "[31577822,31578136)", "DCPDHS0000000001")],
+            "target_info": [("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366")],
             "reo_accession_id": "DCPREO00000339D6",
             "effect_size": 0.010958133,
             "p_value": 0.00000184,
@@ -227,8 +227,8 @@ def reo_source_targets():
             "analysis_accession_id": "DCPAN0000000002",
         },
         {
-            "source_locs": '{"(chr6,\\"[32182864,32183339)\\",DCPDHS0000000002)"}',
-            "target_info": '{"(chr6,\\"[31830969,31846824)\\",SLC44A4,ENSG00000204385)"}',
+            "source_locs": [("chr6", "[32182864,32183339)", "DCPDHS0000000002")],
+            "target_info": [("chr6", "[31830969,31846824)", "SLC44A4", "ENSG00000204385")],
             "reo_accession_id": "DCPREO0000033A96",
             "effect_size": -0.005418836,
             "p_value": 0.001948499,
@@ -238,8 +238,8 @@ def reo_source_targets():
             "analysis_accession_id": "DCPAN0000000002",
         },
         {
-            "source_locs": '{"(chr13,\\"[40666345,40666366)\\",DCPDHS0000000003)"}',
-            "target_info": '{"(chr6,\\"[31834608,31839767)\\",SNHG32,ENSG00000204387)"}',
+            "source_locs": [("chr13", "[40666345,40666366)", "DCPDHS0000000003")],
+            "target_info": [("chr6", "[31834608,31839767)", "SNHG32", "ENSG00000204387")],
             "reo_accession_id": "DCPREO00004F45A1",
             "effect_size": -1.2,
             "p_value": 0.005,

--- a/cegs_portal/search/json_templates/v1/search_results.py
+++ b/cegs_portal/search/json_templates/v1/search_results.py
@@ -14,35 +14,37 @@ SearchResults = TypedDict(
         "location": ChromosomeLocation,
         "assembly": str,
         "features": Pageable[DNAFeature],
-        "sig_reg_effects": dict[str : list[str]],
+        "sig_reg_effects": dict[str, list[str]],
         "facets": Manager[Facet],
     },
 )
 
 
-def parse_source_locs_json(source_locs: str) -> list[tuple[str, int, int, str]]:
+def parse_source_locs_json(source_locs: list[tuple[Optional[str], Optional[str], Optional[str]]]) -> list[str]:
     locs = []
-    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\",(\w+)\)', source_locs):
-        chrom = match[1]
-        start = int(match[2])
-        end = int(match[3])
-        accession_id = match[4]
-        locs.append((chrom, start, end, accession_id))
-        source_locs = source_locs[match.end() :]
+    for source_loc in source_locs:
+        if source_loc[0] is None:
+            continue
+
+        chrom, loc, accession_id = source_loc
+        if match := re.match(r"\[(\d+),(\d+)\)", loc):
+            start = int(match[1])
+            end = int(match[2])
+            locs.append((chrom, start, end, accession_id))
 
     return locs
 
 
-def parse_target_info_json(target_info: Optional[str]) -> list[tuple[str, str]]:
-    if target_info is None:
-        return []
-
+def parse_target_info_json(
+    target_infos: list[tuple[Optional[str], Optional[str], Optional[str], Optional[str]]]
+) -> list[str]:
     info = []
-    while match := re.search(r'\(chr\w+,\\"\[\d+,\d+\)\\",([\w-]+),(\w+)\)', target_info):
-        gene_symbol = match[1]
-        ensembl_id = match[2]
+    for target_info in target_infos:
+        if target_info[2] is None:
+            continue
+
+        _, _, gene_symbol, ensembl_id = target_info
         info.append((gene_symbol, ensembl_id))
-        target_info = target_info[match.end() :]
     return info
 
 

--- a/cegs_portal/search/json_templates/v1/tests/test_search_results.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_search_results.py
@@ -71,8 +71,8 @@ def test_search_results(search_results: SearchResults):
 
 
 def test_parse_source_locs_json():
-    assert parse_source_locs_json('{(chr1,\\"[1,2)\\",DCPDHS0000000001)}') == [("chr1", 1, 2, "DCPDHS0000000001")]
-    assert parse_source_locs_json('{(chr1,\\"[1,2)\\",DCPDHS0000000001),(chr2,\\"[2,4)\\",DCPDHS0000000002)}') == [
+    assert parse_source_locs_json([("chr1", "[1,2)", "DCPDHS0000000001")]) == [("chr1", 1, 2, "DCPDHS0000000001")]
+    assert parse_source_locs_json([("chr1", "[1,2)", "DCPDHS0000000001"), ("chr2", "[2,4)", "DCPDHS0000000002")]) == [
         ("chr1", 1, 2, "DCPDHS0000000001"),
         ("chr2", 2, 4, "DCPDHS0000000002"),
     ]
@@ -80,8 +80,8 @@ def test_parse_source_locs_json():
 
 def test_parse_source_target_data_json():
     test_data = {
-        "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
-        "source_locs": '{(chr1,\\"[1,2)\\",DCPDHS0000000001)}',
+        "target_info": [("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366")],
+        "source_locs": [("chr1", "[1,2)", "DCPDHS0000000001")],
         "asdf": 1234,
     }
     assert parse_source_target_data_json(test_data) == {
@@ -92,9 +92,12 @@ def test_parse_source_target_data_json():
 
 
 def test_parse_target_info_json():
-    assert parse_target_info_json('{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}') == [
+    assert parse_target_info_json([("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366")]) == [
         ("ZBTB12", "ENSG00000204366")
     ]
     assert parse_target_info_json(
-        '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)","(chr6,\\"[8386234,2389234)\\",HLA-A,ENSG00000204367)"}'  # noqa: E501
+        [
+            ("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366"),
+            ("chr6", "[8386234,2389234)", "HLA-A", "ENSG00000204367"),
+        ]
     ) == [("ZBTB12", "ENSG00000204366"), ("HLA-A", "ENSG00000204367")]

--- a/cegs_portal/search/models/tests/dna_feature_factory.py
+++ b/cegs_portal/search/models/tests/dna_feature_factory.py
@@ -4,7 +4,7 @@ import factory
 from factory import Faker, post_generation
 from factory.django import DjangoModelFactory
 from faker import Faker as F
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import DNAFeature, DNAFeatureType
 from cegs_portal.search.models.tests.experiment_factory import ExperimentFactory
@@ -26,7 +26,7 @@ class DNAFeatureFactory(DjangoModelFactory):
     chrom_name = Faker("numerify", text=r"chr1%")
     _start = random.randint(0, 1000000)
     _end = _start + random.randint(1, 1000000)
-    location = NumericRange(_start, _end)
+    location = Int4Range(_start, _end)
     strand = random.choice(["+", "-", None])
     ref_genome = "hg38"
     ref_genome_patch = Faker("numerify", text="##")

--- a/cegs_portal/search/models/utils.py
+++ b/cegs_portal/search/models/utils.py
@@ -1,7 +1,7 @@
 from enum import Enum, StrEnum
 from typing import Optional
 
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from .dna_feature_type import DNAFeatureType
 
@@ -126,9 +126,9 @@ class ChromosomeLocation:
     def __init__(self, chromo: str, start: str | int, end: Optional[str | int] = None):
         self.chromo = chromo
         if end is None:
-            self.range = NumericRange(int(start), int(start), bounds="[]")
+            self.range = Int4Range(int(start), int(start), bounds="[]")
         else:
-            self.range = NumericRange(int(start), int(end))
+            self.range = Int4Range(int(start), int(end))
 
     def __str__(self) -> str:
         return f"{self.chromo}: {self.range.lower}-{self.range.upper}"

--- a/cegs_portal/search/view_models/v1/dna_features.py
+++ b/cegs_portal/search/view_models/v1/dna_features.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, cast
 
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Count, OuterRef, Q, QuerySet, Subquery
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     DNAFeature,
@@ -236,7 +236,7 @@ class DNAFeatureSearch:
             filters["ref_genome"] = assembly
 
         field_lookup = join_fields(field, lookup)
-        filters[field_lookup] = NumericRange(int(start), int(end), "[)")
+        filters[field_lookup] = Int4Range(int(start), int(end), "[)")
 
         prefetch_values = ["parent", "parent_accession"]
 

--- a/cegs_portal/search/views/v1/search.py
+++ b/cegs_portal/search/views/v1/search.py
@@ -128,29 +128,33 @@ def parse_query(
     return search_type, terms, location, assembly, warnings
 
 
-def parse_source_locs_html(source_locs: str) -> list[tuple[str, str]]:
+def parse_source_locs_html(
+    source_locs: list[tuple[Optional[str], Optional[str], Optional[str]]]
+) -> list[tuple[str, str]]:
     locs = []
-    while match := re.search(r'\((chr\w+),\\"\[(\d+),(\d+)\)\\",(\w+)\)', source_locs):
-        chrom = match[1]
-        start = int(match[2])
-        end = int(match[3])
-        accession_id = match[4]
-        locs.append((f"{chrom}:{start:,}-{end:,}", accession_id))
-        source_locs = source_locs[match.end() :]
+    for source_loc in source_locs:
+        if source_loc[0] is None:
+            continue
+
+        chrom, loc, accession_id = source_loc
+        if match := re.match(r"\[(\d+),(\d+)\)", loc):
+            start = int(match[1])
+            end = int(match[2])
+            locs.append((f"{chrom}:{start:,}-{end:,}", accession_id))
 
     return locs
 
 
-def parse_target_info_html(target_info: Optional[str]) -> list[tuple[str, str]]:
-    if target_info is None:
-        return []
-
+def parse_target_info_html(
+    target_infos: list[tuple[Optional[str], Optional[str], Optional[str], Optional[str]]]
+) -> list[tuple[str, str]]:
     info = []
-    while match := re.search(r'\(chr\w+,\\"\[\d+,\d+\)\\",([\w-]+),(\w+)\)', target_info):
-        gene_symbol = match[1]
-        ensembl_id = match[2]
+    for target_info in target_infos:
+        if target_info[2] is None:
+            continue
+
+        _, _, gene_symbol, ensembl_id = target_info
         info.append((gene_symbol, ensembl_id))
-        target_info = target_info[match.end() :]
     return info
 
 

--- a/cegs_portal/search/views/v1/tests/conftest.py
+++ b/cegs_portal/search/views/v1/tests/conftest.py
@@ -1,7 +1,7 @@
 from typing import Iterable
 
 import pytest
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.get_expr_data.conftest import reg_effects  # noqa: F401
 from cegs_portal.search.models import (
@@ -97,35 +97,35 @@ def _dna_features(assembly) -> Iterable[DNAFeature]:
         parent=None,
         feature_type=DNAFeatureType.GENE,
         chrom_name="chr1",
-        location=NumericRange(1, 100),
+        location=Int4Range(1, 100),
         ref_genome=assembly,
     )
     f2 = DNAFeatureFactory(
         parent=None,
         feature_type=DNAFeatureType.GENE,
         chrom_name="chr1",
-        location=NumericRange(200, 300),
+        location=Int4Range(200, 300),
         ref_genome=assembly,
     )
     f3 = DNAFeatureFactory(
         parent=None,
         feature_type=DNAFeatureType.CCRE,
         chrom_name="chr1",
-        location=NumericRange(1000, 2000),
+        location=Int4Range(1000, 2000),
         ref_genome=assembly,
     )
     f4 = DNAFeatureFactory(
         parent=None,
         feature_type=DNAFeatureType.CAR,
         chrom_name="chr1",
-        location=NumericRange(50_000, 60_000),
+        location=Int4Range(50_000, 60_000),
         ref_genome=assembly,
     )
     f5 = DNAFeatureFactory(
         parent=None,
         feature_type=DNAFeatureType.CAR,
         chrom_name="chr1",
-        location=NumericRange(70_000, 80_000),
+        location=Int4Range(70_000, 80_000),
         ref_genome=assembly,
     )
     sig_reo_source1 = RegEffectFactory(

--- a/cegs_portal/search/views/v1/tests/test_search.py
+++ b/cegs_portal/search/views/v1/tests/test_search.py
@@ -571,8 +571,8 @@ def test_experiment_no_query_html(public_test_client: RequestBuilder, search_vie
 
 
 def test_parse_source_locs_html():
-    assert parse_source_locs_html('{(chr1,\\"[1,2)\\",DCPDHS0000000001)}') == [("chr1:1-2", "DCPDHS0000000001")]
-    assert parse_source_locs_html('{(chr1,\\"[1,2)\\",DCPDHS0000000001),(chr2,\\"[2,4)\\",DCPDHS0000000002)}') == [
+    assert parse_source_locs_html([("chr1", "[1,2)", "DCPDHS0000000001")]) == [("chr1:1-2", "DCPDHS0000000001")]
+    assert parse_source_locs_html([("chr1", "[1,2)", "DCPDHS0000000001"), ("chr2", "[2,4)", "DCPDHS0000000002")]) == [
         ("chr1:1-2", "DCPDHS0000000001"),
         ("chr2:2-4", "DCPDHS0000000002"),
     ]
@@ -580,8 +580,8 @@ def test_parse_source_locs_html():
 
 def test_parse_source_target_data_html():
     test_data = {
-        "target_info": '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}',
-        "source_locs": '{(chr1,\\"[1,2)\\",DCPDHS0000000001)}',
+        "target_info": [("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366")],
+        "source_locs": [("chr1", "[1,2)", "DCPDHS0000000001")],
         "asdf": 1234,
     }
     assert parse_source_target_data_html(test_data) == {
@@ -592,11 +592,14 @@ def test_parse_source_target_data_html():
 
 
 def test_parse_target_info_html():
-    assert parse_target_info_html('{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)"}') == [
+    assert parse_target_info_html([("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366")]) == [
         ("ZBTB12", "ENSG00000204366")
     ]
     assert parse_target_info_html(
-        '{"(chr6,\\"[31867384,31869770)\\",ZBTB12,ENSG00000204366)","(chr6,\\"[8386234,2389234)\\",HLA-A,ENSG00000204367)"}'  # noqa: E501
+        [
+            ("chr6", "[31867384,31869770)", "ZBTB12", "ENSG00000204366"),
+            ("chr6", "[8386234,2389234)", "HLA-A", "ENSG00000204367"),
+        ]
     ) == [("ZBTB12", "ENSG00000204366"), ("HLA-A", "ENSG00000204367")]
 
 

--- a/cegs_portal/uploads/data_loading/analysis.py
+++ b/cegs_portal/uploads/data_loading/analysis.py
@@ -5,7 +5,7 @@ from io import StringIO
 from typing import Optional
 
 from django.db import transaction
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     AccessionIds,
@@ -143,7 +143,7 @@ class Analysis:
                         source_cache[source_string] = DNAFeature.objects.filter(
                             experiment_accession_id=experiment_accession_id,
                             chrom_name=source.chrom,
-                            location=NumericRange(source.start, source.end),
+                            location=Int4Range(source.start, source.end),
                             strand=source.strand,
                             ref_genome=genome_assembly,
                             feature_type=DNAFeatureType(source.feature_type),

--- a/cegs_portal/uploads/data_loading/db.py
+++ b/cegs_portal/uploads/data_loading/db.py
@@ -29,50 +29,43 @@ def bulk_reo_save(
     with transaction.atomic(), connection.cursor() as cursor:
         effects.seek(0, SEEK_SET)
         print("Adding RegulatoryEffectObservations")
-        cursor.copy_from(
-            effects,
-            "search_regulatoryeffectobservation",
-            columns=(
-                "id",
-                "accession_id",
-                "experiment_id",
-                "experiment_accession_id",
-                "analysis_accession_id",
-                "facet_num_values",
-                "archived",
-                "public",
-            ),
-        )
+        with cursor.copy(
+            """COPY search_regulatoryeffectobservation (
+                id,
+                accession_id,
+                experiment_id,
+                experiment_accession_id,
+                analysis_accession_id,
+                facet_num_values,
+                archived,
+                public
+            ) FROM STDIN"""
+        ) as copy:
+            copy.write(effects.getvalue())
 
     with transaction.atomic(), connection.cursor() as cursor:
         categorical_facets.seek(0, SEEK_SET)
         print("Adding categorical facets to effects")
-        cursor.copy_from(
-            categorical_facets,
-            "search_regulatoryeffectobservation_facet_values",
-            columns=(
-                "regulatoryeffectobservation_id",
-                "facetvalue_id",
-            ),
-        )
+        with cursor.copy(
+            "COPY search_regulatoryeffectobservation_facet_values (regulatoryeffectobservation_id, facetvalue_id) FROM STDIN"
+        ) as copy:
+            copy.write(categorical_facets.getvalue())
 
     with transaction.atomic(), connection.cursor() as cursor:
         source_associations.seek(0, SEEK_SET)
         print("Adding sources to RegulatoryEffectObservations")
-        cursor.copy_from(
-            source_associations,
-            "search_regulatoryeffectobservation_sources",
-            columns=("regulatoryeffectobservation_id", "dnafeature_id"),
-        )
+        with cursor.copy(
+            "COPY search_regulatoryeffectobservation_sources (regulatoryeffectobservation_id, dnafeature_id) FROM STDIN"
+        ) as copy:
+            copy.write(source_associations.getvalue())
 
         if target_associations is not None:
             target_associations.seek(0, SEEK_SET)
             print("Adding targets to RegulatoryEffectObservations")
-            cursor.copy_from(
-                target_associations,
-                "search_regulatoryeffectobservation_targets",
-                columns=("regulatoryeffectobservation_id", "dnafeature_id"),
-            )
+            with cursor.copy(
+                "COPY search_regulatoryeffectobservation_targets (regulatoryeffectobservation_id, dnafeature_id) FROM STDIN"
+            ) as copy:
+                copy.write(target_associations.getvalue())
 
 
 def feature_entry(
@@ -135,56 +128,50 @@ def bulk_feature_save(features: StringIO):
     features.seek(0, SEEK_SET)
     print("Adding features")
     with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            features,
-            "search_dnafeature",
-            columns=(
-                "id",
-                "accession_id",
-                "ids",
-                "ensembl_id",
-                "name",
-                "cell_line",
-                "chrom_name",
-                "closest_gene_id",
-                "closest_gene_distance",
-                "closest_gene_name",
-                "closest_gene_ensembl_id",
-                "location",
-                "strand",
-                "ref_genome",
-                "ref_genome_patch",
-                "feature_type",
-                "feature_subtype",
-                "source_file_id",
-                "experiment_accession_id",
-                "parent_id",
-                "parent_accession_id",
-                "misc",
-                "archived",
-                "public",
-            ),
-        )
+        with cursor.copy(
+            """COPY search_dnafeature (
+                id,
+                accession_id,
+                ids,
+                ensembl_id,
+                name,
+                cell_line,
+                chrom_name,
+                closest_gene_id,
+                closest_gene_distance,
+                closest_gene_name,
+                closest_gene_ensembl_id,
+                location,
+                strand,
+                ref_genome,
+                ref_genome_patch,
+                feature_type,
+                feature_subtype,
+                source_file_id,
+                experiment_accession_id,
+                parent_id,
+                parent_accession_id,
+                misc,
+                archived,
+                public
+            ) FROM STDIN"""
+        ) as copy:
+            copy.write(features.getvalue())
 
 
 def bulk_feature_facet_save(facets):
     with transaction.atomic(), connection.cursor() as cursor:
         facets.seek(0, SEEK_SET)
         print("Adding facets to features")
-        cursor.copy_from(
-            facets,
-            "search_dnafeature_facet_values",
-            columns=(
-                "dnafeature_id",
-                "facetvalue_id",
-            ),
-        )
+        with cursor.copy("COPY search_dnafeature_facet_values (dnafeature_id, facetvalue_id) FROM STDIN") as copy:
+            copy.write(facets.getvalue())
 
 
 def bulk_save_associations(associations):
     associations.seek(0, SEEK_SET)
     print("Adding ccre associations to features")
     with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            associations, "search_dnafeature_associated_ccres", columns=("from_dnafeature_id", "to_dnafeature_id")
-        )
+        with cursor.copy(
+            "COPY search_dnafeature_associated_ccres (from_dnafeature_id, to_dnafeature_id) FROM STDIN"
+        ) as copy:
+            copy.write(associations.getvalue())

--- a/cegs_portal/uploads/data_loading/experiment.py
+++ b/cegs_portal/uploads/data_loading/experiment.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 from django.db import transaction
 from django.db.models import F, Func
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     AccessionIds,
@@ -66,7 +66,7 @@ class CCREFeature:
     _id: int
     accession_id: str
     chrom_name: str
-    location: NumericRange
+    location: Int4Range
     cell_line: str
     closest_gene_id: int
     closest_gene_distance: int
@@ -114,7 +114,7 @@ class CCREFeature:
         return FeatureOverlap.OVERLAP
 
 
-def get_ccres(genome_assembly) -> list[tuple[int, str, NumericRange]]:
+def get_ccres(genome_assembly) -> list[tuple[int, str, Int4Range]]:
     assert GenomeAssembly(genome_assembly)
 
     return (
@@ -240,7 +240,7 @@ class Experiment:
         db_ids = {}
         with FeatureIds() as feature_ids:
             for feature, feature_id in zip(features, feature_ids):
-                feature_location = NumericRange(*feature.location)
+                feature_location = Int4Range(*feature.location)
                 closest_gene, distance, gene_name = get_closest_gene(
                     feature.genome_assembly, feature.chrom_name, feature_location.lower, feature_location.upper
                 )

--- a/cegs_portal/uploads/views/tests/conftest.py
+++ b/cegs_portal/uploads/views/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.conftest import SearchClient
 from cegs_portal.search.models import (
@@ -149,10 +149,10 @@ def facets() -> list[Facet]:
 
 @pytest.fixture(autouse=True)
 def ccres():
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(100, 200))
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(300, 400))
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(500, 600))
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(700, 800))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(100, 200))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(300, 400))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(500, 600))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(700, 800))
 
 
 @pytest.fixture(autouse=True)

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -34,8 +34,9 @@ RUN echo "deb http://security.debian.org/debian-security/ bullseye-security main
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
   build-essential \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev \
+  python3-dev \
   libgmp10 \
   # Pillow deps
   zlib1g-dev \

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -68,8 +68,9 @@ RUN echo "deb http://security.debian.org/debian-security/ bullseye-security main
 RUN apt-get update
 RUN apt-get upgrade --no-install-recommends -y
 RUN apt-get install --no-install-recommends -y \
-  # psycopg2 dependencies
+  # psycopg dependencies
   libpq-dev \
+  python3-dev \
   # Translations dependencies
   gettext \
   libgmp10

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -15,6 +15,7 @@ ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[".duke.edu", "", ".ceg
 DATABASES["default"] = env.db("DATABASE_URL")  # noqa F405
 DATABASES["default"]["ATOMIC_REQUESTS"] = True  # noqa F405
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=60)  # noqa F405
+DATABASES["default"]["options"] = {"pool": True}  # noqa F405
 
 # CACHES
 # ------------------------------------------------------------------------------

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 
 Werkzeug==3.0.3 # https://github.com/pallets/werkzeug
 ipdb==0.13.9  # https://github.com/gotcha/ipdb
-psycopg2-binary==2.9.3  # https://github.com/psycopg/psycopg2
+psycopg[binary]==3.2.3  # https://github.com/psycopg/psycopg
 watchfiles==0.18.1  # https://github.com/samuelcolvin/watchfiles
 
 # Testing

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,7 +2,8 @@
 
 -r base.txt
 
-psycopg2==2.9.5  # https://github.com/psycopg/psycopg2
+psycopg[c]==3.2.3  # https://github.com/psycopg/psycopg
+psycopg[pool]==3.2.3  # https://github.com/psycopg/psycopg
 
 # Django
 # ------------------------------------------------------------------------------

--- a/scripts/data_loading/DCPEXPR0000000001_load_bounds_2021_scceres_analysis.py
+++ b/scripts/data_loading/DCPEXPR0000000001_load_bounds_2021_scceres_analysis.py
@@ -2,7 +2,7 @@ import csv
 import math
 
 from django.db import transaction
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     AccessionIds,
@@ -89,7 +89,7 @@ def load_reg_effects(reo_file, accession_ids, analysis, ref_genome, ref_genome_p
             elif strand == "-":
                 bounds = "(]"
 
-            grna_location = NumericRange(grna_start, grna_end, bounds)
+            grna_location = Int4Range(grna_start, grna_end, bounds)
 
             guide = DNAFeature.objects.get(
                 experiment_accession=experiment,

--- a/scripts/data_loading/DCPEXPR0000000001_load_bounds_2021_scceres_experiment.py
+++ b/scripts/data_loading/DCPEXPR0000000001_load_bounds_2021_scceres_experiment.py
@@ -1,7 +1,7 @@
 import csv
 
 from django.db import transaction
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     AccessionIds,
@@ -73,7 +73,7 @@ def load_grna(grna_file, accession_ids, experiment, region_source, cell_line, re
                 bounds = "[)"
             elif strand == "-":
                 bounds = "(]"
-            grna_location = NumericRange(grna_start, grna_end, bounds)
+            grna_location = Int4Range(grna_start, grna_end, bounds)
 
             closest_gene, distance, gene_name = get_closest_gene(ref_genome, chrom_name, grna_start, grna_end)
 

--- a/scripts/data_loading/DCPEXPR0000000002_ensembl.py
+++ b/scripts/data_loading/DCPEXPR0000000002_ensembl.py
@@ -1,6 +1,6 @@
 import csv
 
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import DNAFeature
 from utils.experiment import ExperimentMetadata
@@ -22,7 +22,7 @@ def run(experiment_filename):
             gene_name = line["gene_symbol"]
             gene_start = int(line["start"]) - 1
             gene_end = int(line["end"])
-            gene_location = NumericRange(gene_start, gene_end, "[)")
+            gene_location = Int4Range(gene_start, gene_end, "[)")
             if gene_name not in genes:
                 gene_objects = DNAFeature.objects.filter(
                     name=gene_name, location=gene_location, ref_genome=genome_assembly

--- a/scripts/data_loading/db.py
+++ b/scripts/data_loading/db.py
@@ -86,50 +86,43 @@ def bulk_reo_save(
     with transaction.atomic(), connection.cursor() as cursor:
         effects.seek(0, SEEK_SET)
         print("Adding RegulatoryEffectObservations")
-        cursor.copy_from(
-            effects,
-            "search_regulatoryeffectobservation",
-            columns=(
-                "id",
-                "accession_id",
-                "experiment_id",
-                "experiment_accession_id",
-                "analysis_accession_id",
-                "facet_num_values",
-                "archived",
-                "public",
-            ),
-        )
+        with cursor.copy(
+            """COPY search_regulatoryeffectobservation (
+                id,
+                accession_id,
+                experiment_id,
+                experiment_accession_id,
+                analysis_accession_id,
+                facet_num_values,
+                archived,
+                public
+            ) FROM STDIN"""
+        ) as copy:
+            copy.write(effects.getvalue())
 
     with transaction.atomic(), connection.cursor() as cursor:
         categorical_facets.seek(0, SEEK_SET)
         print("Adding categorical facets to effects")
-        cursor.copy_from(
-            categorical_facets,
-            "search_regulatoryeffectobservation_facet_values",
-            columns=(
-                "regulatoryeffectobservation_id",
-                "facetvalue_id",
-            ),
-        )
+        with cursor.copy(
+            "COPY search_regulatoryeffectobservation_facet_values (regulatoryeffectobservation_id, facetvalue_id) FROM STDIN"
+        ) as copy:
+            copy.write(categorical_facets.getvalue())
 
     with transaction.atomic(), connection.cursor() as cursor:
         source_associations.seek(0, SEEK_SET)
         print("Adding sources to RegulatoryEffectObservations")
-        cursor.copy_from(
-            source_associations,
-            "search_regulatoryeffectobservation_sources",
-            columns=("regulatoryeffectobservation_id", "dnafeature_id"),
-        )
+        with cursor.copy(
+            "COPY search_regulatoryeffectobservation_sources (regulatoryeffectobservation_id, dnafeature_id) FROM STDIN"
+        ) as copy:
+            copy.write(source_associations.getvalue())
 
         if target_associations is not None:
             target_associations.seek(0, SEEK_SET)
             print("Adding targets to RegulatoryEffectObservations")
-            cursor.copy_from(
-                target_associations,
-                "search_regulatoryeffectobservation_targets",
-                columns=("regulatoryeffectobservation_id", "dnafeature_id"),
-            )
+            with cursor.copy(
+                "COPY search_regulatoryeffectobservation_targets (regulatoryeffectobservation_id, dnafeature_id) FROM STDIN"
+            ) as copy:
+                copy.write(target_associations.getvalue())
 
 
 def feature_entry(
@@ -192,56 +185,50 @@ def bulk_feature_save(features: StringIO):
     features.seek(0, SEEK_SET)
     print("Adding features")
     with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            features,
-            "search_dnafeature",
-            columns=(
-                "id",
-                "accession_id",
-                "ids",
-                "ensembl_id",
-                "name",
-                "cell_line",
-                "chrom_name",
-                "closest_gene_id",
-                "closest_gene_distance",
-                "closest_gene_name",
-                "closest_gene_ensembl_id",
-                "location",
-                "strand",
-                "ref_genome",
-                "ref_genome_patch",
-                "feature_type",
-                "feature_subtype",
-                "source_file_id",
-                "experiment_accession_id",
-                "parent_id",
-                "parent_accession_id",
-                "misc",
-                "archived",
-                "public",
-            ),
-        )
+        with cursor.copy(
+            """COPY search_dnafeature (
+                id,
+                accession_id,
+                ids,
+                ensembl_id,
+                name,
+                cell_line,
+                chrom_name,
+                closest_gene_id,
+                closest_gene_distance,
+                closest_gene_name,
+                closest_gene_ensembl_id,
+                location,
+                strand,
+                ref_genome,
+                ref_genome_patch,
+                feature_type,
+                feature_subtype,
+                source_file_id,
+                experiment_accession_id,
+                parent_id,
+                parent_accession_id,
+                misc,
+                archived,
+                public
+            ) FROM STDIN"""
+        ) as copy:
+            copy.write(features.getvalue())
 
 
 def bulk_feature_facet_save(facets):
     with transaction.atomic(), connection.cursor() as cursor:
         facets.seek(0, SEEK_SET)
         print("Adding facets to features")
-        cursor.copy_from(
-            facets,
-            "search_dnafeature_facet_values",
-            columns=(
-                "dnafeature_id",
-                "facetvalue_id",
-            ),
-        )
+        with cursor.copy("COPY search_dnafeature_facet_values (dnafeature_id, facetvalue_id) FROM STDIN") as copy:
+            copy.write(facets.getvalue())
 
 
 def bulk_save_associations(associations):
     associations.seek(0, SEEK_SET)
     print("Adding ccre associations to features")
     with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            associations, "search_dnafeature_associated_ccres", columns=("from_dnafeature_id", "to_dnafeature_id")
-        )
+        with cursor.copy(
+            "COPY search_dnafeature_associated_ccres (from_dnafeature_id, to_dnafeature_id) FROM STDIN"
+        ) as copy:
+            copy.write(associations.getvalue())

--- a/scripts/data_loading/load_analysis.py
+++ b/scripts/data_loading/load_analysis.py
@@ -4,7 +4,7 @@ from io import StringIO
 from typing import Optional
 
 from django.db import transaction
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import AccessionIds, AccessionType
 from cegs_portal.search.models import Analysis as AnalysisModel
@@ -97,7 +97,7 @@ class Analysis:
                         source_cache[source_string] = DNAFeature.objects.filter(
                             experiment_accession_id=experiment_accession_id,
                             chrom_name=source.chrom,
-                            location=NumericRange(source.start, source.end, source.bounds),
+                            location=Int4Range(source.start, source.end, source.bounds),
                             strand=source.strand,
                             ref_genome=genome_assembly,
                             feature_type=DNAFeatureType(source.feature_type),

--- a/scripts/data_loading/load_experiment.py
+++ b/scripts/data_loading/load_experiment.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from django.db import transaction
 from django.db.models import F, Func
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     AccessionIds,
@@ -74,7 +74,7 @@ class CCREFeature:
     _id: int
     accession_id: str
     chrom_name: str
-    location: NumericRange
+    location: Int4Range
     cell_line: str
     closest_gene_id: int
     closest_gene_distance: int
@@ -122,7 +122,7 @@ class CCREFeature:
         return FeatureOverlap.OVERLAP
 
 
-def get_ccres(genome_assembly) -> list[tuple[int, str, NumericRange]]:
+def get_ccres(genome_assembly) -> list[tuple[int, str, Int4Range]]:
     assert GenomeAssembly(genome_assembly)
 
     return (
@@ -157,7 +157,7 @@ class Experiment:
         db_ids = {}
         with FeatureIds() as feature_ids:
             for feature, feature_id in zip(features, feature_ids):
-                feature_location = NumericRange(*feature.location)
+                feature_location = Int4Range(*feature.location)
                 closest_gene, distance, gene_name = get_closest_gene(
                     feature.genome_assembly, feature.chrom_name, feature_location.lower, feature_location.upper
                 )

--- a/scripts/data_loading/load_gencode_gff3_data.py
+++ b/scripts/data_loading/load_gencode_gff3_data.py
@@ -40,27 +40,26 @@ ANNOTATION_BUFFER_SIZE = 100_000
 def bulk_annotation_save(genome_annotations: StringIO):
     genome_annotations.seek(0, SEEK_SET)
     with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            genome_annotations,
-            "search_gencodeannotation",
-            columns=(
-                "chrom_name",
-                "location",
-                "strand",
-                "score",
-                "phase",
-                "annotation_type",
-                "id_attr",
-                "ref_genome",
-                "ref_genome_patch",
-                "gene_name",
-                "gene_type",
-                "level",
-                "region_id",
-                "version",
-                "attributes",
-            ),
-        )
+        with cursor.copy(
+            """COPY search_gencodeannotation (
+                chrom_name,
+                location,
+                strand,
+                score,
+                phase,
+                annotation_type,
+                id_attr,
+                ref_genome,
+                ref_genome_patch,
+                gene_name,
+                gene_type,
+                level,
+                region_id,
+                version,
+                attributes,
+            ) FROM STDIN"""
+        ) as copy:
+            copy.write(genome_annotations)
 
 
 @timer("Loading annotations", level=1)

--- a/scripts/data_loading/load_gencode_gff3_data.py
+++ b/scripts/data_loading/load_gencode_gff3_data.py
@@ -3,7 +3,7 @@ from io import SEEK_SET, StringIO
 from urllib.parse import unquote
 
 from django.db import connection, transaction
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import (
     AccessionIds,
@@ -74,7 +74,7 @@ def load_genome_annotations(genome_annotations, ref_genome, ref_genome_patch, ve
             # Adjust start/end to use 0-based indexing
             start = int(start) - 1
             end = int(end)
-            region = GencodeRegion(chrom_name=chrom_name, base_range=NumericRange(start, end, "[)"))
+            region = GencodeRegion(chrom_name=chrom_name, base_range=Int4Range(start, end, "[)"))
             region.save()
             continue
 

--- a/scripts/data_loading/tests/conftest.py
+++ b/scripts/data_loading/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import DNAFeature, DNAFeatureType, GrnaType, PromoterType
 from cegs_portal.search.models.tests.dna_feature_factory import DNAFeatureFactory
@@ -51,16 +51,16 @@ def facets():
 
 @pytest.fixture(autouse=True)
 def ccres():
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(100, 200))
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(300, 400))
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(500, 600))
-    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=NumericRange(700, 800))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(100, 200))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(300, 400))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(500, 600))
+    _ = DNAFeatureFactory(feature_type=DNAFeatureType.CCRE, chrom_name="chr1", location=Int4Range(700, 800))
 
 
 @pytest.fixture(autouse=True)
 def gene():
     _ = DNAFeatureFactory(
-        feature_type=DNAFeatureType.GENE, chrom_name="chr1", location=NumericRange(1000, 2000), strand="+"
+        feature_type=DNAFeatureType.GENE, chrom_name="chr1", location=Int4Range(1000, 2000), strand="+"
     )
 
 

--- a/utils/ccres.py
+++ b/utils/ccres.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from django.db import connection, transaction
 from django.db.models import F, Func
-from psycopg2.extras import NumericRange
+from psycopg.types.range import Int4Range
 
 from cegs_portal.search.models import AccessionType, DNAFeature, DNAFeatureType
 from scripts.data_loading.db import (
@@ -23,7 +23,7 @@ from .db_ids import FeatureIds
 class CcreSource:
     _id: int
     chrom_name: str
-    test_location: NumericRange
+    test_location: Int4Range
     cell_line: str
     closest_gene_id: int
     closest_gene_distance: int
@@ -34,7 +34,7 @@ class CcreSource:
     experiment_accession_id: str
     genome_assembly_patch: str = "0"
     _new_id: Optional[int] = None
-    new_location: Optional[NumericRange] = None
+    new_location: Optional[Int4Range] = None
     feature_type: DNAFeatureType = DNAFeatureType.CCRE
     misc: dict = field(default_factory=lambda: {"pseudo": True})
 
@@ -47,7 +47,7 @@ def save_associations(associations):
         )
 
 
-def get_ccres(genome_assembly) -> list[tuple[int, str, NumericRange]]:
+def get_ccres(genome_assembly) -> list[tuple[int, str, Int4Range]]:
     if genome_assembly not in ["hg19", "hg38"]:
         raise ValueError("Please enter either hg19 or hg38 for the assembly")
 

--- a/utils/ccres.py
+++ b/utils/ccres.py
@@ -42,9 +42,10 @@ class CcreSource:
 def save_associations(associations):
     associations.seek(0, SEEK_SET)
     with transaction.atomic(), connection.cursor() as cursor:
-        cursor.copy_from(
-            associations, "search_dnafeature_associated_ccres", columns=("from_dnafeature_id", "to_dnafeature_id")
-        )
+        with cursor.copy(
+            "COPY search_dnafeature_associated_ccres (from_dnafeature_id, to_dnafeature_id) FROM STDIN"
+        ) as copy:
+            copy.write(associations)
 
 
 def get_ccres(genome_assembly) -> list[tuple[int, str, Int4Range]]:


### PR DESCRIPTION
Psycopg 3 includes the ability to pool database connections. We need to use this in production to support multiple gunicorn workers, because even at 4 we're sometimes getting "too many client" errors.

Psycopg 3 made some changes:
* replaced several copy_ functions with a single copy object
* Array values are returned as python lists rather than a single string
* Int4Range is no longer automatically cast to NumericRange

So there are quite a few code changes! Thank goodness for tests!