### PR TITLE
Make subfeature connections a line

### DIFF
--- a/cegs_portal/search/static/search/js/genoverse.js
+++ b/cegs_portal/search/static/search/js/genoverse.js
@@ -501,6 +501,7 @@ Genoverse.Track.Model.Transcript.Portal = Genoverse.Track.Model.Transcript.exten
 
 Genoverse.Track.View.Transcript.Portal = Genoverse.Track.View.Transcript.extend({
     featureHeight: 13,
+    subFeatureJoinStyle: "line",
     setFeatureColor: function (feature) {
         var processedTranscript = {
             "sense intronic": 1,


### PR DESCRIPTION
Instead of a curve. The curve was too reminiscent of DNA splicing diagrams.

New:
<img width="1443" alt="Screenshot 2024-10-24 at 2 45 26 PM" src="https://github.com/user-attachments/assets/eb750ac8-4def-4489-a162-bb2e745936f8">

Old:
<img width="1443" alt="Screenshot 2024-10-24 at 2 46 48 PM" src="https://github.com/user-attachments/assets/2b1b66b3-fd70-46fa-8b0c-39a150f07b93">
