### PR TITLE
Don't unconditionally set up closest feature types

### DIFF
--- a/cegs_portal/search/static/search/js/dna_feature/closest_feat_type.js
+++ b/cegs_portal/search/static/search/js/dna_feature/closest_feat_type.js
@@ -5,7 +5,12 @@ let closestFeaturesURL = function (feature_accession_id, facetQuery) {
 };
 
 export function closestFeatureTypeSetup(feature_accession_id) {
-    let typeCheckboxes = g("closest-types").querySelectorAll("input[type=checkbox]");
+    let typeCheckboxes = g("closest-types");
+    if (typeCheckboxes == null) {
+        return;
+    }
+
+    typeCheckboxes = typeCheckboxes.querySelectorAll("input[type=checkbox]");
 
     typeCheckboxes.forEach((checkbox) => {
         checkbox.checked = false; // reset the checkboxes after a page reload.


### PR DESCRIPTION
Some genes have no "closest features" and that tab won't exist.