### PR TITLE
Fix bucket colors

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/render.js
+++ b/cegs_portal/search/static/search/js/exp_viz/render.js
@@ -16,35 +16,19 @@ import {
     STATE_LEGEND_INTERVALS,
 } from "./consts.js";
 
-let sourceRenderColors = coverageTypeFunctions(
-    {
-        color: d3.interpolateCool,
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(-260, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
-    },
-    {
+let sourceRenderColors = () => {
+    return {
         color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(260, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-260, 0.75, 0.95)),
-    },
-);
+        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(260, 0.75, 0.95)),
+    };
+};
 
-let targetRenderColors = coverageTypeFunctions(
-    {
-        color: d3.interpolateWarm,
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(-100, 0.75, 0.95), d3.cubehelix(80, 1.5, 0.95)),
-    },
-    {
+let targetRenderColors = () => {
+    return {
         color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
         faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
-    },
-    {
-        color: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.8), d3.cubehelix(-100, 0.75, 0.35)),
-        faded: d3.interpolateCubehelixLong(d3.cubehelix(80, 1.5, 0.95), d3.cubehelix(-100, 0.75, 0.95)),
-    },
-);
+    };
+};
 
 let sourceRenderDataTransform = coverageTypeDeferredFunctions(
     (state) => {


### PR DESCRIPTION
Two issues with bucket colors:

1. The "count" legend colors were left/right swapped with the other two legends
2. The "fade" colors weren't just faded, but also moved around the HSL color wheel.

This also simplifies the color function because we're usng the same set of colors for all three coverage types.