### PR TITLE
Fix test failure that slipped through PR #433

### DIFF
--- a/cegs_portal/search/conftest.py
+++ b/cegs_portal/search/conftest.py
@@ -577,6 +577,7 @@ def genoverse_features():
         chrom_name=chrom,
         location=Int4Range(start, start + length),
         feature_type=DNAFeatureType.DHS,
+        significant_reo=True,
     )
     f2 = DNAFeatureFactory(
         ref_genome=ref_genome,
@@ -584,6 +585,7 @@ def genoverse_features():
         location=Int4Range(start + length + gap, start + length * 2 + gap),
         feature_type=DNAFeatureType.CCRE,
         facet_values=(pels,),
+        significant_reo=True,
     )
     f3 = DNAFeatureFactory(
         ref_genome=ref_genome,


### PR DESCRIPTION
The features need to have their significant_reo property set. I should have run pytest myself, but I'm also surprised that gitlab didn't run the CI pipeline for the branch from #433  which also would have caught it.