### PR TITLE
Fix experiment list facets

### DIFF
--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -4,9 +4,17 @@ import {addDragListeners, addSelectListeners} from "./drag_drop.js";
 
 let controller;
 
+let experimentListURL = function (facetQuery) {
+    return `experiment?${facetQuery !== "" ? "&" + facetQuery : ""}`;
+};
+
 export function facetFilterSetup() {
     let facetCheckboxes = g("categorical-facets").querySelectorAll("input[type=checkbox]");
+
+    let queryParams = new URLSearchParams(window.location.search);
+    let experimentFacets = queryParams.getAll("facet");
     facetCheckboxes.forEach((checkbox) => {
+        checkbox.checked = experimentFacets.includes(checkbox.id); // reset the checkboxes after a page reload.
         checkbox.addEventListener("change", (_event) => {
             if (controller !== undefined) {
                 controller.abort();
@@ -16,6 +24,8 @@ export function facetFilterSetup() {
                 .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
                 .map((i) => `facet=${i.id}`)
                 .join("&");
+
+            window.history.pushState({}, document.title, experimentListURL(facetQuery));
 
             controller = new AbortController();
 

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -242,9 +242,12 @@ class ExperimentListView(MultiResponseFormatView):
         facet_values = ExperimentSearch.experiment_facet_values()
 
         if self.request.user.is_anonymous:
-            return ExperimentSearch.all_public(options["facets"]), facet_values
+            return ExperimentSearch.experiments(options["facets"], UserType.ANONYMOUS), facet_values
 
         if self.request.user.is_superuser or self.request.user.is_portal_admin:
-            return ExperimentSearch.all(options["facets"], UserType.ADMIN), facet_values
+            return ExperimentSearch.experiments(options["facets"], UserType.ADMIN), facet_values
 
-        return ExperimentSearch.all_with_private(options["facets"], self.request.user.all_experiments()), facet_values
+        return (
+            ExperimentSearch.experiments(options["facets"], UserType.LOGGED_IN, self.request.user.all_experiments()),
+            facet_values,
+        )

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -11,6 +11,7 @@ from cegs_portal.search.views.custom_views import (
     ExperimentAccessMixin,
     MultiResponseFormatView,
 )
+from cegs_portal.users.models import UserType
 from cegs_portal.utils.http_exceptions import Http400
 
 
@@ -244,6 +245,6 @@ class ExperimentListView(MultiResponseFormatView):
             return ExperimentSearch.all_public(options["facets"]), facet_values
 
         if self.request.user.is_superuser or self.request.user.is_portal_admin:
-            return ExperimentSearch.all(options["facets"]), facet_values
+            return ExperimentSearch.all(options["facets"], UserType.ADMIN), facet_values
 
         return ExperimentSearch.all_with_private(options["facets"], self.request.user.all_experiments()), facet_values


### PR DESCRIPTION
## Frontend
* adds/removes facets to the query string as they are checked/unchecked.
* Sets the check boxes to the facets specified in the URL when the
page is loaded.

## Backend
Previously all the facets were just "or"d together when filtering experiements. This change makes values within a single facet "or"d and between facets "and"ed (e.g.,  ("Perturb-Seq" OR "Flow-FISH Crispr screen") AND "K562" AND "hg38")


This functionality is meant to match the facet box on the search results page.