### PR TITLE
Add filedrop plugin to all genoverse browsers

### DIFF
--- a/cegs_portal/search/templates/search/v1/dna_feature.html
+++ b/cegs_portal/search/templates/search/v1/dna_feature.html
@@ -453,7 +453,7 @@
             chr       : assembly.chromo.replace("chr", ""),
             start     : assembly.start - 1000,
             end       : assembly.end + 1000,
-            plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips' ],
+            plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips', 'fileDrop' ],
             useHash   : true,
             hideEmptyTracks: false,
             tracks    : [

--- a/cegs_portal/search/templates/search/v1/dna_features.html
+++ b/cegs_portal/search/templates/search/v1/dna_features.html
@@ -113,7 +113,7 @@
             chr       : "{{ loc.chr }}".replace("chr", ""),
             start     : {{ loc.start }},
             end       : {{ loc.end }},
-            plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips' ],
+            plugins   : [[ 'karyotype', { showAssembly: true }], 'trackControls', 'tooltips', 'fileDrop' ],
             useHash   : true,
             hideEmptyTracks: false,
             sharedStateCallbacks: [_ul],


### PR DESCRIPTION
This will let folks drag and drop bigwigs on the browser to see their data alongside what's in the portal.