### PR TITLE
Highlight Selected Bucket

### DIFF
--- a/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
+++ b/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
@@ -100,7 +100,8 @@ function VizRenderContext(chromDimensions, genome) {
     this.yInset = 100;
     this.viewWidth = chromDimensions.maxPxChromWidth + this.xInset * 2;
     this.viewHeight = this.yInset * 2 + (chromDimensions.chromHeight + chromDimensions.chromSpacing) * genome.length;
-
+    this.scaleX = (zoomed) => (zoomed ? 30 : 1);
+    this.scaleY = (zoomed) => (zoomed ? 15 : 1);
     this.toPx = function (size) {
         return this.chromDimensions.maxPxChromWidth * (size / this.chromDimensions.maxChromSize);
     };
@@ -132,12 +133,12 @@ function legendBackground(genome) {
         .attr("stroke-width", 1)
         .attr("stroke", "rgba(0, 0, 0, .1)")
         .attr("fill", "none")
-        .attr("d", chromosomeOutline(1, 1, 1, renderContext, chromDimensions, genome[20], 0));
+        .attr("d", chromosomeOutline(1, 1, renderContext, chromDimensions, genome[20], 0));
 
     return svg.node();
 }
 
-function chromosomeOutline(scale, scaleX, scaleY, renderContext, chromDimensions, chrom, chromIndex) {
+function chromosomeOutline(scaleX, scaleY, renderContext, chromDimensions, chrom, chromIndex) {
     const width = renderContext.toPx(chrom.size) * scaleX;
     const top =
         renderContext.yInset + (chromDimensions.chromSpacing + chromDimensions.chromHeight) * chromIndex * scaleY;
@@ -145,11 +146,11 @@ function chromosomeOutline(scale, scaleX, scaleY, renderContext, chromDimensions
     const outlinePath = ["M", renderContext.xInset, ",", top];
     outlinePath.push(
         "C",
-        renderContext.xInset - 12 * scale,
+        renderContext.xInset - 12 * scaleY,
         ",",
         top,
         " ",
-        renderContext.xInset - 12 * scale,
+        renderContext.xInset - 12 * scaleY,
         ",",
         bottom,
         " ",
@@ -160,11 +161,11 @@ function chromosomeOutline(scale, scaleX, scaleY, renderContext, chromDimensions
     outlinePath.push("M", renderContext.xInset + width, ",", top);
     outlinePath.push(
         "C",
-        renderContext.xInset + width + 12 * scale,
+        renderContext.xInset + width + 12 * scaleY,
         ",",
         top,
         " ",
-        renderContext.xInset + width + 12 * scale,
+        renderContext.xInset + width + 12 * scaleY,
         ",",
         bottom,
         " ",
@@ -243,7 +244,7 @@ export class GenomeRenderer {
         this.onBackgroundClick = null;
     }
 
-    _zoomOutButton(svg, chromIndex, scales, xInset) {
+    _zoomOutButton(svg, chromIndex, scaleX, scaleY, xInset) {
         const fontSize = 140;
         const strokeSize = 3;
         const fillColor = "#9D9D9D";
@@ -252,11 +253,11 @@ export class GenomeRenderer {
         const text = "Zoom Out";
         const textHAnchor = "middle";
         const textVAnchor = "central";
-        const height = this.chromDimensions.chromSpacing * scales.scaleY - vMargin * 2;
-        const width = 25 * scales.scaleX;
+        const height = this.chromDimensions.chromSpacing * scaleY - vMargin * 2;
+        const width = 25 * scaleX;
         const top =
             this.renderContext.yInset +
-            (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * chromIndex * scales.scaleY -
+            (this.chromDimensions.chromSpacing + this.chromDimensions.chromHeight) * chromIndex * scaleY -
             (height + vMargin);
 
         let buttonGroup = svg.append("g");
@@ -268,7 +269,7 @@ export class GenomeRenderer {
             .attr("height", height)
             .attr("stroke-width", strokeSize)
             .attr("fill", fillColor)
-            .attr("rx", cornerRadius * scales.scale);
+            .attr("rx", cornerRadius * scaleY);
         let buttonText = buttonGroup.append("text");
         buttonText
             .attr("x", xInset + this.renderContext.viewWidth / 2)
@@ -290,13 +291,12 @@ export class GenomeRenderer {
         sourceTooltipDataLabel,
         targetTooltipDataLabel,
         viewBox,
-        scale,
-        scaleX,
-        scaleY,
+        zoomed,
         highlightRegions,
     ) {
+        const scaleX = this.renderContext.scaleX(zoomed);
+        const scaleY = this.renderContext.scaleY(zoomed);
         const bucketHeight = 44 * scaleY;
-        const scales = {scale, scaleX, scaleY};
 
         const svg = d3
             .create("svg")
@@ -327,20 +327,12 @@ export class GenomeRenderer {
                 .attr("fill", "none")
                 .attr(
                     "d",
-                    chromosomeOutline(
-                        scale,
-                        scaleX,
-                        scaleY,
-                        this.renderContext,
-                        this.chromDimensions,
-                        this.genome[i],
-                        i,
-                    ),
+                    chromosomeOutline(scaleX, scaleY, this.renderContext, this.chromDimensions, this.genome[i], i),
                 );
         }
 
-        if (scale > 1) {
-            this._zoomOutButton(svg, focusIndex, scales, viewBox[0]);
+        if (zoomed) {
+            this._zoomOutButton(svg, focusIndex, scaleX, scaleY, viewBox[0]);
         }
 
         let nameGroup = svg.append("g");

--- a/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
+++ b/cegs_portal/search/static/search/js/exp_viz/chromosomeSvg.js
@@ -14,6 +14,19 @@ const bandColors = {
 
 const svgns = "http://www.w3.org/2000/svg";
 
+export class ChromRange {
+    constructor(lower, upper) {
+        this.lower = lower;
+        this.upper = upper;
+    }
+}
+export class BucketLocation {
+    constructor(chromIndex, range) {
+        this.chromIndex = chromIndex;
+        this.range = range;
+    }
+}
+
 export class Tooltip {
     constructor(renderContext) {
         this.renderContext = renderContext;
@@ -282,7 +295,7 @@ export class GenomeRenderer {
 
     render(
         coverageData,
-        focusIndex,
+        focusLocation,
         sourceRenderColors,
         targetRenderColors,
         sourceRenderDataTransform,

--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -2,7 +2,7 @@ import {a, cc, e, g, rc, t} from "../dom.js";
 import {State} from "../state.js";
 import {getRegions} from "../bed.js";
 import {getJson, postJson} from "../files.js";
-import {GenomeRenderer} from "./chromosomeSvg.js";
+import {GenomeRenderer, BucketLocation, ChromRange} from "./chromosomeSvg.js";
 import {getDownloadRegions, getDownloadAll} from "./downloads.js";
 import {debounce} from "../utils.js";
 import {render} from "./render.js";
@@ -11,7 +11,7 @@ import {mergeFilteredData} from "./coverageData.js";
 import {coverageValue, effectInterval, levelCountInterval, sigInterval} from "./covTypeUtils.js";
 import {
     STATE_ZOOMED,
-    STATE_ZOOM_CHROMO_INDEX,
+    STATE_ZOOM_GENOME_LOCATION,
     STATE_VIEWBOX,
     STATE_FACETS,
     STATE_CATEGORICAL_FACET_VALUES,
@@ -150,7 +150,7 @@ function build_state(manifests, genomeRenderer, accessionIDs, sourceType) {
 
     let state = new State({
         [STATE_ZOOMED]: false,
-        [STATE_ZOOM_CHROMO_INDEX]: undefined,
+        [STATE_ZOOM_GENOME_LOCATION]: undefined,
         [STATE_VIEWBOX]: [0, 0, genomeRenderer.renderContext.viewWidth, genomeRenderer.renderContext.viewHeight],
         [STATE_FACETS]: facets,
         [STATE_CATEGORICAL_FACET_VALUES]: default_facets,
@@ -249,8 +249,8 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
                 renderer.renderContext.viewWidth,
                 renderer.renderContext.viewHeight,
             ]);
-            state.u(STATE_ZOOM_CHROMO_INDEX, i);
-            state.u(STATE_ZOOMED, !zoomed);
+            state.u(STATE_ZOOM_GENOME_LOCATION, new BucketLocation(i, new ChromRange(start, end)));
+            state.u(STATE_ZOOMED, true);
         }
     };
 
@@ -258,8 +258,8 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         let zoomed = state.g(STATE_ZOOMED);
         if (zoomed) {
             state.u(STATE_VIEWBOX, [0, 0, renderer.renderContext.viewWidth, renderer.renderContext.viewHeight]);
-            state.u(STATE_ZOOM_CHROMO_INDEX, undefined);
-            state.u(STATE_ZOOMED, !zoomed);
+            state.u(STATE_ZOOM_GENOME_LOCATION, undefined);
+            state.u(STATE_ZOOMED, false);
         }
     };
 

--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -12,9 +12,6 @@ import {coverageValue, effectInterval, levelCountInterval, sigInterval} from "./
 import {
     STATE_ZOOMED,
     STATE_ZOOM_CHROMO_INDEX,
-    STATE_SCALE,
-    STATE_SCALE_X,
-    STATE_SCALE_Y,
     STATE_VIEWBOX,
     STATE_FACETS,
     STATE_CATEGORICAL_FACET_VALUES,
@@ -154,9 +151,6 @@ function build_state(manifests, genomeRenderer, accessionIDs, sourceType) {
     let state = new State({
         [STATE_ZOOMED]: false,
         [STATE_ZOOM_CHROMO_INDEX]: undefined,
-        [STATE_SCALE]: 1,
-        [STATE_SCALE_X]: 1,
-        [STATE_SCALE_Y]: 1,
         [STATE_VIEWBOX]: [0, 0, genomeRenderer.renderContext.viewWidth, genomeRenderer.renderContext.viewHeight],
         [STATE_FACETS]: facets,
         [STATE_CATEGORICAL_FACET_VALUES]: default_facets,
@@ -274,11 +268,6 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
     });
 
     state.ac(STATE_ZOOMED, (s, key) => {
-        const zoomed = s[key];
-        state.u(STATE_SCALE, zoomed ? 15 : 1);
-        state.u(STATE_SCALE_X, zoomed ? 30 : 1);
-        state.u(STATE_SCALE_Y, zoomed ? 15 : 1);
-
         let body = getFilterBody(
             state,
             genome,

--- a/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/combo_viz.js
@@ -241,10 +241,12 @@ export async function combined_viz(staticRoot, csrfToken, loggedIn) {
         } else {
             state.u(STATE_VIEWBOX, [
                 renderer.renderContext.xInset +
-                    renderer.renderContext.toPx(start) * 30 -
-                    renderer.renderContext.viewHeight / 6,
+                    renderer.renderContext.toPx(start + (end - start) / 2) * renderer.renderContext.scaleX(true) -
+                    renderer.renderContext.viewWidth / 2,
                 renderer.renderContext.yInset +
-                    (renderer.chromDimensions.chromHeight + renderer.chromDimensions.chromSpacing) * i * 15 -
+                    (renderer.chromDimensions.chromHeight + renderer.chromDimensions.chromSpacing) *
+                        i *
+                        renderer.renderContext.scaleY(true) -
                     renderer.renderContext.viewHeight / 6,
                 renderer.renderContext.viewWidth,
                 renderer.renderContext.viewHeight,

--- a/cegs_portal/search/static/search/js/exp_viz/consts.js
+++ b/cegs_portal/search/static/search/js/exp_viz/consts.js
@@ -1,5 +1,5 @@
 export const STATE_ZOOMED = "state-zoomed";
-export const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
+export const STATE_ZOOM_GENOME_LOCATION = "state-zoom-chromo-index";
 export const STATE_VIEWBOX = "state-viewbox";
 export const STATE_FACETS = "state-facets";
 export const STATE_CATEGORICAL_FACET_VALUES = "state-categorical-facets";

--- a/cegs_portal/search/static/search/js/exp_viz/consts.js
+++ b/cegs_portal/search/static/search/js/exp_viz/consts.js
@@ -1,8 +1,5 @@
 export const STATE_ZOOMED = "state-zoomed";
 export const STATE_ZOOM_CHROMO_INDEX = "state-zoom-chromo-index";
-export const STATE_SCALE = "state-scale";
-export const STATE_SCALE_X = "state-scale-x";
-export const STATE_SCALE_Y = "state-scale-y";
 export const STATE_VIEWBOX = "state-viewbox";
 export const STATE_FACETS = "state-facets";
 export const STATE_CATEGORICAL_FACET_VALUES = "state-categorical-facets";

--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -139,10 +139,12 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
         } else {
             state.u(STATE_VIEWBOX, [
                 renderer.renderContext.xInset +
-                    renderer.renderContext.toPx(start) * 30 -
-                    renderer.renderContext.viewHeight / 6,
+                    renderer.renderContext.toPx(start + (end - start) / 2) * renderer.renderContext.scaleX(true) -
+                    renderer.renderContext.viewWidth / 2,
                 renderer.renderContext.yInset +
-                    (renderer.chromDimensions.chromHeight + renderer.chromDimensions.chromSpacing) * i * 15 -
+                    (renderer.chromDimensions.chromHeight + renderer.chromDimensions.chromSpacing) *
+                        i *
+                        renderer.renderContext.scaleY(true) -
                     renderer.renderContext.viewHeight / 6,
                 renderer.renderContext.viewWidth,
                 renderer.renderContext.viewHeight,

--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -12,9 +12,6 @@ import {coverageValue, effectInterval, levelCountInterval, sigInterval} from "./
 import {
     STATE_ZOOMED,
     STATE_ZOOM_CHROMO_INDEX,
-    STATE_SCALE,
-    STATE_SCALE_X,
-    STATE_SCALE_Y,
     STATE_VIEWBOX,
     STATE_FACETS,
     STATE_CATEGORICAL_FACET_VALUES,
@@ -66,9 +63,6 @@ function build_state(manifest, genomeRenderer, exprAccessionID, analysisAccessio
     let state = new State({
         [STATE_ZOOMED]: false,
         [STATE_ZOOM_CHROMO_INDEX]: undefined,
-        [STATE_SCALE]: 1,
-        [STATE_SCALE_X]: 1,
-        [STATE_SCALE_Y]: 1,
         [STATE_VIEWBOX]: [0, 0, genomeRenderer.renderContext.viewWidth, genomeRenderer.renderContext.viewHeight],
         [STATE_FACETS]: facets,
         [STATE_CATEGORICAL_FACET_VALUES]: default_facets,
@@ -172,11 +166,6 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
     });
 
     state.ac(STATE_ZOOMED, (s, key) => {
-        const zoomed = s[key];
-        state.u(STATE_SCALE, zoomed ? 15 : 1);
-        state.u(STATE_SCALE_X, zoomed ? 30 : 1);
-        state.u(STATE_SCALE_Y, zoomed ? 15 : 1);
-
         let body = getFilterBody(
             state,
             genome,

--- a/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
+++ b/cegs_portal/search/static/search/js/exp_viz/exp_viz.js
@@ -2,7 +2,7 @@ import {a, cc, e, g, rc, t} from "../dom.js";
 import {State} from "../state.js";
 import {getRegions} from "../bed.js";
 import {getJson, postJson} from "../files.js";
-import {GenomeRenderer} from "./chromosomeSvg.js";
+import {GenomeRenderer, BucketLocation, ChromRange} from "./chromosomeSvg.js";
 import {getDownloadRegions, getDownloadAll} from "./downloads.js";
 import {debounce} from "../utils.js";
 import {render} from "./render.js";
@@ -11,7 +11,7 @@ import {mergeFilteredData} from "./coverageData.js";
 import {coverageValue, effectInterval, levelCountInterval, sigInterval} from "./covTypeUtils.js";
 import {
     STATE_ZOOMED,
-    STATE_ZOOM_CHROMO_INDEX,
+    STATE_ZOOM_GENOME_LOCATION,
     STATE_VIEWBOX,
     STATE_FACETS,
     STATE_CATEGORICAL_FACET_VALUES,
@@ -62,7 +62,7 @@ function build_state(manifest, genomeRenderer, exprAccessionID, analysisAccessio
 
     let state = new State({
         [STATE_ZOOMED]: false,
-        [STATE_ZOOM_CHROMO_INDEX]: undefined,
+        [STATE_ZOOM_GENOME_LOCATION]: undefined,
         [STATE_VIEWBOX]: [0, 0, genomeRenderer.renderContext.viewWidth, genomeRenderer.renderContext.viewHeight],
         [STATE_FACETS]: facets,
         [STATE_CATEGORICAL_FACET_VALUES]: default_facets,
@@ -147,8 +147,9 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
                 renderer.renderContext.viewWidth,
                 renderer.renderContext.viewHeight,
             ]);
-            state.u(STATE_ZOOM_CHROMO_INDEX, i);
-            state.u(STATE_ZOOMED, !zoomed);
+
+            state.u(STATE_ZOOM_GENOME_LOCATION, new BucketLocation(i, new ChromRange(start, end)));
+            state.u(STATE_ZOOMED, true);
         }
     };
 
@@ -156,8 +157,8 @@ export async function exp_viz(staticRoot, exprAccessionID, analysisAccessionID, 
         let zoomed = state.g(STATE_ZOOMED);
         if (zoomed) {
             state.u(STATE_VIEWBOX, [0, 0, renderer.renderContext.viewWidth, renderer.renderContext.viewHeight]);
-            state.u(STATE_ZOOM_CHROMO_INDEX, undefined);
-            state.u(STATE_ZOOMED, !zoomed);
+            state.u(STATE_ZOOM_GENOME_LOCATION, undefined);
+            state.u(STATE_ZOOMED, false);
         }
     };
 

--- a/cegs_portal/search/static/search/js/exp_viz/render.js
+++ b/cegs_portal/search/static/search/js/exp_viz/render.js
@@ -2,10 +2,8 @@ import {a, g, rc, t} from "../dom.js";
 import {Legend} from "./obsLegend.js";
 import {coverageTypeDeferredFunctions, coverageTypeFunctions} from "./covTypeUtils.js";
 import {
+    STATE_ZOOMED,
     STATE_ZOOM_CHROMO_INDEX,
-    STATE_SCALE,
-    STATE_SCALE_X,
-    STATE_SCALE_Y,
     STATE_VIEWBOX,
     STATE_ALL_FILTERED,
     STATE_NUMERIC_FILTER_INTERVALS,
@@ -108,9 +106,7 @@ let tooltipDataSelectors = [
 
 export function render(state, genomeRenderer) {
     const viewBox = state.g(STATE_VIEWBOX);
-    const scale = state.g(STATE_SCALE);
-    const scaleX = state.g(STATE_SCALE_X);
-    const scaleY = state.g(STATE_SCALE_Y);
+    const zoomed = state.g(STATE_ZOOMED);
     const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
     let currentLevel = state.g(STATE_ALL_FILTERED);
     let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
@@ -133,9 +129,7 @@ export function render(state, genomeRenderer) {
             sourceTooltipDataLabel(state),
             targetTooltipDataLabel,
             viewBox,
-            scale,
-            scaleX,
-            scaleY,
+            zoomed,
             highlightRegions,
         ),
     );

--- a/cegs_portal/search/static/search/js/exp_viz/render.js
+++ b/cegs_portal/search/static/search/js/exp_viz/render.js
@@ -3,7 +3,7 @@ import {Legend} from "./obsLegend.js";
 import {coverageTypeDeferredFunctions, coverageTypeFunctions} from "./covTypeUtils.js";
 import {
     STATE_ZOOMED,
-    STATE_ZOOM_CHROMO_INDEX,
+    STATE_ZOOM_GENOME_LOCATION,
     STATE_VIEWBOX,
     STATE_ALL_FILTERED,
     STATE_NUMERIC_FILTER_INTERVALS,
@@ -109,7 +109,7 @@ export function render(state, genomeRenderer) {
     const zoomed = state.g(STATE_ZOOMED);
     const highlightRegions = state.g(STATE_HIGHLIGHT_REGIONS);
     let currentLevel = state.g(STATE_ALL_FILTERED);
-    let focusIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
+    let focusLocation = state.g(STATE_ZOOM_GENOME_LOCATION);
     let itemCounts = state.g(STATE_ITEM_COUNTS);
     let legendIntervals = state.g(STATE_LEGEND_INTERVALS);
 
@@ -120,7 +120,7 @@ export function render(state, genomeRenderer) {
         g("chrom-data"),
         genomeRenderer.render(
             currentLevel,
-            focusIndex,
+            focusLocation,
             sourceColors,
             targetColors,
             sourceRenderDataTransform(state),

--- a/cegs_portal/search/static/search/js/exp_viz/ui.js
+++ b/cegs_portal/search/static/search/js/exp_viz/ui.js
@@ -10,7 +10,7 @@ import {
     STATE_NUMERIC_FACET_VALUES,
     STATE_SELECTED_EXPERIMENTS,
     STATE_SOURCE_TYPE,
-    STATE_ZOOM_CHROMO_INDEX,
+    STATE_ZOOM_GENOME_LOCATION,
     STATE_ZOOMED,
 } from "./consts.js";
 
@@ -174,8 +174,8 @@ export function getFilterBody(state, genome, chroms, filter_values, combo_op) {
         chromosomes: genome.map((c) => c.chrom),
     };
     if (state.g(STATE_ZOOMED)) {
-        let zoomChromoIndex = state.g(STATE_ZOOM_CHROMO_INDEX);
-        filters.zoom = chroms[zoomChromoIndex].chrom;
+        let zoomChromoIndex = state.g(STATE_ZOOM_GENOME_LOCATION);
+        filters.zoom = chroms[zoomChromoIndex.chromIndex].chrom;
     }
     try {
         let combinations = state.g(STATE_SELECTED_EXPERIMENTS).map((exp) => exp.join("/"));


### PR DESCRIPTION
After a user zoomed in they couldn't tell where the bucket they selected was. This adds a basic highlight to show the user which 100kb buckets are in the 2mb bucket they selected.

<img width="1150" alt="Screenshot 2024-10-31 at 2 39 55 PM" src="https://github.com/user-attachments/assets/3fd58ba7-a6fc-414e-97f8-73eac772f363">
