### PR TITLE
Add assembly info to experiment box

### DIFF
--- a/cegs_portal/search/json_templates/v1/experiment.py
+++ b/cegs_portal/search/json_templates/v1/experiment.py
@@ -12,6 +12,7 @@ def experiments(experiments_data: tuple[Any, Any], options: Optional[dict[str, A
                 "name": e.name,
                 "description": e.description if e.description is not None else "",
                 "biosamples": [biosample(b) for b in e.biosamples.all()],
+                "genome_assembly": e.default_analysis.genome_assembly if e.default_analysis else None,
             }
             for e in experiments_obj
         ],

--- a/cegs_portal/search/json_templates/v1/tests/test_experiment.py
+++ b/cegs_portal/search/json_templates/v1/tests/test_experiment.py
@@ -21,6 +21,7 @@ def test_experiments_json(experiment_list_data: tuple[Any, Any]):
                 "name": e.name,
                 "description": e.description if e.description is not None else "",
                 "biosamples": [b_json(b) for b in e.biosamples.all()],
+                "genome_assembly": e.default_analysis.genome_assembly,
             }
             for e in experiments_obj
         ]

--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -19,7 +19,13 @@ export function facetFilterSetup() {
         checkbox.checked = experimentFacets.includes(checkbox.id); // reset the checkboxes after a page reload.
         checkbox.addEventListener("change", (_event) => {
             let url = experimentListURL(facetCheckboxes);
-            window.history.pushState({}, document.title, url);
+
+            // We don't want to mess with the state when using this from a modal
+            // on an experiment/multi-experiment page
+            if (window.location.pathname === "/search/experiment") {
+                window.history.pushState({}, document.title, url);
+            }
+
             htmx.ajax("GET", `/search/${url}`, "#experiment-list")
                 .then(() => {
                     addDragListeners();

--- a/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
+++ b/cegs_portal/search/static/search/js/experiment_list/facet_filter.js
@@ -1,11 +1,13 @@
-import {e, g, rc} from "../dom.js";
-import {getJson} from "../files.js";
+import {g} from "../dom.js";
 import {addDragListeners, addSelectListeners} from "./drag_drop.js";
 
-let controller;
+let experimentListURL = function (facetCheckboxes) {
+    let facetQuery = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
+        .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
+        .map((i) => `facet=${i.id}`)
+        .join("&");
 
-let experimentListURL = function (facetQuery) {
-    return `experiment?${facetQuery !== "" ? "&" + facetQuery : ""}`;
+    return `experiment?${facetQuery !== "" ? facetQuery : ""}`;
 };
 
 export function facetFilterSetup() {
@@ -16,72 +18,15 @@ export function facetFilterSetup() {
     facetCheckboxes.forEach((checkbox) => {
         checkbox.checked = experimentFacets.includes(checkbox.id); // reset the checkboxes after a page reload.
         checkbox.addEventListener("change", (_event) => {
-            if (controller !== undefined) {
-                controller.abort();
-            }
-
-            let facetQuery = Array.from(facetCheckboxes) // Convert checkboxes to an array to use filter and map.
-                .filter((i) => i.checked) // Use Array.filter to remove unchecked checkboxes.
-                .map((i) => `facet=${i.id}`)
-                .join("&");
-
-            window.history.pushState({}, document.title, experimentListURL(facetQuery));
-
-            controller = new AbortController();
-
-            getJson(`/search/experiment?${facetQuery}&accept=application/json`, controller.signal)
-                .then((response_json) => {
-                    let experimentListNode = g("experiment-list");
-                    let experimentNodes = response_json["experiments"].map((expr) => {
-                        return e(
-                            "a",
-                            {
-                                href: `/search/experiment/${expr.accession_id}`,
-                                class: "exp-list-content-container-link experiment-summary",
-                                "data-accession": expr.accession_id,
-                                "data-name": expr.name,
-                            },
-                            e(
-                                "div",
-                                {
-                                    class: "container",
-                                },
-                                [
-                                    e("div", {class: "flex justify-between"}, [
-                                        e("div", {class: "exp-name"}, expr.name),
-                                        e(
-                                            "div",
-                                            {
-                                                class: "select-experiment font-bold text-2xl",
-                                                title: "Select Experiment",
-                                                "data-accession": expr.accession_id,
-                                                "data-name": expr.name,
-                                            },
-                                            "＋",
-                                        ),
-                                    ]),
-                                    e("div", expr.description),
-                                    e("div", {class: "flex justify-between"}, [
-                                        e(
-                                            "div",
-                                            {class: "cell-lines"},
-                                            `Cell Lines: ${expr.biosamples.map((b) => b.cell_line).join(", ")}`,
-                                        ),
-                                        e("div", {class: "accession-id"}, expr.accession_id),
-                                    ]),
-                                ],
-                            ),
-                        );
-                    });
-                    rc(experimentListNode, experimentNodes);
-
+            let url = experimentListURL(facetCheckboxes);
+            window.history.pushState({}, document.title, url);
+            htmx.ajax("GET", `/search/${url}`, "#experiment-list")
+                .then(() => {
                     addDragListeners();
                     addSelectListeners();
                 })
                 .catch((err) => {
-                    if (err.name != "AbortError") {
-                        console.error(err.message);
-                    }
+                    console.error(err.message);
                 });
         });
     });

--- a/cegs_portal/search/templates/search/v1/experiment_collection.html
+++ b/cegs_portal/search/templates/search/v1/experiment_collection.html
@@ -25,21 +25,8 @@
         </div>
     </div>
 
-    <div class="max-w-screen-lg">
-      {% for experiment in experiments.all %}
-          <a href="{% url 'search:experiment' experiment.accession_id %}" class="exp-list-content-container-link experiment-summary">
-              <div class="container items-center">
-                  <div class="flex justify-between">
-                      <div class="exp-name">{{ experiment.name }}</div>
-                  </div>
-                  <div>{{ experiment.description }}</div>
-                  <div class="flex justify-between">
-                      <div class="cell-lines">Cell Lines: {{ experiment.cell_lines }}</div>
-                      <div class="accession-id">{{ experiment.accession_id }}</div>
-                  </div>
-              </div>
-          </a>
-      {% endfor %}
+    <div class="max-w-screen-lg" id="experiment-list">
+      {% include 'search/v1/partials/_experiment_list.html' with experiments=experiments %}
     </div >
 </div>
 

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -272,21 +272,7 @@
           </div>
         </div>
         <div class="md:order-2 lg:w-3/4 lg:mx-auto" id="experiment-list">
-            {% for experiment in experiments %}
-            <a href="{% url 'search:experiment' experiment.accession_id %}" class="exp-list-content-container-link experiment-summary" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">
-                <div class="content-container items-center">
-                    <div class="flex justify-between">
-                        <div class="exp-name">{{ experiment.name }}</div>
-                        <div class="select-experiment font-bold text-2xl" title="Select Experiment" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">＋</div>
-                    </div>
-                    <div>{{ experiment.description }}</div>
-                    <div class="flex justify-between">
-                        <div class="cell-lines">Cell Lines: {{ experiment.cell_lines }}</div>
-                        <div class="accession-id">{{ experiment.accession_id }}</div>
-                    </div>
-                </div>
-            </a>
-            {% endfor %}
+            {% include 'search/v1/partials/_experiment_list.html' with experiments=experiments %}
         </div>
     </div>
 </div>

--- a/cegs_portal/search/templates/search/v1/partials/_experiment_index.html
+++ b/cegs_portal/search/templates/search/v1/partials/_experiment_index.html
@@ -4,106 +4,93 @@
 <div class="exp-modal-underlay" onclick="closeModal()"></div>
 <div class="content-container exp-modal-content pb-6">
     <div class="close-button" onclick="closeModal()">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
-        <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"/>
-    </svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
+          <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"/>
+      </svg>
     </div>
     <div class="scroll-area">
-    <div class="flex flex-col md:flex-row md:space-x-10 items-start mx-auto">
-        <div class="md:order-1 md:w-1/4 w-full mx-auto">
-            <div class="dropdown-container">
-                <fieldset class="my-4" name="experimentFilters">
-                    <legend class="flex flex-row group font-bold min-w-full" id="experimentFiltersHeader"
-                        data-te-collapse-init
-                        data-te-target="#experimentFiltersCollapse"
-                        aria-expanded="true"
-                        aria-controls="experimentFiltersCollapse">
-                        <div class="flex justify-center items-center">
-                            <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Experiments</div>
-                        </div>
-                        <div
-                            class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke-width="1.5"
-                                stroke="currentColor"
-                                class="h-6 w-6 rotate-180">
-                                <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                            </svg>
-                        </div>
-                    </legend>
-                    <div class="flex flex-row flex-wrap gap-1"
-                        id="experimentFiltersCollapse"
-                        data-te-collapse-item
-                        data-te-collapse-show
-                        aria-labelledby="experimentFiltersHeader">
-                        <div id="categorical-facets" class="w-full">
-                            {% for facet, values in facets.items %}
-                                <fieldset class="my-4" name="facetfield">
-                                    <legend class="flex flex-row group font-bold min-w-full" id="facetHeader{{ forloop.counter }}"
-                                        data-te-collapse-init
-                                        data-te-target="#facetCollapse{{ forloop.counter }}"
-                                        aria-expanded="false"
-                                        aria-controls="facetCollapse{{ forloop.counter }}"
-                                        data-te-collapse-collapsed>
-                                        <div>{{ facet }}</div>
-                                        <div
-                                            class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                stroke-width="1.5"
-                                                stroke="currentColor"
-                                                class="h-6 w-6 rotate-180">
-                                                <path
-                                                    stroke-linecap="round"
-                                                    stroke-linejoin="round"
-                                                    d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                                            </svg>
-                                        </div>
-                                    </legend>
-                                    <div class="flex flex-row flex-wrap gap-1 hidden"
-                                        id="facetCollapse{{ forloop.counter }}"
-                                        data-te-collapse-item
-                                        aria-labelledby="facetHeader{{ forloop.counter }}">
-                                        {% for value in values %}
-                                        <div class="ml-1">
-                                            <input id="{{ value.id }}" type="checkbox" name="{{ facet }}"/>
-                                            <label for="{{ value.id }}">{{ value.value }}</label>
-                                        </div>
-                                        {% endfor %}
-                                    </div>
-                                </fieldset>
-                            {% endfor %}
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-        </div>
+      <div class="flex flex-col md:flex-row md:space-x-10 items-start mx-auto">
+          <div class="md:order-1 md:w-1/4 w-full mx-auto">
+              <div class="dropdown-container">
+                  <fieldset class="my-4" name="experimentFilters">
+                      <legend class="flex flex-row group font-bold min-w-full" id="experimentFiltersHeader"
+                          data-te-collapse-init
+                          data-te-target="#experimentFiltersCollapse"
+                          aria-expanded="true"
+                          aria-controls="experimentFiltersCollapse">
+                          <div class="flex justify-center items-center">
+                              <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Experiments</div>
+                          </div>
+                          <div
+                              class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
+                              <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke-width="1.5"
+                                  stroke="currentColor"
+                                  class="h-6 w-6 rotate-180">
+                                  <path
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                              </svg>
+                          </div>
+                      </legend>
+                      <div class="flex flex-row flex-wrap gap-1"
+                          id="experimentFiltersCollapse"
+                          data-te-collapse-item
+                          data-te-collapse-show
+                          aria-labelledby="experimentFiltersHeader">
+                          <div id="categorical-facets" class="w-full">
+                              {% for facet, values in facets.items %}
+                                  <fieldset class="my-4" name="facetfield">
+                                      <legend class="flex flex-row group font-bold min-w-full" id="facetHeader{{ forloop.counter }}"
+                                          data-te-collapse-init
+                                          data-te-target="#facetCollapse{{ forloop.counter }}"
+                                          aria-expanded="false"
+                                          aria-controls="facetCollapse{{ forloop.counter }}"
+                                          data-te-collapse-collapsed>
+                                          <div>{{ facet }}</div>
+                                          <div
+                                              class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
+                                              <svg
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  fill="none"
+                                                  viewBox="0 0 24 24"
+                                                  stroke-width="1.5"
+                                                  stroke="currentColor"
+                                                  class="h-6 w-6 rotate-180">
+                                                  <path
+                                                      stroke-linecap="round"
+                                                      stroke-linejoin="round"
+                                                      d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                              </svg>
+                                          </div>
+                                      </legend>
+                                      <div class="flex flex-row flex-wrap gap-1 hidden"
+                                          id="facetCollapse{{ forloop.counter }}"
+                                          data-te-collapse-item
+                                          aria-labelledby="facetHeader{{ forloop.counter }}">
+                                          {% for value in values %}
+                                          <div class="ml-1">
+                                              <input id="{{ value.id }}" type="checkbox" name="{{ facet }}"/>
+                                              <label for="{{ value.id }}">{{ value.value }}</label>
+                                          </div>
+                                          {% endfor %}
+                                      </div>
+                                  </fieldset>
+                              {% endfor %}
+                          </div>
+                      </div>
+                  </fieldset>
+              </div>
+          </div>
 
-        <div class="md:order-2 md:w-3/4 mx-auto" id="experiment-list">
-            {% for experiment in experiments %}
-            <a href="{% url 'search:experiment' experiment.accession_id %}" class="exp-list-content-container-link experiment-summary" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">
-                <div class="content-container items-center">
-                    <div class="flex justify-between">
-                        <div class="exp-name">{{ experiment.name }}</div>
-                    </div>
-                    <div>{{ experiment.description }}</div>
-                    <div class="flex justify-between">
-                        <div class="cell-lines">Cell Lines: {{ experiment.cell_lines }}</div>
-                        <div class="accession-id">{{ experiment.accession_id }}</div>
-                    </div>
-                </div>
-            </a>
-            {% endfor %}
-        </div>
-        </div>
+          <div class="md:order-2 md:w-3/4 mx-auto" id="experiment-list">
+              {% include 'search/v1/partials/_experiment_list.html' with experiments=experiments %}
+          </div>
+      </div>
     </div>
 </div>
 </div>

--- a/cegs_portal/search/templates/search/v1/partials/_experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/partials/_experiment_list.html
@@ -1,0 +1,20 @@
+{% for experiment in experiments %}
+<a href="{% url 'search:experiment' experiment.accession_id %}" class="exp-list-content-container-link experiment-summary" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">
+    <div class="content-container items-center">
+        <div class="flex justify-between">
+            <div class="exp-name">{{ experiment.name }}</div>
+            <div class="select-experiment font-bold text-2xl" title="Select Experiment" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">＋</div>
+        </div>
+        <div>{{ experiment.description }}</div>
+        <div class="flex justify-between">
+            <div class="flex gap-x-4">
+              <div class="cell-lines">Cell Lines: {{ experiment.cell_lines }}</div>
+              {% if experiment.default_analysis %}
+              <div class="cell-lines">Assembly: {{ experiment.default_analysis.genome_assembly }}</div>
+              {% endif %}
+            </div>
+            <div class="accession-id">{{ experiment.accession_id }}</div>
+        </div>
+    </div>
+</a>
+{% endfor %}

--- a/cegs_portal/search/templates/search/v1/partials/_multi_experiment_index.html
+++ b/cegs_portal/search/templates/search/v1/partials/_multi_experiment_index.html
@@ -1,244 +1,230 @@
 {% load static i18n %}
 
 <div id="multi-exp-modal">
-<div class="multi-exp-modal-underlay" onclick="closeModal()"></div>
-<div class="content-container multi-exp-modal-content pb-6">
+  <div class="multi-exp-modal-underlay" onclick="closeModal()"></div>
+  <div class="content-container multi-exp-modal-content pb-6">
     <div class="close-button" onclick="closeModal()">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
-        <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"/>
-    </svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-x-lg" viewBox="0 0 16 16">
+          <path d="M2.146 2.854a.5.5 0 1 1 .708-.708L8 7.293l5.146-5.147a.5.5 0 0 1 .708.708L8.707 8l5.147 5.146a.5.5 0 0 1-.708.708L8 8.707l-5.146 5.147a.5.5 0 0 1-.708-.708L7.293 8 2.146 2.854Z"/>
+      </svg>
     </div>
     <div class="scroll-area">
       <div class="flex flex-col md:flex-row md:space-x-10 items-start mx-auto">
         <div class="md:order-1 md:w-1/4 w-full mx-auto">
-        <div class="dropdown-container">
-            <fieldset class="my-4" name="experimentFilters">
-                <legend class="flex flex-row group font-bold min-w-full" id="experimentFiltersHeader"
-                    data-te-collapse-init
-                    data-te-target="#experimentFiltersCollapse"
-                    aria-expanded="true"
-                    aria-controls="experimentFiltersCollapse">
-                    <div class="flex justify-center items-center">
-                        <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Experiments</div>
-                    </div>
-                    <div
-                        class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke-width="1.5"
-                            stroke="currentColor"
-                            class="h-6 w-6 rotate-180">
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                        </svg>
-                    </div>
-                </legend>
-                <div class="flex flex-row flex-wrap gap-1"
-                    id="experimentFiltersCollapse"
-                    data-te-collapse-item
-                    data-te-collapse-show
-                    aria-labelledby="experimentFiltersHeader">
-                    <div id="categorical-facets" class="w-full">
-                        {% for facet, values in facets.items %}
-                            <fieldset class="my-4" name="facetfield">
-                                <legend class="flex flex-row group font-bold min-w-full" id="facetHeader{{ forloop.counter }}"
-                                    data-te-collapse-init
-                                    data-te-target="#facetCollapse{{ forloop.counter }}"
-                                    aria-expanded="false"
-                                    aria-controls="facetCollapse{{ forloop.counter }}"
-                                    data-te-collapse-collapsed>
-                                    <div>{{ facet }}</div>
-                                    <div
-                                        class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke-width="1.5"
-                                            stroke="currentColor"
-                                            class="h-6 w-6 rotate-180">
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                                        </svg>
-                                    </div>
-                                </legend>
-                                <div class="flex flex-row flex-wrap gap-1 hidden"
-                                    id="facetCollapse{{ forloop.counter }}"
-                                    data-te-collapse-item
-                                    aria-labelledby="facetHeader{{ forloop.counter }}">
-                                    {% for value in values %}
-                                    <div class="ml-1">
-                                        <input id="{{ value.id }}" type="checkbox" name="{{ facet }}"/>
-                                        <label for="{{ value.id }}">{{ value.value }}</label>
-                                    </div>
-                                    {% endfor %}
-                                </div>
-                            </fieldset>
-                        {% endfor %}
-                    </div>
-                </div>
-            </fieldset>
-        </div>
-
-        <div class="dropdown-container">
-            <fieldset class="my-4" name="combinedExperiments">
-                <legend class="flex flex-row group font-bold min-w-full" id="combinedExperimentsHeader"
-                    data-te-collapse-init
-                    data-te-target="#combinedExperimentsCollapse"
-                    aria-controls="combinedExperimentsCollapse"
-                    aria-expanded="true">
-                    <div class="flex justify-center items-center">
-                        <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-layers-half"></i> Combine Experiments</div>
-                    </div>
-                    <span
-                        class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke-width="1.5"
-                            stroke="currentColor"
-                            class="rotate-180">
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                        </svg>
-                    </span>
-                </legend>
-                <div class="flex flex-row flex-wrap gap-1"
-                    id="combinedExperimentsCollapse"
-                    data-te-collapse-item
-                    aria-labelledby="combinedExperimentsHeader"
-                    aria-expanded="true"
-                    data-te-collapse-show>
-                    <div class="w-full">
-                        <div>
-                            <h2 class="mb-0" id="selectExperiments">
-                                <button
-                                    class="bg-white remove-lr-margin group relative flex w-full items-center py-4 text-left text-base text-neutral-800 transition [overflow-anchor:none] hover:z-[2] focus:z-[3] focus:outline-none"
-                                    type="button"
-                                    data-te-collapse-init
-                                    data-te-collapse-show
-                                    data-te-target="#selectExperimentsCollapse"
-                                    aria-controls="selectExperimentsCollapse"
-                                    aria-expanded="true"
-                                    >
-                                    <span class="font-bold text-2xl text-slate-500">
-                                        ＋ <div class="text-xl font-bold text-slate-500 inline">Select Experiments</div>
-                                    </span>
-                                    <span
-                                        class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke-width="1.5"
-                                            stroke="currentColor"
-                                            class="rotate-180">
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                                        </svg>
-                                    </span>
-                                </button>
-                            </h2>
-                            <div
-                                id="selectExperimentsCollapse"
-                                class=""
-                                data-te-collapse-item
-                                data-te-collapse-show
-                                aria-labelledby="selectExperiments"
-                                aria-expanded="true">
-                                <div class="w-full h-1/2 border border-gray-300 p-5" id="selected-experiments">
-                                    <div class="italic flex justify-center" id="no-selected-experiments">Drag experiments here to select</div>
-                                    <div id="selected-experiment-list"></div>
-                                </div>
-                                <div class="flex justify-center mt-2">
-                                    <button class="global-button rounded-none border-2 border-gray-300 h-6 text-xs" id="select-all-button">Select all experiments</button>
-                                    <button class="global-button rounded-none border-2 border-gray-300 h-6 text-xs" id="remove-all-button">Clear all</button>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="bg-white">
-                            <h2 class="mb-0" id="analyzeExperiments">
-                                <button
-                                    class="remove-lr-margin group relative flex w-full items-center border-0 bg-white py-4 text-left text-base text-neutral-800 transition [overflow-anchor:none] hover:z-[2] focus:z-[3] focus:outline-none"
-                                    type="button"
-                                    data-te-collapse-init
-                                    data-te-collapse-show
-                                    data-te-target="#analyzeExperimentsCollapse"
-                                    aria-controls="analyzeExperimentsCollapse"
-                                    aria-expanded="true">
-                                    <div class="text-xl font-bold text-slate-500">
-                                        <i class="bi bi-pie-chart-fill mr-1"></i> Analyze Multiple Experiments
-                                    </div>
-                                    <span
-                                        class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke-width="1.5"
-                                            stroke="currentColor"
-                                            class="rotate-180">
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                                        </svg>
-                                    </span>
-                                </button>
-                            </h2>
-                            <div
-                                id="analyzeExperimentsCollapse"
-                                class=""
-                                data-te-collapse-item
-                                data-te-collapse-show
-                                aria-labelledby="analyzeExperiments"
-                                aria-expanded="true">
-                                <div class="w-full h-1/2 border border-gray-300 p-5" id="view-experiments">
-                                    <div class="italic flex justify-center text-center" id="experiments-link">Please select at least one experiment.</div>
-                                    <div class="italic mt-2">
-                                        Note: Selected experiments must be within the same genome assembly for analysis
-                                        {% include 'search/v1/partials/_help_tooltip.html' with help_text="Filter by genome assembly and select the desired experiments." %}
+          <div class="dropdown-container">
+              <fieldset class="my-4" name="experimentFilters">
+                  <legend class="flex flex-row group font-bold min-w-full" id="experimentFiltersHeader"
+                      data-te-collapse-init
+                      data-te-target="#experimentFiltersCollapse"
+                      aria-expanded="true"
+                      aria-controls="experimentFiltersCollapse">
+                      <div class="flex justify-center items-center">
+                          <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-funnel-fill"></i> Filter Experiments</div>
+                      </div>
+                      <div
+                          class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
+                          <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke-width="1.5"
+                              stroke="currentColor"
+                              class="h-6 w-6 rotate-180">
+                              <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                          </svg>
+                      </div>
+                  </legend>
+                  <div class="flex flex-row flex-wrap gap-1"
+                      id="experimentFiltersCollapse"
+                      data-te-collapse-item
+                      data-te-collapse-show
+                      aria-labelledby="experimentFiltersHeader">
+                      <div id="categorical-facets" class="w-full">
+                          {% for facet, values in facets.items %}
+                              <fieldset class="my-4" name="facetfield">
+                                  <legend class="flex flex-row group font-bold min-w-full" id="facetHeader{{ forloop.counter }}"
+                                      data-te-collapse-init
+                                      data-te-target="#facetCollapse{{ forloop.counter }}"
+                                      aria-expanded="false"
+                                      aria-controls="facetCollapse{{ forloop.counter }}"
+                                      data-te-collapse-collapsed>
+                                      <div>{{ facet }}</div>
+                                      <div
+                                          class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none dark:fill-blue-300 dark:group-[[data-te-collapse-collapsed]]:fill-white inline-block">
+                                          <svg
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              fill="none"
+                                              viewBox="0 0 24 24"
+                                              stroke-width="1.5"
+                                              stroke="currentColor"
+                                              class="h-6 w-6 rotate-180">
+                                              <path
+                                                  stroke-linecap="round"
+                                                  stroke-linejoin="round"
+                                                  d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                          </svg>
                                       </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </fieldset>
+                                  </legend>
+                                  <div class="flex flex-row flex-wrap gap-1 hidden"
+                                      id="facetCollapse{{ forloop.counter }}"
+                                      data-te-collapse-item
+                                      aria-labelledby="facetHeader{{ forloop.counter }}">
+                                      {% for value in values %}
+                                      <div class="ml-1">
+                                          <input id="{{ value.id }}" type="checkbox" name="{{ facet }}"/>
+                                          <label for="{{ value.id }}">{{ value.value }}</label>
+                                      </div>
+                                      {% endfor %}
+                                  </div>
+                              </fieldset>
+                          {% endfor %}
+                      </div>
+                  </div>
+              </fieldset>
+          </div>
+
+          <div class="dropdown-container">
+              <fieldset class="my-4" name="combinedExperiments">
+                  <legend class="flex flex-row group font-bold min-w-full" id="combinedExperimentsHeader"
+                      data-te-collapse-init
+                      data-te-target="#combinedExperimentsCollapse"
+                      aria-controls="combinedExperimentsCollapse"
+                      aria-expanded="true">
+                      <div class="flex justify-center items-center">
+                          <div class="text-xl font-bold text-slate-500 text-center"><i class="bi bi-layers-half"></i> Combine Experiments</div>
+                      </div>
+                      <span
+                          class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
+                          <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke-width="1.5"
+                              stroke="currentColor"
+                              class="rotate-180">
+                              <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                          </svg>
+                      </span>
+                  </legend>
+                  <div class="flex flex-row flex-wrap gap-1"
+                      id="combinedExperimentsCollapse"
+                      data-te-collapse-item
+                      aria-labelledby="combinedExperimentsHeader"
+                      aria-expanded="true"
+                      data-te-collapse-show>
+                      <div class="w-full">
+                          <div>
+                              <h2 class="mb-0" id="selectExperiments">
+                                  <button
+                                      class="bg-white remove-lr-margin group relative flex w-full items-center py-4 text-left text-base text-neutral-800 transition [overflow-anchor:none] hover:z-[2] focus:z-[3] focus:outline-none"
+                                      type="button"
+                                      data-te-collapse-init
+                                      data-te-collapse-show
+                                      data-te-target="#selectExperimentsCollapse"
+                                      aria-controls="selectExperimentsCollapse"
+                                      aria-expanded="true"
+                                      >
+                                      <span class="font-bold text-2xl text-slate-500">
+                                          ＋ <div class="text-xl font-bold text-slate-500 inline">Select Experiments</div>
+                                      </span>
+                                      <span
+                                          class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
+                                          <svg
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              fill="none"
+                                              viewBox="0 0 24 24"
+                                              stroke-width="1.5"
+                                              stroke="currentColor"
+                                              class="rotate-180">
+                                              <path
+                                                  stroke-linecap="round"
+                                                  stroke-linejoin="round"
+                                                  d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                          </svg>
+                                      </span>
+                                  </button>
+                              </h2>
+                              <div
+                                  id="selectExperimentsCollapse"
+                                  class=""
+                                  data-te-collapse-item
+                                  data-te-collapse-show
+                                  aria-labelledby="selectExperiments"
+                                  aria-expanded="true">
+                                  <div class="w-full h-1/2 border border-gray-300 p-5" id="selected-experiments">
+                                      <div class="italic flex justify-center" id="no-selected-experiments">Drag experiments here to select</div>
+                                      <div id="selected-experiment-list"></div>
+                                  </div>
+                                  <div class="flex justify-center mt-2">
+                                      <button class="global-button rounded-none border-2 border-gray-300 h-6 text-xs" id="select-all-button">Select all experiments</button>
+                                      <button class="global-button rounded-none border-2 border-gray-300 h-6 text-xs" id="remove-all-button">Clear all</button>
+                                  </div>
+                              </div>
+                          </div>
+                          <div class="bg-white">
+                              <h2 class="mb-0" id="analyzeExperiments">
+                                  <button
+                                      class="remove-lr-margin group relative flex w-full items-center border-0 bg-white py-4 text-left text-base text-neutral-800 transition [overflow-anchor:none] hover:z-[2] focus:z-[3] focus:outline-none"
+                                      type="button"
+                                      data-te-collapse-init
+                                      data-te-collapse-show
+                                      data-te-target="#analyzeExperimentsCollapse"
+                                      aria-controls="analyzeExperimentsCollapse"
+                                      aria-expanded="true">
+                                      <div class="text-xl font-bold text-slate-500">
+                                          <i class="bi bi-pie-chart-fill mr-1"></i> Analyze Multiple Experiments
+                                      </div>
+                                      <span
+                                          class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
+                                          <svg
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              fill="none"
+                                              viewBox="0 0 24 24"
+                                              stroke-width="1.5"
+                                              stroke="currentColor"
+                                              class="rotate-180">
+                                              <path
+                                                  stroke-linecap="round"
+                                                  stroke-linejoin="round"
+                                                  d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                          </svg>
+                                      </span>
+                                  </button>
+                              </h2>
+                              <div
+                                  id="analyzeExperimentsCollapse"
+                                  class=""
+                                  data-te-collapse-item
+                                  data-te-collapse-show
+                                  aria-labelledby="analyzeExperiments"
+                                  aria-expanded="true">
+                                  <div class="w-full h-1/2 border border-gray-300 p-5" id="view-experiments">
+                                      <div class="italic flex justify-center text-center" id="experiments-link">Please select at least one experiment.</div>
+                                      <div class="italic mt-2">
+                                          Note: Selected experiments must be within the same genome assembly for analysis
+                                          {% include 'search/v1/partials/_help_tooltip.html' with help_text="Filter by genome assembly and select the desired experiments." %}
+                                        </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </fieldset>
+          </div>
         </div>
-      </div>
 
         <div class="md:order-2 md:w-3/4 mx-auto" id="experiment-list">
-            {% for experiment in experiments %}
-            <a href="{% url 'search:experiment' experiment.accession_id %}" class="exp-list-content-container-link experiment-summary" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">
-                <div class="content-container items-center">
-                    <div class="flex justify-between">
-                        <div class="exp-name">{{ experiment.name }}</div>
-                        <div class="select-experiment font-bold text-2xl" title="Select Experiment" data-accession="{{ experiment.accession_id }}" data-name="{{ experiment.name }}">＋</div>
-                    </div>
-                    <div>{{ experiment.description }}</div>
-                    <div class="flex justify-between">
-                        <div class="cell-lines">Cell Lines: {{ experiment.cell_lines }}</div>
-                        <div class="accession-id">{{ experiment.accession_id }}</div>
-                    </div>
-                </div>
-            </a>
-            {% endfor %}
+            {% include 'search/v1/partials/_experiment_list.html' with experiments=experiments %}
         </div>
+      </div>
     </div>
-    </div>
-</div>
+  </div>
 </div>
 
 {% block inline_javascript %}

--- a/cegs_portal/search/view_models/v1/experiment.py
+++ b/cegs_portal/search/view_models/v1/experiment.py
@@ -65,6 +65,7 @@ class ExperimentSearch:
                 cell_lines=StringAgg("biosamples__cell_line_name", ", ", default=Value("")),
             )
             .order_by("accession_id")
+            .select_related("default_analysis")
             .prefetch_related("biosamples")
         )
 

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -179,6 +179,7 @@ class ExperimentsView(UserPassesTestMixin, MultiResponseFormatView):
 class ExperimentListView(MultiResponseFormatView):
     json_renderer = experiments
     template = "search/v1/experiment_list.html"
+    table_partial = "search/v1/partials/_experiment_list.html"
 
     def request_options(self, request):
         """
@@ -197,6 +198,15 @@ class ExperimentListView(MultiResponseFormatView):
 
     def get(self, request, options, data):
         experiment_objects, facet_values = data
+
+        if request.headers.get("HX-Request"):
+            return render(
+                request,
+                self.table_partial,
+                {
+                    "experiments": experiment_objects,
+                },
+            )
 
         facets = {}
         for value in facet_values.all():

--- a/cegs_portal/search/views/v1/experiment.py
+++ b/cegs_portal/search/views/v1/experiment.py
@@ -199,15 +199,6 @@ class ExperimentListView(MultiResponseFormatView):
     def get(self, request, options, data):
         experiment_objects, facet_values = data
 
-        if request.headers.get("HX-Request"):
-            return render(
-                request,
-                self.table_partial,
-                {
-                    "experiments": experiment_objects,
-                },
-            )
-
         facets = {}
         for value in facet_values.all():
             if value.facet.name in facets:
@@ -240,6 +231,15 @@ class ExperimentListView(MultiResponseFormatView):
                     "experiments": experiment_objects,
                     "experiment_ids": [expr.accession_id for expr in experiment_objects],
                     "facets": sorted_facets,
+                },
+            )
+
+        if request.headers.get("HX-Target") == "experiment-list":
+            return render(
+                request,
+                self.table_partial,
+                {
+                    "experiments": experiment_objects,
                 },
             )
 


### PR DESCRIPTION
This adds the experiment assembly to the experiment box used when listing experiments.

It also takes the opportunity to do some refactoring and use htmx+template for the experiment list rather than a bunch of awkward javascript.

Finally, it fixes an issue with the URL changing when facets are selected from experiment list modal views.

NOTE: It might be helpful to hide whitespace changes when reviewing this. 

![Screenshot 2024-12-09 at 12 10 45 PM](https://github.com/user-attachments/assets/c8ed83f9-97a7-4bd3-a896-215098803900)
![Screenshot 2024-12-09 at 12 10 27 PM](https://github.com/user-attachments/assets/a818bbd6-d37d-427a-a962-100bfe80649e)
![Screenshot 2024-12-09 at 12 11 04 PM](https://github.com/user-attachments/assets/d450b1e8-e79b-4842-8741-49851b260884)
