### PR TITLE
Order DNA Feature REOs by significance

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -368,9 +368,13 @@ def source_reg_effects():
     reo3 = RegEffectFactory(
         sources=(source,),
     )
+
+    reos = [reo1, reo2, reo3]
+    reos.sort(key=lambda r: r.facet_num_values[RegulatoryEffectObservation.Facet.SIGNIFICANCE.value])
+
     return {
         "source": source,
-        "effects": [reo1, reo2, reo3],
+        "effects": reos,
     }
 
 
@@ -403,9 +407,12 @@ def sig_only_source_reg_effects():
         facet_values=(direction_non_significant,),
     )
 
+    reos = [reo1, reo2, reo3, reo4]
+    reos.sort(key=lambda r: r.facet_num_values[RegulatoryEffectObservation.Facet.SIGNIFICANCE.value])
+
     return {
         "source": source,
-        "effects": [reo1, reo2, reo3, reo4],
+        "effects": reos,
     }
 
 
@@ -438,9 +445,12 @@ def sig_only_target_reg_effects():
         facet_values=(direction_non_significant,),
     )
 
+    reos = [reo1, reo2, reo3, reo4]
+    reos.sort(key=lambda r: r.facet_num_values[RegulatoryEffectObservation.Facet.SIGNIFICANCE.value])
+
     return {
         "target": target,
-        "effects": [reo1, reo2, reo3, reo4],
+        "effects": reos,
     }
 
 
@@ -478,9 +488,12 @@ def target_reg_effects():
     reo3 = RegEffectFactory(
         targets=(target,),
     )
+    reos = [reo1, reo2, reo3]
+    reos.sort(key=lambda r: r.facet_num_values[RegulatoryEffectObservation.Facet.SIGNIFICANCE.value])
+
     return {
         "target": target,
-        "effects": [reo1, reo2, reo3],
+        "effects": reos,
     }
 
 

--- a/cegs_portal/search/view_models/v1/reg_effects.py
+++ b/cegs_portal/search/view_models/v1/reg_effects.py
@@ -1,6 +1,7 @@
 from typing import Optional, cast
 
 from django.db.models import Q
+from django.db.models.fields.json import KT
 
 from cegs_portal.search.models import (
     DNAFeature,
@@ -83,7 +84,7 @@ class RegEffectSearch:
                 "sources",
                 "targets",
             )
-            .order_by("accession_id")
+            .order_by(KT("facet_num_values__Significance"))
         )
 
         if sig_only:
@@ -112,7 +113,7 @@ class RegEffectSearch:
                 "sources",
                 "targets",
             )
-            .order_by("accession_id")
+            .order_by(KT("facet_num_values__Significance"))
         )
 
         if sig_only:

--- a/cegs_portal/search/views/v1/tests/test_source_reg_effects.py
+++ b/cegs_portal/search/views/v1/tests/test_source_reg_effects.py
@@ -18,7 +18,7 @@ def view():
 
 def test_source_reg_effects_list_e2e(client: Client, source_reg_effects, sig_only_source_reg_effects):
     source = source_reg_effects["source"]
-    effects = sorted(source_reg_effects["effects"], key=lambda x: x.accession_id)
+    effects = source_reg_effects["effects"]
     response = client.get(f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json")
 
     assert response.status_code == 200
@@ -164,7 +164,7 @@ def test_get_archived_source_reg_effects_with_authenticated_authorized_group_cli
 
 def test_source_reg_effects_list_page_json(public_test_client: RequestBuilder, view, source_reg_effects):
     source = source_reg_effects["source"]
-    effects = sorted(source_reg_effects["effects"], key=lambda x: x.accession_id)
+    effects = source_reg_effects["effects"]
     response = public_test_client.get(
         f"/search/feature/accession/{source.accession_id}/source_for?accept=application/json&page=1&per_page=1"
     ).request(view, feature_id=source.accession_id)

--- a/cegs_portal/search/views/v1/tests/test_target_reg_effects.py
+++ b/cegs_portal/search/views/v1/tests/test_target_reg_effects.py
@@ -18,7 +18,7 @@ def view():
 
 def test_target_reg_effects_list_e2e(client: Client, target_reg_effects, sig_only_target_reg_effects):
     target = target_reg_effects["target"]
-    effects = sorted(target_reg_effects["effects"], key=lambda x: x.accession_id)
+    effects = target_reg_effects["effects"]
     response = client.get(f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json")
 
     assert response.status_code == 200
@@ -164,7 +164,7 @@ def test_get_archived_target_reg_effects_with_authenticated_authorized_group_cli
 
 def test_target_reg_effects_list_page_json(public_test_client: RequestBuilder, view, target_reg_effects):
     target = target_reg_effects["target"]
-    effects = sorted(target_reg_effects["effects"], key=lambda x: x.accession_id)
+    effects = target_reg_effects["effects"]
     response = public_test_client.get(
         f"/search/feature/accession/{target.accession_id}/target_of?accept=application/json&page=1&per_page=1"
     ).request(view, feature_id=target.accession_id)


### PR DESCRIPTION
Significance is also the Corrected p-Value. Previously these were ordered by accession id, which doesn't make much sense.

![Screenshot 2024-10-25 at 1 25 34 PM](https://github.com/user-attachments/assets/80086690-708b-4ee5-af7d-1c51999a46cc)
