### PR TITLE
Experiment display changes

### DIFF
--- a/cegs_portal/search/models/experiment.py
+++ b/cegs_portal/search/models/experiment.py
@@ -86,8 +86,11 @@ class Experiment(Accessioned, Faceted, AccessControlled):
         return self.facet_values.get(facet__name=Experiment.Facet.ASSAYS.value).value
 
     def save(self, *args, **kwargs):
+        update_access = kwargs.get("update_access", False)
+        if "update_access" in kwargs:
+            del kwargs["update_access"]
         super(Experiment, self).save(*args, **kwargs)
-        if kwargs.get("update_access", False):
+        if update_access:
             created = self.pk is None
             update_experiment_access(self, created)
 

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -164,6 +164,11 @@
 {% block content %}
 <div class="flex flex-column justify-center min-w-full">
     <div class="content-container min-w-fit max-w-fit">
+        {% if experiment.archived %}
+        <div class="bg-red-300 text-center text-xl font-bold py-2 my-1">
+            This experiment has been archived.
+        </div>
+        {% endif %}
         <div class="bg-white border-b">
             <div class="text-2xl font-bold flex items-center justify-center" style="color: rgb(71 85 105);">
                 <span><i class="fa-solid fa-flask-vial mr-1"></i>{{ experiment.name }}

--- a/cegs_portal/search/templates/search/v1/experiment.html
+++ b/cegs_portal/search/templates/search/v1/experiment.html
@@ -462,9 +462,9 @@
           </div>
           {% endif %}
         </div>
-        {% if related_experiments.exists or experiment.collections.exists %}
-        <div class="content-container min-w-full grid grid-cols-1 {% if related_experiments.exists and experiment.collections.exists %}lg:grid-cols-2 {% endif %}gap-4">
-          {% if related_experiments.exists %}
+        {% if related_experiments or experiment.collections.exists %}
+        <div class="content-container min-w-full grid grid-cols-1 {% if related_experiments and experiment.collections.exists %}lg:grid-cols-2 {% endif %}gap-4">
+          {% if related_experiments %}
           <div>
               <div class="bg-white border-b">
                   <div class="text-xl text-slate-500 font-bold mb-4 text-left">Related Experiments</div>
@@ -473,7 +473,7 @@
               <div class="{% cycle 'bg-gray-100' 'bg-white' %} border-b flex items-center">
                   <div class="text-sm px-6 py-4 font-medium w-1/4"><a class="link" href="{% url 'search:experiment' related.other_experiment_id %}">{{ related.name }}</a></div>
                   <div class="text-sm px-6 py-4 text-gray-500 font-light italic w-3/4">
-                      {{ related.description|default_if_none:"No Description" }}
+                      {{ related.description|linebreaksbr }}
                   </div>
               </div>
               {% endfor %}

--- a/cegs_portal/search/views/v1/tests/test_experiment.py
+++ b/cegs_portal/search/views/v1/tests/test_experiment.py
@@ -107,36 +107,37 @@ def test_experiment_with_authenticated_authorized_group_client(
 def test_archived_experiment_with_anonymous_client(
     public_test_client: RequestBuilder, experiment_view, archived_experiment: Experiment
 ):
-    with pytest.raises(PermissionDenied):
-        public_test_client.get(
-            f"/search/experiment/{archived_experiment.accession_id}?accept=application/json"
-        ).request(experiment_view, exp_id=archived_experiment.accession_id)
+    response = public_test_client.get(
+        f"/search/experiment/{archived_experiment.accession_id}?accept=application/json"
+    ).request(experiment_view, exp_id=archived_experiment.accession_id)
+    assert response.status_code == 200
 
 
 def test_archived_experiment_with_authenticated_client(
     login_test_client: RequestBuilder, experiment_view, archived_experiment: Experiment
 ):
-    with pytest.raises(PermissionDenied):
-        login_test_client.get(f"/search/experiment/{archived_experiment.accession_id}?accept=application/json").request(
-            experiment_view, exp_id=archived_experiment.accession_id
-        )
+    response = login_test_client.get(
+        f"/search/experiment/{archived_experiment.accession_id}?accept=application/json"
+    ).request(experiment_view, exp_id=archived_experiment.accession_id)
+    assert response.status_code == 200
 
 
 def test_archived_experiment_with_authenticated_authorized_client(
     login_test_client: RequestBuilder, experiment_view, archived_experiment: Experiment
 ):
     login_test_client.set_user_experiments([archived_experiment.accession_id])
-    with pytest.raises(PermissionDenied):
-        login_test_client.get(f"/search/experiment/{archived_experiment.accession_id}?accept=application/json").request(
-            experiment_view, exp_id=archived_experiment.accession_id
-        )
+
+    response = login_test_client.get(
+        f"/search/experiment/{archived_experiment.accession_id}?accept=application/json"
+    ).request(experiment_view, exp_id=archived_experiment.accession_id)
+    assert response.status_code == 200
 
 
 def test_archived_experiment_with_authenticated_authorized_group_client(
     group_login_test_client: RequestBuilder, experiment_view, archived_experiment: Experiment
 ):
     group_login_test_client.set_group_experiments([archived_experiment.accession_id])
-    with pytest.raises(PermissionDenied):
-        group_login_test_client.get(
-            f"/search/experiment/{archived_experiment.accession_id}?accept=application/json"
-        ).request(experiment_view, exp_id=archived_experiment.accession_id)
+    response = group_login_test_client.get(
+        f"/search/experiment/{archived_experiment.accession_id}?accept=application/json"
+    ).request(experiment_view, exp_id=archived_experiment.accession_id)
+    assert response.status_code == 200

--- a/cegs_portal/static/css/project.css
+++ b/cegs_portal/static/css/project.css
@@ -1153,6 +1153,11 @@ input[type="submit"], input[type="button"], button {
   margin-right: auto;
 }
 
+.my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
 .my-2 {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
@@ -1748,6 +1753,11 @@ input[type="submit"], input[type="button"], button {
 .bg-primary-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(48 97 175 / var(--tw-bg-opacity));
+}
+
+.bg-red-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 165 165 / var(--tw-bg-opacity));
 }
 
 .bg-slate-100 {


### PR DESCRIPTION
This changes came about as a result of adding the liftover related experiments

1) Archived experiments can be viewed, but with an "This experiment has been archived" banner
2) Linebreaks are shown in the related experiments description.
3) Fixed a bug when saving experiments via the admin UI

<img width="1467" alt="Screenshot 2025-01-24 at 11 53 51 AM" src="https://github.com/user-attachments/assets/420500b9-2a53-4702-83f1-e675720419ca" />
<img width="1467" alt="Screenshot 2025-01-24 at 11 53 39 AM" src="https://github.com/user-attachments/assets/411bffcb-82cf-4736-bc6f-7f413530cd76" />
