### PR TITLE
Disable persistent connections

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -14,7 +14,6 @@ ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=[".duke.edu", "", ".ceg
 # ------------------------------------------------------------------------------
 DATABASES["default"] = env.db("DATABASE_URL")  # noqa F405
 DATABASES["default"]["ATOMIC_REQUESTS"] = True  # noqa F405
-DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=60)  # noqa F405
 DATABASES["default"]["OPTIONS"] = {"pool": True}  # noqa F405
 
 # CACHES


### PR DESCRIPTION
Connection pooling and persistent connections are mutually exclusive. Removing this option disabled persistent connections.