### PR TITLE
Improve admin changelist views

### DIFF
--- a/cegs_portal/search/admin.py
+++ b/cegs_portal/search/admin.py
@@ -166,9 +166,22 @@ class ExperimentAdmin(admin.ModelAdmin):
 
 admin.site.register(Experiment, ExperimentAdmin)
 
-admin.site.register(ExperimentCollection)
 
-admin.site.register(ExperimentRelation)
+class ExperimentCollectionAdmin(admin.ModelAdmin):
+    list_display = ("name", "description")
+
+
+admin.site.register(ExperimentCollection, ExperimentCollectionAdmin)
+
+
+class ExperimentRelationAdmin(admin.ModelAdmin):
+    list_display = ("from_experiment", "to_experiment")
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("this_experiment", "other_experiment")
+
+
+admin.site.register(ExperimentRelation, ExperimentRelationAdmin)
 
 admin.site.register(Facet)
 

--- a/cegs_portal/search/models/experiment.py
+++ b/cegs_portal/search/models/experiment.py
@@ -1,5 +1,6 @@
 from enum import Enum, StrEnum
 
+from django.contrib import admin
 from django.contrib.postgres.fields import DateRangeField
 from django.db import models
 
@@ -101,6 +102,14 @@ class ExperimentRelation(models.Model):
         Experiment, to_field="accession_id", related_name="other", on_delete=models.CASCADE
     )
     description = models.CharField(max_length=4096, null=True, blank=True)
+
+    @admin.display(description="From Experiment")
+    def from_experiment(self):
+        return f"{self.this_experiment.accession_id}: {self.this_experiment.name}"
+
+    @admin.display(description="To Experiment")
+    def to_experiment(self):
+        return f"{self.other_experiment.accession_id}: {self.other_experiment.name}"
 
 
 class ExperimentCollection(Accessioned, Faceted, AccessControlled):


### PR DESCRIPTION
Experiment Collection and Experiment Relation both had the default change list items, which aren't very descriptive. This improves them both while avoiding and n+1 query issue for Experiment Relations

Before:
<img width="1178" alt="Screenshot 2024-12-19 at 4 38 15 PM" src="https://github.com/user-attachments/assets/7558fb0f-924a-4605-8955-7767f46344e6" />
<img width="1178" alt="Screenshot 2024-12-19 at 4 38 07 PM" src="https://github.com/user-attachments/assets/9e07d507-1961-47b9-8604-6818565bfc6e" />


After:
<img width="1178" alt="Screenshot 2024-12-19 at 4 37 40 PM" src="https://github.com/user-attachments/assets/000c01f9-65b3-472a-9d44-81874a5a3c11" />
<img width="1178" alt="Screenshot 2024-12-19 at 4 37 50 PM" src="https://github.com/user-attachments/assets/d5154455-b69f-49de-a28b-e938d967ed34" />

