### PR TITLE
Add collection info to experiment UI

### DIFF
--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -462,8 +462,9 @@
           </div>
           {% endif %}
         </div>
-        {% if related_experiments.exists %}
-        <div class="content-container mx-auto min-w-full grid grid-cols-1 {% if experiment.attribution %}lg:grid-cols-2 {% endif %}gap-4">
+        {% if related_experiments.exists or experiment.collections.exists %}
+        <div class="content-container min-w-full grid grid-cols-1 {% if related_experiments.exists and experiment.collections.exists %}lg:grid-cols-2 {% endif %}gap-4">
+          {% if related_experiments.exists %}
           <div>
               <div class="bg-white border-b">
                   <div class="text-xl text-slate-500 font-bold mb-4 text-left">Related Experiments</div>
@@ -472,11 +473,27 @@
               <div class="{% cycle 'bg-gray-100' 'bg-white' %} border-b flex items-center">
                   <div class="text-sm px-6 py-4 font-medium w-1/4"><a class="link" href="{% url 'search:experiment' related.other_experiment_id %}">{{ related.name }}</a></div>
                   <div class="text-sm px-6 py-4 text-gray-500 font-light italic w-3/4">
-                      {{ related.description }}
+                      {{ related.description|default_if_none:"No Description" }}
                   </div>
               </div>
               {% endfor %}
           </div>
+          {% endif %}
+          {% if experiment.collections.exists %}
+          <div>
+              <div class="bg-white border-b">
+                  <div class="text-xl text-slate-500 font-bold mb-4 text-left">Collections</div>
+              </div>
+              {% for collection in experiment.collections.all %}
+              <div class="{% cycle 'bg-gray-100' 'bg-white' %} border-b flex items-center">
+                  <div class="text-sm px-6 py-4 font-medium w-1/4"><a class="link" href="{% url 'search:experiment_collection' collection.accession_id %}">{{ collection.name }}</a></div>
+                  <div class="text-sm px-6 py-4 text-gray-500 font-light italic w-3/4">
+                      {{ collection.description|default_if_none:"No Description" }}
+                  </div>
+              </div>
+              {% endfor %}
+          </div>
+          {% endif %}
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
Adds some UI to the experiment page that shows the collections an experiment is a part of.

<img width="1467" alt="Screenshot 2025-01-06 at 2 35 07 PM" src="https://github.com/user-attachments/assets/38d398fd-30ef-46b1-9eb3-2116ebc262f3" />
