### PR TITLE
Combo viz error

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -90,7 +90,7 @@ function merge_facets(experiments_facets) {
         facet_array.reduce((acc, f) => {
             acc[f.id] = f;
             return acc;
-        }, {})
+        }, {}),
     );
     let base_facets = facet_maps[0];
     let rest_facets = facet_maps.slice(1);
@@ -185,9 +185,9 @@ async function getCombinedCoverageData(staticRoot, accessionIDs) {
         manifests = await Promise.all(
             accessionIDs.map((accessionIDPair) =>
                 getJson(
-                    `${staticRoot}search/experiments/${accessionIDPair[0]}/${accessionIDPair[1]}/coverage_manifest.json`
-                )
-            )
+                    `${staticRoot}search/experiments/${accessionIDPair[0]}/${accessionIDPair[1]}/coverage_manifest.json`,
+                ),
+            ),
         );
 
         let genomeNames = manifests.map((m) => m.genome.name);
@@ -198,10 +198,10 @@ async function getCombinedCoverageData(staticRoot, accessionIDs) {
         genome = await getJson(`${staticRoot}genome_data/${manifests[0].genome.file}`);
     } catch (error) {
         let consoleError;
-        if (error instanceof Error) {
-            consoleError = "Files necessary to load coverage not found.";
-        } else if (error instanceof GenomeError) {
+        if (error instanceof GenomeError) {
             consoleError = error.message;
+        } else if (error instanceof Error) {
+            consoleError = "Files necessary to load coverage not found.";
         }
 
         throw new Error(consoleError);
@@ -276,7 +276,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
             genome,
             manifests[0].chromosomes,
             [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
-            state.g(STATE_COMBO_SET_OP)
+            state.g(STATE_COMBO_SET_OP),
         );
 
         postJson("/search/combined_experiment_coverage", JSON.stringify(body)).then((response_json) => {
@@ -294,7 +294,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
             genome,
             manifests[0].chromosomes,
             [state.g(STATE_CATEGORICAL_FACET_VALUES)],
-            state.g(STATE_COMBO_SET_OP)
+            state.g(STATE_COMBO_SET_OP),
         );
 
         postJson("/search/combined_experiment_coverage", JSON.stringify(body)).then((response_json) => {
@@ -303,7 +303,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
             state.u(
                 STATE_NUMERIC_FACET_VALUES,
                 [response_json.numeric_intervals.effect, response_json.numeric_intervals.sig],
-                false
+                false,
             );
             state.u(STATE_ITEM_COUNTS, [
                 response_json.reo_count,
@@ -317,7 +317,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
 
     state.ac(
         STATE_CATEGORICAL_FACET_VALUES,
-        debounce((s, key) => get_all_data(), 300)
+        debounce((s, key) => get_all_data(), 300),
     );
 
     state.ac(
@@ -329,13 +329,13 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
                 genome,
                 manifests[0].chromosomes,
                 [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
-                state.g(STATE_COMBO_SET_OP)
+                state.g(STATE_COMBO_SET_OP),
             );
 
             postJson("/search/combined_experiment_coverage", JSON.stringify(body)).then((response_json) => {
                 state.u(
                     STATE_COVERAGE_DATA,
-                    mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes)
+                    mergeFilteredData(state.g(STATE_COVERAGE_DATA), response_json.chromosomes),
                 );
                 state.u(STATE_ITEM_COUNTS, [
                     response_json.reo_count,
@@ -343,13 +343,13 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
                     response_json.target_count,
                 ]);
             });
-        }, 300)
+        }, 300),
     );
 
     state.ac(STATE_NUMERIC_FILTER_INTERVALS, (s, key) => {
         cc(g("chrom-data-numeric-facets"));
         numericFilterControls(state, state.g(STATE_FACETS)).forEach((element) =>
-            a(g("chrom-data-numeric-facets"), element)
+            a(g("chrom-data-numeric-facets"), element),
         );
     });
 
@@ -375,7 +375,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
                     countFilters: state.g(STATE_COUNT_FILTER_VALUES),
                 });
             }
