### PR TITLE
Show logged-in-only actions with message

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -327,8 +327,14 @@
                     <div id="regionUploadInputReset"></div>
                 </div>
 
-                {% if logged_in %}
+
                 <div class="facet-content-section content-container hidden md:block">
+                  <div id="logged-in-only-container">
+                    {% if not logged_in %}
+                    <div id="logged-in-only-overlay" class="grid grid-cols-1 place-content-center">
+                        <h3 class="flex items-center justify-center">Please Login to Download Data</h3>
+                    </div>
+                    {% endif %}
                     <form name="dataDownloadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="dataDlAll">Download All Selected Data*</label>
@@ -345,8 +351,8 @@
                     <div class="flex justify-center">
                     * Data downloads take facet filtering, except for "Number of {{ experiment.get_source_type_display }}s" and "Number of Genes Assayed", into account.
                     </div>
+                  </div>
                 </div>
-                {% endif %}
             </div>
 
             <div class="content-container basis-3/4">

--- a/cegs_portal/search/templates/search/v1/experiment_list.html
+++ b/cegs_portal/search/templates/search/v1/experiment_list.html
@@ -216,7 +216,7 @@
                         </div>
                       </div>
                     </div>
-                    {% if logged_in %}
+
                     <div
                       class="bg-white hidden md:block">
                       <h2 class="accordion-header mb-0" id="downloadData">
@@ -229,7 +229,7 @@
                           aria-expanded="false"
                           aria-controls="collapseThree">
                           <div class="text-xl font-bold text-slate-500">
-                            <i class="bi bi-download mr-1"></i> Download Data from Selected Experiments
+                            <i class="bi bi-download mr-1"></i> {% if logged_in %}Download Data from Selected Experiments{% else %}Please Login to Download Data from Selected Experiments{% endif %}
                           </div>
                           <span
                             class="ml-auto h-6 w-6 shrink-0 fill-[#336dec] transition-transform duration-200 ease-in-out group-[[data-te-collapse-collapsed]]:mr-0 group-[[data-te-collapse-collapsed]]:rotate-180 group-[[data-te-collapse-collapsed]]:fill-[#212529] motion-reduce:transition-none">
@@ -248,24 +248,29 @@
                           </span>
                         </button>
                       </h2>
-                      <div
-                        id="collapseThree"
-                        class="!visible hidden"
-                        data-te-collapse-item
-                        aria-labelledby="downloadData">
-                        <div class="px-5 py-4">
-                          <form name="dataDownloadForm">
-                            <div>
-                                <label class="font-bold flex justify-center" for="dataDlFile">Select a .bed File with Regions of Interest</label>
-                                <input class="hidden" id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
-                                <label for="dataDownloadInput" class="flex justify-center global-button mt-3 border-2 p-2 text-sm">Upload file</label>
-                            </div>
-                          </form>
-                          <div id="dataDownloadLink" class="italic mt-5 mb-5 flex justify-center">Please select at least one experiment.</div>
+                      <div id="logged-in-only-container">
+                        {% if not logged_in %}
+                        <div id="logged-in-only-overlay"></div>
+                        {% endif %}
+                        <div
+                          id="collapseThree"
+                          class="!visible hidden"
+                          data-te-collapse-item
+                          aria-labelledby="downloadData">
+                          <div class="px-5 py-4">
+                            <form name="dataDownloadForm">
+                              <div>
+                                  <label class="font-bold flex justify-center" for="dataDlFile">Select a .bed File with Regions of Interest</label>
+                                  <input class="hidden" id="dataDownloadInput" type="file" accept=".bed" name="dataDlFile" />
+                                  <label for="dataDownloadInput" class="flex justify-center global-button mt-3 border-2 p-2 text-sm">Upload file</label>
+                              </div>
+                            </form>
+                            <div id="dataDownloadLink" class="italic mt-5 mb-5 flex justify-center">Please select at least one experiment.</div>
+                          </div>
                         </div>
                       </div>
                     </div>
-                    {% endif %}
+
                   </div>
                   </div>
               </fieldset>

--- a/cegs_portal/search/templates/search/v1/experiments.html
+++ b/cegs_portal/search/templates/search/v1/experiments.html
@@ -231,8 +231,13 @@
                     <div id="regionUploadInputReset"></div>
                 </div>
 
