### PR TITLE
Let tables be full width

### DIFF
--- a/cegs_portal/search/templates/search/v1/non_targeting_reos.html
+++ b/cegs_portal/search/templates/search/v1/non_targeting_reos.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div>
-<div class="title-separator"></div>
+    <div class="title-separator"></div>
     <div class="md:ps-10" style="display: flex; justify-content: space-between">
         <span class="page-header-w-icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" class="svg-icon mr-2">
@@ -19,7 +19,7 @@
         </span>
     </div>
     <div class="title-separator"></div>
-    <div class="container">
+    <div class="content-container">
         <table class="profile-table">
             <thead>
                 <tr>

--- a/cegs_portal/search/templates/search/v1/partials/_reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/partials/_reg_effect.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 {% load custom_helpers %}
 
-<div class="content-container min-w-full max-w-sm">
+<div class="content-container min-w-full max-w-sm md:max-w-full">
     <div class="table-title flex flex-col md:flex-row items-center justify-between">
         <div class="flex-1">
             <!-- This empty div takes up space on the left for centering and for responsive design-->

--- a/cegs_portal/search/templates/search/v1/partials/_target_reg_effect.html
+++ b/cegs_portal/search/templates/search/v1/partials/_target_reg_effect.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 {% load custom_helpers %}
 
-<div class="content-container min-w-full max-w-sm">
+<div class="content-container min-w-full max-w-sm md:max-w-full">
     <div class="table-title flex flex-col md:flex-row items-center justify-between">
         <div class="flex-1">
             <!-- This empty div takes up space on the left for centering and for responsive design-->

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -3048,6 +3048,10 @@ fieldset legend {
     min-width: 0px;
   }
 
+  .md\:max-w-full {
+    max-width: 100%;
+  }
+
   .md\:flex-row {
     -webkit-box-orient: horizontal;
     -webkit-box-direction: normal;


### PR DESCRIPTION
These tables were stuck at always being the "small" width, regardless of container size. This change lets them be "full width" once the width is the tailwind "medium".