-        }, 60)
+        }, 60),
     );
 
     state.ac(STATE_HIGHLIGHT_REGIONS, (s, key) => {
@@ -410,7 +410,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
             });
             rc(g("regionUploadInputReset"), highlightResetButton);
         },
-        false
+        false,
     );
     let regionUploadInput = g("regionUploadInput");
 
@@ -428,9 +428,9 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
                     [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
                     dataDownloadInput,
                     exprAccessionID,
-                    csrfToken
+                    csrfToken,
                 ),
-            false
+            false,
         );
 
         let dataDownloadAll = g("dataDownloadAll");
@@ -440,9 +440,9 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
                 getDownloadAll(
                     [state.g(STATE_CATEGORICAL_FACET_VALUES), state.g(STATE_NUMERIC_FACET_VALUES)],
                     exprAccessionID,
-                    csrfToken
+                    csrfToken,
                 ),
-            false
+            false,
         );
     }
 
@@ -456,7 +456,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
             let selectedCoverageType = coverageSelector.value;
             state.u(STATE_COVERAGE_TYPE, coverageValue(selectedCoverageType));
         },
-        false
+        false,
     );
 
     state.ac(STATE_COVERAGE_TYPE, (s, key) => {
@@ -473,7 +473,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         () => {
             state.u(STATE_FEATURE_FILTER_TYPE, featureFilterSelector.value);
         },
-        false
+        false,
     );
 
     state.ac(STATE_FEATURE_FILTER_TYPE, (s, key) => {
@@ -489,7 +489,7 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         () => {
             state.u(STATE_COMBO_SET_OP, setOpSelector.value);
         },
-        false
+        false,
     );
 
     state.ac(STATE_COMBO_SET_OP, (s, key) => {

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -133,6 +133,12 @@
         animation-timing-function: ease;
     }
 
+    .comparison-error {
+        color: #b94a48;
+        padding: 3px;
+        border: 2px solid;
+    }
+
     @keyframes fadeIn {
         0% {opacity: 0;}
         100% {opacity: 1;}
@@ -195,7 +201,7 @@
             <tbody>
                 {% for expr in experiments %}
                 <tr class="{% cycle 'bg-gray-100 border-b' 'bg-white border-b' %}">
-                    <td class="px-6 py-2 text-sm font-medium text-gray-900">{{ expr.name }}</td>
+                    <td class="px-6 py-2 text-sm font-medium text-gray-900">{{ expr.name }} ({{ expr.default_analysis.genome_assembly }})</td>
                     <td class="text-sm text-gray-900 font-light px-6 py-2 whitespace-nowrap">
                         <a class="link" href="{% url 'search:experiment' expr.accession_id %}">
                             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="svg-link-arrow bi bi-arrow-up-right-square-fill inline" viewBox="0 0 16 16">
@@ -287,6 +293,7 @@
                     </div>
                 </div>
                 <div class="min-w-full max-w-xs">
+                    <div id="chrom-error"></div>
                     <div class="overflow-x-auto ">
                         <div id="chrom-data" class="min-w-[768px] md:min-w-0"></div>
                     </div>

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -161,6 +161,7 @@ class ExperimentsView(UserPassesTestMixin, MultiResponseFormatView):
                         "accession_id": exp.accession_id,
                         "source": exp.get_source_type_display(),
                         "analysis_accession_id": exp.default_analysis.accession_id,
+                        "genome_assembly": exp.default_analysis.genome_assembly,
                     }
                     for exp in data.all()
                 ],


### PR DESCRIPTION
Adds some user-facing UI to the "multiple assemblies" error.

Also does the comparison based on information from the experiment
default analysis BEFORE trying to get the covergage manifests.

This is slightly faster and makes sure the assembly names in the error
match those (now) in beside the experiment names.

![Screenshot 2024-10-11 at 10-03-23 Experiments](https://github.com/user-attachments/assets/ad580585-2170-420c-b885-ccb941cdab74)