-                {% if logged_in %}
                 <div class="facet-content-section content-container mx-auto hidden md:block">
+                  <div id="logged-in-only-container">
+                    {% if not logged_in %}
+                    <div id="logged-in-only-overlay" class="grid grid-cols-1 place-content-center">
+                        <h3 class="flex items-center justify-center">Please Login to Download Data</h3>
+                    </div>
+                    {% endif %}
                     <form name="dataDownloadForm">
                         <div>
                             <label class="font-bold flex justify-center" for="dataDlAll">Download All Selected Data*</label>
@@ -249,8 +254,8 @@
                     <div>
                     * Data downloads take facet filtering, except for "Number of Tested Elements" and "Number of Genes Assayed", into account.
                     </div>
+                  </div>
                 </div>
-                {% endif %}
             </div>
 
             <div class="basis-3/4 content-container">

--- a/cegs_portal/search/templates/search/v1/search_results.html
+++ b/cegs_portal/search/templates/search/v1/search_results.html
@@ -323,8 +323,13 @@
                         </fieldset>
                     </div>
 
-                    {% if logged_in %}
                     <div class="content-container hidden md:block">
+                      <div id="logged-in-only-container">
+                        {% if not logged_in %}
+                        <div id="logged-in-only-overlay" class="grid grid-cols-1 place-content-center">
+                            <h3 class="flex items-center justify-center">Please Login to Download Data</h3>
+                        </div>
+                        {% endif %}
                         <form name="dataDownloadForm">
                             <div>
                                 <label class="font-bold flex justify-center" for="dataDlAll">Download Region Data*</label>
@@ -334,8 +339,8 @@
                         </form>
                         <div id="dataDownloadLink" class="mt-5 mb-5"></div>
                         <div class="text-sm flex justify-center">Includes all observations, filtered by selected facets</div>
+                      </div>
                     </div>
-                    {% endif %}
                 </div>
 
                 <div class="flex flex-col gap-4 basis-3/4">

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1532,6 +1532,10 @@ input[type="submit"], input[type="button"], button {
       flex-wrap: nowrap;
 }
 
+.place-content-center {
+  place-content: center;
+}
+
 .items-start {
   -webkit-box-align: start;
       -ms-flex-align: start;
@@ -2183,6 +2187,18 @@ fieldset legend {
 
 .inline_url_field div {
   display: inline;
+}
+
+#logged-in-only-container {
+  contain: paint layout;
+}
+
+#logged-in-only-overlay {
+  z-index: 1000;
+  position: absolute;
+  background-color: rgba(255, 255, 255, 0.9);
+  width: 100%;
+  height: 100%;
 }
 
 /* The navbar styles are copied from bootstrap.css (getbootstrap.com) and then modified */

--- a/cegs_portal/static/css/project.css.tw
+++ b/cegs_portal/static/css/project.css.tw
@@ -58,6 +58,18 @@ fieldset legend {
   display: inline;
 }
 
+#logged-in-only-container {
+    contain: paint layout;
+}
+
+#logged-in-only-overlay {
+    z-index: 1000;
+    position: absolute;
+    background-color: rgba(255, 255, 255, 0.9);
+    width: 100%;
+    height: 100%;
+}
+
 @layer components {
   .bg-color {
     background-color: white;


### PR DESCRIPTION
Instead of hiding logged-in only actions completely we should show that they exist, but users need to login to use them. That way people know the functionality is there.

![Screenshot 2024-12-09 at 2 33 25 PM](https://github.com/user-attachments/assets/100dc9d8-03fa-4aaa-9d10-890c7c185ab1)
![Screenshot 2024-12-09 at 2 33 13 PM](https://github.com/user-attachments/assets/5cd56486-ead5-4664-a77f-db52760252a1)
![Screenshot 2024-12-09 at 2 33 02 PM](https://github.com/user-attachments/assets/301a35eb-d0cc-41e8-9909-98597650de1c)
![Screenshot 2024-12-09 at 2 32 39 PM](https://github.com/user-attachments/assets/7b9ced20-e772-4ed8-a130-4a848c894044)
