### PR TITLE
Tooltip, ref genome ordered, opened filter accordion

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -209,6 +209,10 @@
                         aria-labelledby="analyzeExperiments">
                         <div class="w-full h-1/2 border border-gray-300 p-5" id="view-experiments">
                           <div class="italic flex justify-center text-center" id="experiments-link">Please select at least one experiment.</div>
+                          <div class="italic mt-2">
+                           Note: Selected experiments must be within the same genome assembly for analysis
+                           {% include 'search/v1/partials/_help_tooltip.html' with help_text="Filter by genome assembly and select the desired experiments." %}
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/cegs_portal/search/templates/search/v1/partials/_experiment_index.html
+++ b/cegs_portal/search/templates/search/v1/partials/_experiment_index.html
@@ -16,9 +16,8 @@
                     <legend class="flex flex-row group font-bold min-w-full" id="experimentFiltersHeader"
                         data-te-collapse-init
                         data-te-target="#experimentFiltersCollapse"
-                        aria-expanded="false"
-                        aria-controls="experimentFiltersCollapse"
-                        data-te-collapse-collapsed>
+                        aria-expanded="true"
+                        aria-controls="experimentFiltersCollapse">
                         <div class="flex justify-center items-center">
                             <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Experiments</div>
                         </div>
@@ -38,9 +37,10 @@
                             </svg>
                         </div>
                     </legend>
-                    <div class="flex flex-row flex-wrap gap-1 hidden"
+                    <div class="flex flex-row flex-wrap gap-1"
                         id="experimentFiltersCollapse"
                         data-te-collapse-item
+                        data-te-collapse-show
                         aria-labelledby="experimentFiltersHeader">
                         <div id="categorical-facets" class="w-full">
                             {% for facet, values in facets.items %}

--- a/cegs_portal/search/templates/search/v1/partials/_multi_experiment_index.html
+++ b/cegs_portal/search/templates/search/v1/partials/_multi_experiment_index.html
@@ -16,9 +16,8 @@
                 <legend class="flex flex-row group font-bold min-w-full" id="experimentFiltersHeader"
                     data-te-collapse-init
                     data-te-target="#experimentFiltersCollapse"
-                    aria-expanded="false"
-                    aria-controls="experimentFiltersCollapse"
-                    data-te-collapse-collapsed>
+                    aria-expanded="true"
+                    aria-controls="experimentFiltersCollapse">
                     <div class="flex justify-center items-center">
                         <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Experiments</div>
                     </div>
@@ -38,9 +37,10 @@
                         </svg>
                     </div>
                 </legend>
-                <div class="flex flex-row flex-wrap gap-1 hidden"
+                <div class="flex flex-row flex-wrap gap-1"
                     id="experimentFiltersCollapse"
                     data-te-collapse-item
+                    data-te-collapse-show
                     aria-labelledby="experimentFiltersHeader">
                     <div id="categorical-facets" class="w-full">
                         {% for facet, values in facets.items %}
@@ -206,6 +206,10 @@
                                 aria-expanded="true">
                                 <div class="w-full h-1/2 border border-gray-300 p-5" id="view-experiments">
                                     <div class="italic flex justify-center text-center" id="experiments-link">Please select at least one experiment.</div>
+                                    <div class="italic mt-2">
+                                        Note: Selected experiments must be within the same genome assembly for analysis
+                                        {% include 'search/v1/partials/_help_tooltip.html' with help_text="Filter by genome assembly and select the desired experiments." %}
+                                      </div>
                                 </div>
                             </div>
                         </div>

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -205,6 +205,12 @@ class ExperimentListView(MultiResponseFormatView):
             else:
                 facets[value.facet.name] = [value]
 
+        sorted_facets = {}
+        if "Genome Assembly" in facets:
+            sorted_facets["Genome Assembly"] = facets.pop("Genome Assembly")
+
+        sorted_facets.update(facets)
+
         if request.headers.get("HX-Target") == "multi-exp-modal-container":
             return render(
                 request,
@@ -212,7 +218,7 @@ class ExperimentListView(MultiResponseFormatView):
                 {
                     "experiments": experiment_objects,
                     "experiment_ids": [expr.accession_id for expr in experiment_objects],
-                    "facets": facets,
+                    "facets": sorted_facets,
                 },
             )
 
@@ -223,7 +229,7 @@ class ExperimentListView(MultiResponseFormatView):
                 {
                     "experiments": experiment_objects,
                     "experiment_ids": [expr.accession_id for expr in experiment_objects],
-                    "facets": facets,
+                    "facets": sorted_facets,
                 },
             )
 
@@ -234,7 +240,7 @@ class ExperimentListView(MultiResponseFormatView):
                 "logged_in": not request.user.is_anonymous,
                 "experiments": experiment_objects,
                 "experiment_ids": [expr.accession_id for expr in experiment_objects],
-                "facets": facets,
+                "facets": sorted_facets,
             },
         )
 

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1947,12 +1947,20 @@ input[type="submit"], input[type="button"], button {
   font-weight: 500;
 }
 
+.font-semibold {
+  font-weight: 600;
+}
+
 .uppercase {
   text-transform: uppercase;
 }
 
 .italic {
   font-style: italic;
+}
+
+.leading-relaxed {
+  line-height: 1.625;
 }
 
 .leading-tight {
@@ -3112,6 +3120,10 @@ fieldset legend {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .md\:p-5 {
+    padding: 1.25rem;
   }
 
   .md\:ps-10 {


### PR DESCRIPTION
Added tooltip to experiment partials, placed ref genome  at top of exp filter, opened filter exp accordion in exp and multi exp partials.

![image](https://github.com/user-attachments/assets/4448baed-2ce2-4c5e-92d7-f36a61bf882d)
![image](https://github.com/user-attachments/assets/ab82c7dd-0e49-449f-aa73-04dba1d82860)
![image](https://github.com/user-attachments/assets/4e5d75c3-f836-4674-b702-254ffdf7ec00)
